### PR TITLE
[WIP] Add method of ignoring classes, constants and functions from base PHP and extensions

### DIFF
--- a/bin/php-scoper
+++ b/bin/php-scoper
@@ -10,7 +10,14 @@
  * file that was distributed with this source code.
  */
 
+<<<<<<< HEAD
 use function Humbug\PhpScoper\createApplication;
+=======
+$declared = array_merge(get_declared_classes(), get_declared_interfaces());
+
+use Webmozart\PhpScoper\Console\Application;
+use Webmozart\PhpScoper\Console\ApplicationConfig;
+>>>>>>> Map declared classes at start and route to Node Visitor
 
 if (file_exists($autoload = __DIR__.'/../../../autoload.php')) {
     require_once $autoload;
@@ -18,6 +25,12 @@ if (file_exists($autoload = __DIR__.'/../../../autoload.php')) {
     require_once __DIR__.'/../vendor/autoload.php';
 }
 
+<<<<<<< HEAD
 $app = createApplication();
+=======
+$app = new Application();
+$conf = new ApplicationConfig();
+$conf->configure($app, $declared);
+>>>>>>> Map declared classes at start and route to Node Visitor
 
 $app->run();

--- a/bin/php-scoper
+++ b/bin/php-scoper
@@ -2,30 +2,16 @@
 <?php
 
 /*
- * This file is part of the webmozart/php-scoper package.
+ * This file is part of the humbug/php-scoper package.
  *
- * (c) Bernhard Schussek <bschussek@gmail.com>
+ * Copyright (c) 2017 Théo FIDRY <theo.fidry@gmail.com>,
+ *                    Pádraic Brady <padraic.brady@gmail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  */
 
-<<<<<<< HEAD
-<<<<<<< HEAD
 use function Humbug\PhpScoper\createApplication;
-=======
-$declared = array_merge(get_declared_classes(), get_declared_interfaces());
-=======
-$declared = array_merge(
-    get_declared_classes(),
-    get_declared_interfaces(),
-    get_defined_constants(),
-);
->>>>>>> Stash to FQN constant check
-
-use Webmozart\PhpScoper\Console\Application;
-use Webmozart\PhpScoper\Console\ApplicationConfig;
->>>>>>> Map declared classes at start and route to Node Visitor
 
 if (file_exists($autoload = __DIR__.'/../../../autoload.php')) {
     require_once $autoload;
@@ -33,12 +19,6 @@ if (file_exists($autoload = __DIR__.'/../../../autoload.php')) {
     require_once __DIR__.'/../vendor/autoload.php';
 }
 
-<<<<<<< HEAD
 $app = createApplication();
-=======
-$app = new Application();
-$conf = new ApplicationConfig();
-$conf->configure($app, $declared);
->>>>>>> Map declared classes at start and route to Node Visitor
 
 $app->run();

--- a/bin/php-scoper
+++ b/bin/php-scoper
@@ -11,9 +11,17 @@
  */
 
 <<<<<<< HEAD
+<<<<<<< HEAD
 use function Humbug\PhpScoper\createApplication;
 =======
 $declared = array_merge(get_declared_classes(), get_declared_interfaces());
+=======
+$declared = array_merge(
+    get_declared_classes(),
+    get_declared_interfaces(),
+    get_defined_constants(),
+);
+>>>>>>> Stash to FQN constant check
 
 use Webmozart\PhpScoper\Console\Application;
 use Webmozart\PhpScoper\Console\ApplicationConfig;

--- a/src/Console/ApplicationConfig.php
+++ b/src/Console/ApplicationConfig.php
@@ -1,0 +1,40 @@
+<?php
+
+/*
+ * This file is part of the webmozart/php-scoper package.
+ *
+ * (c) Bernhard Schussek <bschussek@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Webmozart\PhpScoper\Console;
+
+use Symfony\Component\Console\Output\OutputInterface;
+use Webmozart\PhpScoper\Formatter\BasicFormatter;
+use Webmozart\PhpScoper\Handler\AddPrefixCommandHandler;
+
+/**
+ * The configuration of the PHP-Scoper CLI.
+ *
+ * @since  1.0
+ *
+ * @author Bernhard Schussek <bschussek@gmail.com>
+ */
+class ApplicationConfig
+{
+    public function configure(Application $app, array $declaredClasses = [])
+    {
+        $app->command(
+            'add-prefix prefix path*',
+            function ($prefix, $path, OutputInterface $output) use ($declaredClasses) {
+                $formatter = new BasicFormatter($output);
+                $formatter->outputScopingStart();
+                $handler = new AddPrefixCommandHandler();
+                $handler->handle($prefix, $path, $formatter, $declaredClasses);
+                $formatter->outputScopingEnd();
+            }
+        );
+    }
+}

--- a/src/Handler/AddPrefixCommandHandler.php
+++ b/src/Handler/AddPrefixCommandHandler.php
@@ -1,0 +1,134 @@
+<?php
+
+/*
+ * This file is part of the webmozart/php-scoper package.
+ *
+ * (c) Bernhard Schussek <bschussek@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Webmozart\PhpScoper\Handler;
+
+use PhpParser\ParserFactory;
+use Symfony\Component\Filesystem\Filesystem;
+use Symfony\Component\Finder\Finder;
+use Webmozart\PhpScoper\Exception\ParsingException;
+use Webmozart\PhpScoper\Exception\RuntimeException;
+use Webmozart\PhpScoper\Formatter\BasicFormatter;
+use Webmozart\PhpScoper\Scoper;
+
+/**
+ * Handles the "add-prefix" command.
+ *
+ * @author Bernhard Schussek <bschussek@gmail.com>
+ */
+class AddPrefixCommandHandler
+{
+    /**
+     * @var Filesystem
+     */
+    private $filesystem;
+
+    /**
+     * @var Finder
+     */
+    private $finder;
+
+    /**
+     * @var Scoper
+     */
+    private $scoper;
+
+    public function __construct(array $declaredClasses = [])
+    {
+        $this->filesystem = new Filesystem();
+        $this->finder = new Finder();
+
+        $parser = (new ParserFactory())->create(ParserFactory::PREFER_PHP7);
+        $this->scoper = new Scoper($parser, $declaredClasses);
+    }
+
+    /**
+     * Handles the "add-prefix" command.
+     *
+     * @param string         $prefix
+     * @param string[]       $paths
+     * @param BasicFormatter $formatter
+     *
+     * @return int Returns 0 on success and a positive integer on error.
+     */
+    public function handle($prefix, array $paths, BasicFormatter $formatter)
+    {
+        $prefix = rtrim($prefix, '\\');
+        $pathsToSearch = [];
+        $filesToAppend = [];
+
+        foreach ($paths as $path) {
+            if (!$this->filesystem->isAbsolutePath($path)) {
+                $path = getcwd().DIRECTORY_SEPARATOR.$path;
+            }
+
+            if (($exists = !file_exists($path)) || !is_readable($path)) {
+                $issue = $exists ? 'does not exist' : 'is not readable';
+                throw new RuntimeException(sprintf(
+                    'A given path %s: %s',
+                    $issue,
+                    $path
+                ));
+            }
+
+            if (is_dir($path)) {
+                $pathsToSearch[] = $path;
+            } else {
+                $filesToAppend[] = $path;
+            }
+        }
+
+        $this->finder->files()
+            ->name('*.php')
+            ->in($pathsToSearch)
+            ->append($filesToAppend)
+            ->sortByName();
+
+        $this->scopeFiles($prefix, $formatter);
+
+        return 0;
+    }
+
+    /**
+     * Scopes all files attached to Finder instance.
+     *
+     * @param string         $prefix
+     * @param BasicFormatter $formatter
+     */
+    private function scopeFiles($prefix, BasicFormatter $formatter)
+    {
+        $count = count($this->finder);
+        $formatter->outputFileCount($count);
+
+        foreach ($this->finder as $file) {
+            $this->scopeFile($file->getPathName(), $prefix, $formatter);
+        }
+    }
+
+    /**
+     * Scopes a given file.
+     *
+     * @param string         $path
+     * @param string         $prefix
+     * @param BasicFormatter $formatter
+     */
+    private function scopeFile($path, $prefix, BasicFormatter $formatter)
+    {
+        $fileContent = file_get_contents($path);
+        try {
+            $scoppedContent = $this->scoper->addNamespacePrefix($fileContent, $prefix);
+            $this->filesystem->dumpFile($path, $scoppedContent);
+            $formatter->outputSuccess($path);
+        } catch (ParsingException $exception) {
+            $formatter->outputFail($path);
+        }
+    }
+}

--- a/src/NodeVisitor/FullyQualifiedNamespaceUseScoperNodeVisitor.php
+++ b/src/NodeVisitor/FullyQualifiedNamespaceUseScoperNodeVisitor.php
@@ -37,6 +37,9 @@ final class FullyQualifiedNamespaceUseScoperNodeVisitor extends NodeVisitorAbstr
     public function enterNode(Node $node)
     {
         if ($node instanceof FullyQualified) {
+            if ($node->hasAttribute('phpscoper_ignore')) {
+                return;
+            }
             return new Name(Name::concat($this->prefix, (string) $node));
         }
 

--- a/src/NodeVisitor/IgnoreNamespaceScoperNodeVisitor.php
+++ b/src/NodeVisitor/IgnoreNamespaceScoperNodeVisitor.php
@@ -13,6 +13,7 @@
 namespace Webmozart\PhpScoper\NodeVisitor;
 
 use PhpParser\Node;
+use PhpParser\Node\Name\FullyQualified;
 use PhpParser\Node\Stmt\UseUse;
 use PhpParser\NodeVisitorAbstract;
 
@@ -20,7 +21,7 @@ final class IgnoreNamespaceScoperNodeVisitor extends NodeVisitorAbstract
 {
 
     /**
-     * @var array
+     * @var array Class names to ignore when scoping
      */
     private $reserved;
 
@@ -35,6 +36,9 @@ final class IgnoreNamespaceScoperNodeVisitor extends NodeVisitorAbstract
     public function enterNode(Node $node)
     {
         if ($node instanceof UseUse && in_array((string) $node->name, $this->reserved)) {
+            $node->setAttribute('phpscoper_ignore', true);
+        }
+        if ($node instanceof FullyQualified && in_array((string) $node, $this->reserved)) {
             $node->setAttribute('phpscoper_ignore', true);
         }
     }

--- a/src/NodeVisitor/IgnoreNamespaceScoperNodeVisitor.php
+++ b/src/NodeVisitor/IgnoreNamespaceScoperNodeVisitor.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of the humbug/php-scoper package.
  *
@@ -10,7 +12,8 @@
  * file that was distributed with this source code.
  */
 
-namespace Webmozart\PhpScoper\NodeVisitor;
+
+namespace Humbug\PhpScoper\NodeVisitor;
 
 use PhpParser\Node;
 use PhpParser\Node\Name\FullyQualified;
@@ -23,18 +26,16 @@ final class IgnoreNamespaceScoperNodeVisitor extends NodeVisitorAbstract
     /**
      * @var array Class names to ignore when scoping
      */
-    private $reserved;
-
-    public function __construct(array $declaredClasses)
-    {
-        $this->reserved = $declaredClasses;
-    }
+    private $reserved = ['toberemoved'];
 
     /**
      * @param Node $node
      */
     public function enterNode(Node $node)
     {
+        /**
+         * @todo  UseUse should not be skipped if part of FullyQualified sub-section
+         */
         if ($node instanceof UseUse && in_array((string) $node->name, $this->reserved)) {
             $node->setAttribute('phpscoper_ignore', true);
         }

--- a/src/NodeVisitor/IgnoreNamespaceScoperNodeVisitor.php
+++ b/src/NodeVisitor/IgnoreNamespaceScoperNodeVisitor.php
@@ -13,20 +13,28 @@
 namespace Webmozart\PhpScoper\NodeVisitor;
 
 use PhpParser\Node;
-use PhpParser\Node\Name;
 use PhpParser\Node\Stmt\UseUse;
 use PhpParser\NodeVisitorAbstract;
 
-class IgnoreNamespaceScoperNodeVisitor extends NodeVisitorAbstract
+final class IgnoreNamespaceScoperNodeVisitor extends NodeVisitorAbstract
 {
 
-    private static $reserved = [
-        'Closure'
-    ];
+    /**
+     * @var array
+     */
+    private $reserved;
 
+    public function __construct(array $declaredClasses)
+    {
+        $this->reserved = $declaredClasses;
+    }
+
+    /**
+     * @param Node $node
+     */
     public function enterNode(Node $node)
     {
-        if ($node instanceof UseUse && in_array((string) $node->name, self::$reserved)) {
+        if ($node instanceof UseUse && in_array((string) $node->name, $this->reserved)) {
             $node->setAttribute('phpscoper_ignore', true);
         }
     }

--- a/src/NodeVisitor/IgnoreNamespaceScoperNodeVisitor.php
+++ b/src/NodeVisitor/IgnoreNamespaceScoperNodeVisitor.php
@@ -1,0 +1,33 @@
+<?php
+
+/*
+ * This file is part of the humbug/php-scoper package.
+ *
+ * Copyright (c) 2017 Théo FIDRY <theo.fidry@gmail.com>,
+ *                    Pádraic Brady <padraic.brady@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Webmozart\PhpScoper\NodeVisitor;
+
+use PhpParser\Node;
+use PhpParser\Node\Name;
+use PhpParser\Node\Stmt\UseUse;
+use PhpParser\NodeVisitorAbstract;
+
+class IgnoreNamespaceScoperNodeVisitor extends NodeVisitorAbstract
+{
+
+    private static $reserved = [
+        'Closure'
+    ];
+
+    public function enterNode(Node $node)
+    {
+        if ($node instanceof UseUse && in_array((string) $node->name, self::$reserved)) {
+            $node->setAttribute('phpscoper_ignore', true);
+        }
+    }
+}

--- a/src/NodeVisitor/UseNamespaceScoperNodeVisitor.php
+++ b/src/NodeVisitor/UseNamespaceScoperNodeVisitor.php
@@ -37,17 +37,13 @@ final class UseNamespaceScoperNodeVisitor extends NodeVisitorAbstract
      */
     public function enterNode(Node $node)
     {
-<<<<<<< HEAD
         if ($node instanceof UseUse
             && $node->hasAttribute('parent') && false === ($node->getAttribute('parent') instanceof  GroupUse)
             && $this->prefix !== $node->name->getFirst()
         ) {
-=======
-        if ($node instanceof UseUse) {
             if ($node->hasAttribute('phpscoper_ignore')) {
                 return;
             }
->>>>>>> Add method to ignore specific use statements
             $node->name = Name::concat($this->prefix, $node->name);
         }
 

--- a/src/NodeVisitor/UseNamespaceScoperNodeVisitor.php
+++ b/src/NodeVisitor/UseNamespaceScoperNodeVisitor.php
@@ -37,10 +37,17 @@ final class UseNamespaceScoperNodeVisitor extends NodeVisitorAbstract
      */
     public function enterNode(Node $node)
     {
+<<<<<<< HEAD
         if ($node instanceof UseUse
             && $node->hasAttribute('parent') && false === ($node->getAttribute('parent') instanceof  GroupUse)
             && $this->prefix !== $node->name->getFirst()
         ) {
+=======
+        if ($node instanceof UseUse) {
+            if ($node->hasAttribute('phpscoper_ignore')) {
+                return;
+            }
+>>>>>>> Add method to ignore specific use statements
             $node->name = Name::concat($this->prefix, $node->name);
         }
 

--- a/src/Scoper.php
+++ b/src/Scoper.php
@@ -24,6 +24,14 @@ use PhpParser\Error;
 use PhpParser\NodeTraverser;
 use PhpParser\Parser;
 use PhpParser\PrettyPrinter\Standard;
+<<<<<<< HEAD
+=======
+use Webmozart\PhpScoper\Exception\ParsingException;
+use Webmozart\PhpScoper\NodeVisitor\FullyQualifiedNamespaceUseScoperNodeVisitor;
+use Webmozart\PhpScoper\NodeVisitor\IgnoreNamespaceScoperNodeVisitor;
+use Webmozart\PhpScoper\NodeVisitor\NamespaceScoperNodeVisitor;
+use Webmozart\PhpScoper\NodeVisitor\UseNamespaceScoperNodeVisitor;
+>>>>>>> Add method to ignore specific use statements
 
 /**
  * @final
@@ -48,8 +56,12 @@ class Scoper
     public function scope(string $content, string $prefix): string
     {
         $traverser = new NodeTraverser();
+<<<<<<< HEAD
         $traverser->addVisitor(new ParentNodeVisitor());
         $traverser->addVisitor(new GroupUseNamespaceScoperNodeVisitor($prefix));
+=======
+        $traverser->addVisitor(new IgnoreNamespaceScoperNodeVisitor());
+>>>>>>> Add method to ignore specific use statements
         $traverser->addVisitor(new NamespaceScoperNodeVisitor($prefix));
         $traverser->addVisitor(new UseNamespaceScoperNodeVisitor($prefix));
         $traverser->addVisitor(new FullyQualifiedNamespaceUseScoperNodeVisitor($prefix));

--- a/src/Scoper.php
+++ b/src/Scoper.php
@@ -40,9 +40,15 @@ class Scoper
 {
     private $parser;
 
-    public function __construct(Parser $parser)
+    /**
+     * @var array
+     */
+    private $declaredClasses;
+
+    public function __construct(Parser $parser, array $declaredClasses = [])
     {
         $this->parser = $parser;
+        $this->declaredClasses = $declaredClasses;
     }
 
     /**
@@ -57,11 +63,15 @@ class Scoper
     {
         $traverser = new NodeTraverser();
 <<<<<<< HEAD
+<<<<<<< HEAD
         $traverser->addVisitor(new ParentNodeVisitor());
         $traverser->addVisitor(new GroupUseNamespaceScoperNodeVisitor($prefix));
 =======
         $traverser->addVisitor(new IgnoreNamespaceScoperNodeVisitor());
 >>>>>>> Add method to ignore specific use statements
+=======
+        $traverser->addVisitor(new IgnoreNamespaceScoperNodeVisitor($this->declaredClasses));
+>>>>>>> Map declared classes at start and route to Node Visitor
         $traverser->addVisitor(new NamespaceScoperNodeVisitor($prefix));
         $traverser->addVisitor(new UseNamespaceScoperNodeVisitor($prefix));
         $traverser->addVisitor(new FullyQualifiedNamespaceUseScoperNodeVisitor($prefix));

--- a/src/Scoper.php
+++ b/src/Scoper.php
@@ -16,6 +16,7 @@ namespace Humbug\PhpScoper;
 
 use Humbug\PhpScoper\NodeVisitor\FullyQualifiedNamespaceUseScoperNodeVisitor;
 use Humbug\PhpScoper\NodeVisitor\GroupUseNamespaceScoperNodeVisitor;
+use Humbug\PhpScoper\NodeVisitor\IgnoreNamespaceScoperNodeVisitor;
 use Humbug\PhpScoper\NodeVisitor\NamespaceScoperNodeVisitor;
 use Humbug\PhpScoper\NodeVisitor\ParentNodeVisitor;
 use Humbug\PhpScoper\NodeVisitor\UseNamespaceScoperNodeVisitor;
@@ -24,31 +25,20 @@ use PhpParser\Error;
 use PhpParser\NodeTraverser;
 use PhpParser\Parser;
 use PhpParser\PrettyPrinter\Standard;
-<<<<<<< HEAD
-=======
-use Webmozart\PhpScoper\Exception\ParsingException;
-use Webmozart\PhpScoper\NodeVisitor\FullyQualifiedNamespaceUseScoperNodeVisitor;
-use Webmozart\PhpScoper\NodeVisitor\IgnoreNamespaceScoperNodeVisitor;
-use Webmozart\PhpScoper\NodeVisitor\NamespaceScoperNodeVisitor;
-use Webmozart\PhpScoper\NodeVisitor\UseNamespaceScoperNodeVisitor;
->>>>>>> Add method to ignore specific use statements
 
 /**
  * @final
  */
 class Scoper
 {
+    /**
+     * @var Parser
+     */
     private $parser;
 
-    /**
-     * @var array
-     */
-    private $declaredClasses;
-
-    public function __construct(Parser $parser, array $declaredClasses = [])
+    public function __construct(Parser $parser)
     {
         $this->parser = $parser;
-        $this->declaredClasses = $declaredClasses;
     }
 
     /**
@@ -62,16 +52,9 @@ class Scoper
     public function scope(string $content, string $prefix): string
     {
         $traverser = new NodeTraverser();
-<<<<<<< HEAD
-<<<<<<< HEAD
         $traverser->addVisitor(new ParentNodeVisitor());
         $traverser->addVisitor(new GroupUseNamespaceScoperNodeVisitor($prefix));
-=======
         $traverser->addVisitor(new IgnoreNamespaceScoperNodeVisitor());
->>>>>>> Add method to ignore specific use statements
-=======
-        $traverser->addVisitor(new IgnoreNamespaceScoperNodeVisitor($this->declaredClasses));
->>>>>>> Map declared classes at start and route to Node Visitor
         $traverser->addVisitor(new NamespaceScoperNodeVisitor($prefix));
         $traverser->addVisitor(new UseNamespaceScoperNodeVisitor($prefix));
         $traverser->addVisitor(new FullyQualifiedNamespaceUseScoperNodeVisitor($prefix));

--- a/tests/Fixtures/reserved_classes.php
+++ b/tests/Fixtures/reserved_classes.php
@@ -1,0 +1,3 @@
+<?php
+
+use Closure;

--- a/tests/Fixtures/reserved_classes.php
+++ b/tests/Fixtures/reserved_classes.php
@@ -1,11 +1,15 @@
 <?php
 
 use Closure;
+// FQNs
 $foo = new \Closure();
 function foo(\Closure $bar)
 {
+    $a = \PHP_EOL;
 }
+// No FQNs
 $foo = new Closure();
 function foo(Closure $bar)
 {
+    $a = PHP_EOL;
 }

--- a/tests/Fixtures/reserved_classes.php
+++ b/tests/Fixtures/reserved_classes.php
@@ -1,3 +1,11 @@
 <?php
 
 use Closure;
+$foo = new \Closure();
+function foo(\Closure $bar)
+{
+}
+$foo = new Closure();
+function foo(Closure $bar)
+{
+}

--- a/tests/ScoperTest.php
+++ b/tests/ScoperTest.php
@@ -34,14 +34,7 @@ class ScoperTest extends TestCase
      */
     public function setUp()
     {
-<<<<<<< HEAD
         $this->scoper = new Scoper(createParser());
-=======
-        $this->scoper = new Scoper(
-            (new ParserFactory())->create(ParserFactory::PREFER_PHP7),
-            ['Closure']
-        );
->>>>>>> Map declared classes at start and route to Node Visitor
     }
 
     public function test_cannot_scope_an_invalid_PHP_file()
@@ -76,6 +69,12 @@ PHP;
         $actual = $this->scoper->scope($content, $prefix);
 
         $this->assertSame($expected, $actual);
+    }
+
+    public function testShouldNotScopePhpOrSplReservedClasses()
+    {
+        $content = file_get_contents(__DIR__.'/Fixtures/reserved_classes.php');
+        $this->assertEquals($content, $this->scoper->scope($content, 'MyPrefix'));
     }
 
     public function provideValidFiles()
@@ -520,11 +519,5 @@ use const Humbug\FooNamespace\FOO;
 
 PHP
             ];
-    }
-
-    public function testShouldNotScopePhpOrSplReservedClasses()
-    {
-        $content = file_get_contents(__DIR__.'/Fixtures/reserved_classes.php');
-        $this->assertEquals($content, $this->scoper->addNamespacePrefix($content, 'MyPrefix'));
     }
 }

--- a/tests/ScoperTest.php
+++ b/tests/ScoperTest.php
@@ -514,4 +514,10 @@ use const Humbug\FooNamespace\FOO;
 PHP
             ];
     }
+
+    public function testShouldNotScopePhpOrSplReservedClasses()
+    {
+        $content = file_get_contents(__DIR__.'/Fixtures/reserved_classes.php');
+        $this->assertEquals($content, $this->scoper->addNamespacePrefix($content, 'MyPrefix'));
+    }
 }

--- a/tests/ScoperTest.php
+++ b/tests/ScoperTest.php
@@ -34,7 +34,14 @@ class ScoperTest extends TestCase
      */
     public function setUp()
     {
+<<<<<<< HEAD
         $this->scoper = new Scoper(createParser());
+=======
+        $this->scoper = new Scoper(
+            (new ParserFactory())->create(ParserFactory::PREFER_PHP7),
+            ['Closure']
+        );
+>>>>>>> Map declared classes at start and route to Node Visitor
     }
 
     public function test_cannot_scope_an_invalid_PHP_file()


### PR DESCRIPTION
On a parallel to the PHP 7 fix using a custom attribute set on nodes to ignore PHP/SPL/Extension classes. Same is also needed for:

- [ ] Apply to FQN constants, e.g. `\PHP_EOL` vs `PHP_EOL`.
- [ ] Apply to FQN functions, should be even rarer then constants but possible, e.g. `\str_replace()`.