### PR TITLE
Tests for PHP 7.0 NS syntax

### DIFF
--- a/src/NodeVisitor/GroupUseNamespaceScoperNodeVisitor.php
+++ b/src/NodeVisitor/GroupUseNamespaceScoperNodeVisitor.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+/*
+ * This file is part of the humbug/php-scoper package.
+ *
+ * Copyright (c) 2017 Théo FIDRY <theo.fidry@gmail.com>,
+ *                    Pádraic Brady <padraic.brady@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Webmozart\PhpScoper\NodeVisitor;
+
+use PhpParser\Node;
+use PhpParser\Node\Name;
+use PhpParser\Node\Stmt\GroupUse;
+use PhpParser\NodeVisitorAbstract;
+
+class GroupUseNamespaceScoperNodeVisitor extends NodeVisitorAbstract
+{
+    /**
+     * @var string
+     */
+    private $prefix;
+
+    /**
+     * @param string $prefix
+     */
+    public function __construct(string $prefix)
+    {
+        $this->prefix = $prefix;
+    }
+
+    /**
+     * @param Node[] $nodes
+     */
+    public function beforeTraverse(array $nodes)
+    {
+        foreach ($nodes as $node) {
+            if ($node instanceof GroupUse) {
+                $this->ignoreUseUses($node);
+            }
+        }
+    }
+
+    /**
+     * @param Node $node
+     */
+    public function enterNode(Node $node)
+    {
+        if ($node instanceof GroupUse) {
+            $node->prefix = Name::concat($this->prefix, $node->prefix);
+        }
+    }
+
+    /**
+     * @param GroupUse $node
+     */
+    private function ignoreUseUses(GroupUse $node)
+    {
+        foreach ($node->uses as $use) {
+            $use->setAttribute('phpscoper_ignore', true);
+        }
+    }
+}

--- a/src/NodeVisitor/UseNamespaceScoperNodeVisitor.php
+++ b/src/NodeVisitor/UseNamespaceScoperNodeVisitor.php
@@ -22,6 +22,9 @@ class UseNamespaceScoperNodeVisitor extends NodeVisitorAbstract
     public function enterNode(Node $node)
     {
         if ($node instanceof UseUse) {
+            if ($node->hasAttribute('phpscoper_ignore')) {
+                return;
+            }
             $node->name = Name::concat($this->prefix, $node->name);
         }
     }

--- a/src/Scoper.php
+++ b/src/Scoper.php
@@ -17,6 +17,7 @@ use PhpParser\Parser;
 use PhpParser\PrettyPrinter\Standard;
 use Webmozart\PhpScoper\Exception\ParsingException;
 use Webmozart\PhpScoper\NodeVisitor\FullyQualifiedNamespaceUseScoperNodeVisitor;
+use Webmozart\PhpScoper\NodeVisitor\GroupUseNamespaceScoperNodeVisitor;
 use Webmozart\PhpScoper\NodeVisitor\NamespaceScoperNodeVisitor;
 use Webmozart\PhpScoper\NodeVisitor\UseNamespaceScoperNodeVisitor;
 
@@ -43,6 +44,7 @@ class Scoper
         $traverser = new NodeTraverser();
         $traverser->addVisitor(new NamespaceScoperNodeVisitor($prefix));
         $traverser->addVisitor(new UseNamespaceScoperNodeVisitor($prefix));
+        $traverser->addVisitor(new GroupUseNamespaceScoperNodeVisitor($prefix));
         $traverser->addVisitor(new FullyQualifiedNamespaceUseScoperNodeVisitor($prefix));
 
         try {

--- a/tests/ScoperTest.php
+++ b/tests/ScoperTest.php
@@ -183,7 +183,7 @@ EOF;
         $expected = <<<EOF
 <?php
 
-use MyPrefix\AnotherNamespace\{Foo,Bar,Baz};
+use MyPrefix\AnotherNamespace\{Foo, Bar, Baz};
 
 EOF;
 
@@ -201,7 +201,7 @@ EOF;
         $expected = <<<EOF
 <?php
 
-use function MyPrefix\AnotherNamespace\{foo,bar,baz};
+use function MyPrefix\AnotherNamespace\{foo, bar, baz};
 
 EOF;
 
@@ -219,7 +219,7 @@ EOF;
         $expected = <<<EOF
 <?php
 
-use const MyPrefix\AnotherNamespace\{FOO,BAR,BAZ};
+use const MyPrefix\AnotherNamespace\{FOO, BAR, BAZ};
 
 EOF;
 

--- a/tests/ScoperTest.php
+++ b/tests/ScoperTest.php
@@ -82,6 +82,150 @@ EOF;
         $this->assertEquals($expected, $this->scoper->addNamespacePrefix($content, 'MyPrefix'));
     }
 
