### PR TITLE
Update Appveyor config; test for PHP 5.6, 7.0, 7.1

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,37 +1,63 @@
 build: false
-platform: x86
+platform:
+  - x64
 clone_folder: c:\projects\webmozart\php-scoper
 
 branches:
   only:
     - master
 
-cache:
-  - '%LOCALAPPDATA%\Composer\files'
-
-init:
-  - SET PATH=C:\Program Files\OpenSSL;c:\tools\php;%PATH%
-
 environment:
   matrix:
-    - COMPOSER_FLAGS: ""
-    - COMPOSER_FLAGS: --prefer-lowest --prefer-stable
+  #- dependencies: lowest
+  #  php_ver_target: 5.6
+  - dependencies: highest
+    php_ver_target: 5.6
+  #- dependencies: lowest
+  #  php_ver_target: 7.0
+  - dependencies: highest
+    php_ver_target: 7.0
+  #- dependencies: lowest
+  #  php_ver_target: 7.1
+  - dependencies: highest
+    php_ver_target: 7.1
+
+cache: # cache is cleared when linked file is modified
+    - '%LOCALAPPDATA%\Composer\files -> composer.lock'
+    - composer.phar
+    - C:\ProgramData\chocolatey\bin -> appveyor.yml
+    - C:\ProgramData\chocolatey\lib -> appveyor.yml
+    - c:\tools\php -> appveyor.yml
+
+init:
+    - SET PATH=C:\Program Files\OpenSSL;c:\tools\php;%PATH%
+    - SET PHP=1
+    - SET ANSICON=121x90 (121x90)
+    - SET COMPOSER_NO_INTERACTION=1
 
 install:
-  - cinst -y OpenSSL.Light
-  - cinst -y php
-  - cd c:\tools\php
-  - copy php.ini-production php.ini /Y
-  - echo date.timezone="UTC" >> php.ini
-  - echo extension_dir=ext >> php.ini
-  - echo extension=php_openssl.dll >> php.ini
-  - echo extension=php_mbstring.dll >> php.ini
-  - echo extension=php_fileinfo.dll >> php.ini
-  - echo memory_limit=1G >> php.ini
-  - cd c:\projects\webmozart\php-scoper
-  - php -r "readfile('http://getcomposer.org/installer');" | php
-  - php composer.phar update %COMPOSER_FLAGS% --prefer-source --no-interaction --no-progress
+    - IF EXIST c:\tools\php (SET PHP=0)
+    # Enable Windows update service
+    - ps: Set-Service wuauserv -StartupType Manual
+    # Install PHP
+    - ps: appveyor-retry cinst --params '""/InstallDir:C:\tools\php""' --ignore-checksums -y php --version ((choco search php --exact --all-versions -r | select-string -pattern $env:php_ver_target | sort { [version]($_ -split '\|' | select -last 1) } -Descending | Select-Object -first 1) -replace '[php|]','')
+    - cd c:\tools\php
+    - IF %PHP%==1 copy php.ini-production php.ini /Y
+    - IF %PHP%==1 echo date.timezone="UTC" >> php.ini
+    - IF %PHP%==1 echo extension_dir=ext >> php.ini
+    - IF %PHP%==1 echo extension=php_openssl.dll >> php.ini
+    - IF %PHP%==1 echo extension=php_mbstring.dll >> php.ini
+    - IF %PHP%==1 echo extension=php_fileinfo.dll >> php.ini
+    - IF %PHP%==1 echo @php %%~dp0composer.phar %%* > composer.bat
+    - IF %PHP%==1 echo memory_limit=1G >> php.ini
+    # Install composer and update per matrix
+    - appveyor-retry appveyor DownloadFile https://getcomposer.org/composer.phar
+    - cd c:\projects\webmozart\php-scoper
+    - IF %dependencies%==lowest appveyor-retry composer update --no-suggest --prefer-dist --prefer-lowest
+    - IF %dependencies%==highest appveyor-retry composer update --no-suggest --prefer-dist
+    - composer show
+
 
 test_script:
-  - cd c:\projects\webmozart\php-scoper
-  - vendor\bin\phpunit.bat --verbose
+    - cd c:\projects\webmozart\php-scoper
+    - vendor\bin\phpunit -c phpunit.xml.dist


### PR DESCRIPTION
- Extends PHP versions to test against.
- Enables Windows Update (choco depends on updates some of the time).
- Not sure about x86 vs x64, so assumed a modern system and switched.
- Enabled caching to speed up builds.

Note: Build will fail pending #16.