### PR TITLE
Force delete the test temp directory on Windows

### DIFF
--- a/tests/Handler/AddPrefixCommandHandlerTest.php
+++ b/tests/Handler/AddPrefixCommandHandlerTest.php
@@ -93,7 +93,7 @@ class AddPrefixCommandHandlerTest extends TestCase
 
     public function testAddPrefixToDirectory()
     {
-        chdir($this->tempDir); exit;
+        chdir($this->tempDir);
 
         $args = self::$command->parseArgs(new StringArgs('MyPrefix\\\\ dir'.DIRECTORY_SEPARATOR.'dir'));
 

--- a/tests/Handler/AddPrefixCommandHandlerTest.php
+++ b/tests/Handler/AddPrefixCommandHandlerTest.php
@@ -84,12 +84,16 @@ class AddPrefixCommandHandlerTest extends TestCase
     {
         chdir($this->workingDirectory);
         $filesystem = new Filesystem();
-        $filesystem->remove($this->tempDir);
+        if (!defined('PHP_WINDOWS_VERSION_BUILD') {
+            $filesystem->remove($this->tempDir);
+        } else {
+            exec(sprintf("rd /s /q %s", escapeshellarg($this->tempDir)));
+        }
     }
 
     public function testAddPrefixToDirectory()
     {
-        chdir($this->tempDir);
+        chdir($this->tempDir); exit;
 
         $args = self::$command->parseArgs(new StringArgs('MyPrefix\\\\ dir'.DIRECTORY_SEPARATOR.'dir'));
 

--- a/tests/Handler/AddPrefixCommandHandlerTest.php
+++ b/tests/Handler/AddPrefixCommandHandlerTest.php
@@ -84,7 +84,7 @@ class AddPrefixCommandHandlerTest extends TestCase
     {
         chdir($this->workingDirectory);
         $filesystem = new Filesystem();
-        if (!defined('PHP_WINDOWS_VERSION_BUILD') {
+        if (!defined('PHP_WINDOWS_VERSION_BUILD')) {
             $filesystem->remove($this->tempDir);
         } else {
             exec(sprintf("rd /s /q %s", escapeshellarg($this->tempDir)));


### PR DESCRIPTION
Currently creating an error on Appveyor build using Symfony Filesystem. This instead executes `rd /s` command to delete the entire tree including files.