### PR TITLE
Fix StyleCI misconfiguration

### DIFF
--- a/.styleci.yml
+++ b/.styleci.yml
@@ -4,7 +4,6 @@ enabled:
     - ordered_use
 
 disabled:
-    - empty_return
     - phpdoc_annotation_without_dot # This is still buggy: https://github.com/symfony/symfony/pull/19198
 
 finder:


### PR DESCRIPTION
"The provided fixer 'empty_return' cannot be disabled unless it was already enabled by your preset."