+    public function testShouldScopeMNamespacedFunctionUse()
+    {
+        $content = <<<EOF
+<?php
+
+use function FooNamespace\\foo;
+
+EOF;
+        $expected = <<<EOF
+<?php
+
+use function MyPrefix\FooNamespace\\foo;
+
+EOF;
+
+        $this->assertEquals($expected, $r = $this->scoper->addNamespacePrefix($content, 'MyPrefix'), $r);
+    }
+
+    public function testShouldScopeNamespacedConstantUse()
+    {
+        $content = <<<EOF
+<?php
+
+use const FooNamespace\FOO;
+
+EOF;
+        $expected = <<<EOF
+<?php
+
+use const MyPrefix\FooNamespace\FOO;
+
+EOF;
+
+        $this->assertEquals($expected, $this->scoper->addNamespacePrefix($content, 'MyPrefix'));
+    }
+
+    public function testShouldScopeMultipleNamespaceUsesInOneStatement()
+    {
+        $content = <<<EOF
+<?php
+
+use FooNamespace as Foo, BarNamespace as Bar;
+
+EOF;
+        $expected = <<<EOF
+<?php
+
+use MyPrefix\FooNamespace as Foo, MyPrefix\BarNamespace as Bar;
+
+EOF;
+
+        $this->assertEquals($expected, $this->scoper->addNamespacePrefix($content, 'MyPrefix'));
+    }
+
+    public function testShouldScopeMultipleNamespacedFunctionUsesInOneStatement()
+    {
+        $content = <<<EOF
+<?php
+
+use function FooNamespace\\foo, BarNamespace\bar;
+
+EOF;
+        $expected = <<<EOF
+<?php
+
+use function MyPrefix\FooNamespace\\foo, MyPrefix\BarNamespace\bar;
+
+EOF;
+
+        $this->assertEquals($expected, $this->scoper->addNamespacePrefix($content, 'MyPrefix'));
+    }
+
+    public function testShouldScopeMultipleNamespacedConstantUsesInOneStatement()
+    {
+        $content = <<<EOF
+<?php
+
+use const FooNamespace\FOO, BarNamespace\BAR;
+
+EOF;
+        $expected = <<<EOF
+<?php
+
+use const MyPrefix\FooNamespace\FOO, MyPrefix\BarNamespace\BAR;
+
+EOF;
+
+        $this->assertEquals($expected, $this->scoper->addNamespacePrefix($content, 'MyPrefix'));
+    }
+
+    public function testShouldScopeMultipleSubNamespaceUsesInOneStatement()
+    {
+        $content = <<<EOF
+<?php
+
+use AnotherNamespace\{Foo,Bar,Baz};
+
+EOF;
+        $expected = <<<EOF
+<?php
+
+use MyPrefix\AnotherNamespace\{Foo,Bar,Baz};
+
+EOF;
+
+        $this->assertEquals($expected, $this->scoper->addNamespacePrefix($content, 'MyPrefix'));
+    }
+
+    public function testShouldScopeMultipleSubNamespacedFunctionUsesInOneStatement()
+    {
+        $content = <<<EOF
+<?php
+
+use function AnotherNamespace\{foo,bar,baz};
+
+EOF;
+        $expected = <<<EOF
+<?php
+
+use function MyPrefix\AnotherNamespace\{foo,bar,baz};
+
+EOF;
+
+        $this->assertEquals($expected, $this->scoper->addNamespacePrefix($content, 'MyPrefix'));
+    }
+
+    public function testShouldScopeMultipleSubNamespacedConstantUsesInOneStatement()
+    {
+        $content = <<<EOF
+<?php
+
+use const AnotherNamespace\{FOO,BAR,BAZ};
+
+EOF;
+        $expected = <<<EOF
+<?php
+
+use const MyPrefix\AnotherNamespace\{FOO,BAR,BAZ};
+
+EOF;
+
+        $this->assertEquals($expected, $this->scoper->addNamespacePrefix($content, 'MyPrefix'));
+    }
+
     public function testScopeFullyQualifiedNamespaceUse()
     {
         $content = <<<EOF


### PR DESCRIPTION
Adding PHP 7 syntax for testing. Fails with `MyNs\{Foo,Bar}` style use statements pending a fix.