### PR TITLE
Update dependencies and tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,11 +14,14 @@ matrix:
   include:
     - php: 5.5
     - php: 5.6
-    - php: 5.6
+    - php: 7.0
+    - php: 7.1
+    - php: 7.1
       env: COMPOSER_FLAGS='--prefer-lowest --prefer-stable'
     - php: hhvm
     - php: nightly
   allow_failures:
+    - php: 5.5
     - php: hhvm
     - php: nightly
   fast_finish: true

--- a/composer.json
+++ b/composer.json
@@ -10,16 +10,17 @@
     ],
     "require": {
         "php": ">=5.5",
-        "webmozart/console": "^1.0-beta2",
-        "webmozart/path-util": "^2.2.2",
-        "symfony/filesystem": "^2.7",
-        "symfony/process": "^2.7",
-        "padraic/phar-updater": "^1.0.1",
-        "nikic/php-parser": "2.0.x-dev"
+        "webmozart/console": "^1.0-beta5",
+        "webmozart/path-util": "^2.3",
+        "symfony/filesystem": "^3.2",
+        "symfony/process": "^3.2",
+        "symfony/finder": "^3.2",
+        "padraic/phar-updater": "^1.0.3",
+        "nikic/php-parser": "^3.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^4.6",
-        "sebastian/version": "^1.0.1"
+        "phpunit/phpunit": "^5.7",
+        "sebastian/version": "^2.0"
     },
     "autoload": {
         "psr-4": {

--- a/src/Handler/AddPrefixCommandHandler.php
+++ b/src/Handler/AddPrefixCommandHandler.php
@@ -69,7 +69,7 @@ class AddPrefixCommandHandler
             }
 
             if (is_dir($path)) {
-                $this->finder->files()->name('*.php')->in($path);
+                $this->finder->files()->name('*.php')->in($path)->sortByName();
 
                 foreach ($this->finder as $file) {
                     $this->scopeFile($file->getPathName(), $prefix, $io);

--- a/tests/Fixtures/replaced/dir/dir/MySecondClass.php
+++ b/tests/Fixtures/replaced/dir/dir/MySecondClass.php
@@ -1,3 +1,4 @@
 <?php
 
 namespace MyPrefix\MyNamespace;
+

--- a/tests/Fixtures/replaced/dir/dir/MyThirdClass.php
+++ b/tests/Fixtures/replaced/dir/dir/MyThirdClass.php
@@ -1,3 +1,4 @@
 <?php
 
 namespace MyPrefix\MyNamespace;
+

--- a/tests/Handler/AddPrefixCommandHandlerTest.php
+++ b/tests/Handler/AddPrefixCommandHandlerTest.php
@@ -11,7 +11,7 @@
 
 namespace Webmozart\PhpScoper\Tests\Handler;
 
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use Symfony\Component\Filesystem\Filesystem;
 use Webmozart\Console\Api\Command\Command;
 use Webmozart\Console\Args\StringArgs;
@@ -25,7 +25,7 @@ use Webmozart\PhpScoper\Tests\TestUtil;
 /**
  * @author Bernhard Schussek <bschussek@gmail.com>
  */
-class AddPrefixCommandHandlerTest extends PHPUnit_Framework_TestCase
+class AddPrefixCommandHandlerTest extends TestCase
 {
     /**
      * @var Application
@@ -94,9 +94,9 @@ class AddPrefixCommandHandlerTest extends PHPUnit_Framework_TestCase
         $args = self::$command->parseArgs(new StringArgs('MyPrefix\\\\ dir'.DIRECTORY_SEPARATOR.'dir'));
 
         $expected = <<<EOF
-Scoping $this->tempDir/dir/dir/MyClass.php. . . Success
 Scoping $this->tempDir/dir/dir/MySecondClass.php. . . Success
 Scoping $this->tempDir/dir/dir/MyThirdClass.php. . . Success
+Scoping $this->tempDir/dir/dir/MyClass.php. . . Success
 
 EOF;
         $expected = str_replace('/', DIRECTORY_SEPARATOR, $expected);

--- a/tests/Handler/AddPrefixCommandHandlerTest.php
+++ b/tests/Handler/AddPrefixCommandHandlerTest.php
@@ -94,9 +94,9 @@ class AddPrefixCommandHandlerTest extends TestCase
         $args = self::$command->parseArgs(new StringArgs('MyPrefix\\\\ dir'.DIRECTORY_SEPARATOR.'dir'));
 
         $expected = <<<EOF
+Scoping $this->tempDir/dir/dir/MyClass.php. . . Success
 Scoping $this->tempDir/dir/dir/MySecondClass.php. . . Success
 Scoping $this->tempDir/dir/dir/MyThirdClass.php. . . Success
-Scoping $this->tempDir/dir/dir/MyClass.php. . . Success
 
 EOF;
         $expected = str_replace('/', DIRECTORY_SEPARATOR, $expected);

--- a/tests/PhpScoperTest.php
+++ b/tests/PhpScoperTest.php
@@ -11,7 +11,7 @@
 
 namespace Webmozart\PhpScoper\Tests;
 
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Process\PhpExecutableFinder;
 use Symfony\Component\Process\Process;
@@ -21,7 +21,7 @@ use Webmozart\PathUtil\Path;
 /**
  * @author Bernhard Schussek <bschussek@gmail.com>
  */
-class PhpScoperTest extends PHPUnit_Framework_TestCase
+class PhpScoperTest extends TestCase
 {
     private static $php;
 

--- a/tests/ScoperTest.php
+++ b/tests/ScoperTest.php
@@ -12,13 +12,13 @@
 namespace Webmozart\PhpScoper\Tests;
 
 use PhpParser\ParserFactory;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use Webmozart\PhpScoper\Scoper;
 
 /**
  * @author Matthieu Auger <mail@matthieuauger.com>
  */
-class ScoperTest extends PHPUnit_Framework_TestCase
+class ScoperTest extends TestCase
 {
     /**
      * @var Scoper
@@ -30,6 +30,9 @@ class ScoperTest extends PHPUnit_Framework_TestCase
         $this->scoper = new Scoper((new ParserFactory())->create(ParserFactory::PREFER_PHP7));
     }
 
+    /**
+     * @expectedException Webmozart\PhpScoper\Exception\ParsingException
+     */
     public function testScopeIncorrectFile()
     {
         $content = <<<'EOF'
@@ -39,7 +42,6 @@ $class = ;
 
 EOF;
 
-        $this->setExpectedException('Webmozart\PhpScoper\Exception\ParsingException');
         $this->scoper->addNamespacePrefix($content, 'MyPrefix');
     }
 
@@ -55,6 +57,7 @@ EOF;
 <?php
 
 namespace MyPrefix\MyNamespace;
+
 
 EOF;
 


### PR DESCRIPTION
Does what it says on the tin ;). Allows composer to install correctly; gets tests to passing state.

A few test updates add additional spaces to fixtures used as expected output. I'll leave it as separate exercise to see where those are added, and if they can be conditionally omitted.

Note: Updated Appveyor config and extended separately with #17. The failure at present is just choco needing Windows Update to run for its missing deps.