### PR TITLE
Handle non-existent files and non PHP files

### DIFF
--- a/src/Handler/HandleAddPrefix.php
+++ b/src/Handler/HandleAddPrefix.php
@@ -16,7 +16,9 @@ namespace Humbug\PhpScoper\Handler;
 
 use Humbug\PhpScoper\Logger\ConsoleLogger;
 use Humbug\PhpScoper\Scoper;
+use Humbug\PhpScoper\Throwable\Exception\ParsingException;
 use Humbug\PhpScoper\Throwable\Exception\RuntimeException;
+use PhpParser\Error;
 use SplFileInfo;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Finder\Finder;
@@ -28,9 +30,6 @@ use function Humbug\PhpScoper\get_common_path;
  */
 class HandleAddPrefix
 {
-    /** @internal */
-    const PHP_FILE_PATTERN = '/\.php$/';
-
     private $fileSystem;
     private $scoper;
 
@@ -65,8 +64,9 @@ class HandleAddPrefix
 
     /**
      * @param string[] $paths
+     * @param string   $output
      *
-     * @return string[] absolute paths
+     * @return string[]
      */
     private function retrieveFiles(array $paths, string $output): array
     {
@@ -74,9 +74,18 @@ class HandleAddPrefix
         $filesToAppend = [];
 
         foreach ($paths as $path) {
+            if (false === file_exists($path)) {
+                throw new RuntimeException(
+                    sprintf(
+                        'Could not find the file "%s".',
+                        $path
+                    )
+                );
+            }
+
             if (is_dir($path)) {
                 $pathsToSearch[] = $path;
-            } elseif (1 === preg_match(self::PHP_FILE_PATTERN, $path)) {
+            } else {
                 $filesToAppend[] = $path;
             }
         }
@@ -84,7 +93,6 @@ class HandleAddPrefix
         $finder = new Finder();
 
         $finder->files()
-            ->name(self::PHP_FILE_PATTERN)
             ->in($pathsToSearch)
             ->append($filesToAppend)
             ->sortByName()
@@ -149,7 +157,21 @@ class HandleAddPrefix
     {
         $fileContent = file_get_contents($inputFilePath);
 
-        $scoppedContent = $this->scoper->scope($fileContent, $prefix);
+        try {
+            $scoppedContent = (1 === preg_match('/.*\.php$/', $inputFilePath))
+                ? $this->scoper->scope($fileContent, $prefix)
+                : $fileContent
+            ;
+        } catch (Error $error) {
+            throw new ParsingException(
+                sprintf(
+                    'Could not parse the file "%s".',
+                    $inputFilePath
+                ),
+                0,
+                $error
+            );
+        }
 
         $this->fileSystem->dumpFile($outputFilePath, $scoppedContent);
 

--- a/tests/Handler/HandleAddPrefixTest.php
+++ b/tests/Handler/HandleAddPrefixTest.php
@@ -115,7 +115,7 @@ class HandleAddPrefixTest extends TestCase
 
             if ($isScoped) {
                 $this->scoperProphecy->scope($fileContent, $prefix)->shouldBeCalled();
-                $scopedFiles++;
+                ++$scopedFiles;
             } else {
                 $this->scoperProphecy->scope($fileContent, $prefix)->shouldNotBeCalled();
             }

--- a/tests/Handler/HandleAddPrefixTest.php
+++ b/tests/Handler/HandleAddPrefixTest.php
@@ -17,6 +17,9 @@ namespace Humbug\PhpScoper\Handler;
 use Error;
 use Humbug\PhpScoper\Logger\ConsoleLogger;
 use Humbug\PhpScoper\Scoper;
+use Humbug\PhpScoper\Throwable\Exception\ParsingException;
+use Humbug\PhpScoper\Throwable\Exception\RuntimeException;
+use PhpParser\Error as PhpParserError;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
 use Prophecy\Prophecy\ObjectProphecy;
@@ -105,11 +108,17 @@ class HandleAddPrefixTest extends TestCase
         /** @var ConsoleLogger $logger */
         $logger = $this->loggerProphecy->reveal();
 
-        foreach ($expected as $fileContent) {
+        $scopedFiles = 0;
+        foreach ($expected as $fileContent => $isScoped) {
             $filePath = realpath(escape_path(self::FIXTURE_PATH_000.$fileContent));
             $this->assertNotFalse($filePath, 'Type check.');
 
-            $this->scoperProphecy->scope($fileContent, $prefix)->shouldBeCalled();
+            if ($isScoped) {
+                $this->scoperProphecy->scope($fileContent, $prefix)->shouldBeCalled();
+                $scopedFiles++;
+            } else {
+                $this->scoperProphecy->scope($fileContent, $prefix)->shouldNotBeCalled();
+            }
             $this->loggerProphecy->outputSuccess($filePath)->shouldBeCalled();
         }
 
@@ -117,7 +126,8 @@ class HandleAddPrefixTest extends TestCase
 
         $this->handle->__invoke($prefix, $paths, $outputPath, $logger);
 
-        $this->scoperProphecy->scope(Argument::cetera())->shouldHaveBeenCalledTimes(count($expected));
+        $this->scoperProphecy->scope(Argument::cetera())->shouldHaveBeenCalledTimes($scopedFiles);
+
         $this->loggerProphecy->outputSuccess(Argument::cetera())->shouldHaveBeenCalledTimes(count($expected));
         $this->loggerProphecy->outputFileCount(Argument::cetera())->shouldHaveBeenCalledTimes(1);
     }
@@ -155,6 +165,65 @@ PHP;
         $this->assertSame($expected, $actual);
     }
 
+    public function test_leaves_non_PHP_files_unchanged()
+    {
+        $prefix = 'MyPrefix';
+
+        $paths = [
+            $filePath = escape_path(self::FIXTURE_PATH_000.'/unknown'),
+        ];
+
+        $outputPath = $this->tmpDir;
+
+        /** @var ConsoleLogger $logger */
+        $logger = $this->loggerProphecy->reveal();
+
+        $expected = <<<'TEXT'
+/unknown
+TEXT;
+
+        $this->scoperProphecy->scope(Argument::cetera())->shouldNotBeCalled();
+
+        $this->handle->__invoke($prefix, $paths, $outputPath, $logger);
+
+        $actual = file_get_contents(
+            escape_path($this->tmpDir.'/unknown')
+        );
+
+        $this->assertSame($expected, $actual);
+    }
+
+    public function test_cannot_collect_files_from_unknown_paths()
+    {
+        $prefix = 'MyPrefix';
+
+        $paths = [
+            $filePath = escape_path('/nowhere'),
+        ];
+
+        $outputPath = $this->tmpDir.DIRECTORY_SEPARATOR.'output-dir';
+
+        /** @var ConsoleLogger $logger */
+        $logger = $this->loggerProphecy->reveal();
+
+        $this->scoperProphecy->scope(Argument::cetera())->shouldNotBeCalled();
+
+        try {
+            $this->handle->__invoke($prefix, $paths, $outputPath, $logger);
+
+            $this->fail('Expected exception to be thrown.');
+        } catch (RuntimeException $exception) {
+            $this->assertSame(
+                'Could not find the file "/nowhere".',
+                $exception->getMessage()
+            );
+            $this->assertSame(0, $exception->getCode());
+            $this->assertNull($exception->getPrevious());
+        }
+
+        $this->assertFalse(file_exists($outputPath));
+    }
+
     public function test_removes_scoped_files_on_failure()
     {
         $prefix = 'MyPrefix';
@@ -170,7 +239,7 @@ PHP;
 
         $this->scoperProphecy
             ->scope(Argument::any(), $prefix)
-            ->willThrow($error = new Error())
+            ->willThrow($error = new Error('Unknown error'))
         ;
 
         try {
@@ -184,6 +253,40 @@ PHP;
         $this->assertFalse(file_exists($outputPath));
     }
 
+    public function test_throws_an_error_when_cannot_parse_a_file()
+    {
+        $prefix = 'MyPrefix';
+
+        $paths = [
+            $filePath = escape_path(self::FIXTURE_PATH_001.'/file.php'),
+        ];
+
+        $outputPath = $this->tmpDir.DIRECTORY_SEPARATOR.'output-dir';
+
+        /** @var ConsoleLogger $logger */
+        $logger = $this->loggerProphecy->reveal();
+
+        $this->scoperProphecy
+            ->scope(Argument::any(), $prefix)
+            ->willThrow($error = new PhpParserError('Could not parse file'))
+        ;
+
+        try {
+            $this->handle->__invoke($prefix, $paths, $outputPath, $logger);
+
+            $this->fail('Expected exception to be thrown.');
+        } catch (ParsingException $exception) {
+            $this->assertSame(
+                'Could not parse the file "'.realpath($filePath).'".',
+                $exception->getMessage()
+            );
+            $this->assertEquals(0, $exception->getCode());
+            $this->assertSame($error, $exception->getPrevious());
+        }
+
+        $this->assertFalse(file_exists($outputPath));
+    }
+
     public function providePaths()
     {
         yield 'directory with file' => [
@@ -191,7 +294,7 @@ PHP;
                 'dir1',
             ],
             [
-                '/dir1/fileA.php',
+                '/dir1/fileA.php' => true,
             ],
         ];
 
@@ -200,7 +303,7 @@ PHP;
                 'file1.php',
             ],
             [
-                '/file1.php',
+                '/file1.php' => true,
             ],
         ];
 
@@ -208,7 +311,9 @@ PHP;
             [
                 'unknown',
             ],
-            [],
+            [
+                '/unknown' => false,
+            ],
         ];
 
         yield 'empty directory' => [
@@ -225,11 +330,13 @@ PHP;
                 'file2.php',
             ],
             [
-                '/dir1/fileA.php',
-                '/dir2/dir3/fileD.php',
-                '/dir2/fileB.php',
-                '/dir2/fileC.php',
-                '/file2.php',
+                '/dir1/fileA.php' => true,
+                '/dir2/dir3/fileD.php' => true,
+                '/dir2/dir3/unknown' => false,
+                '/dir2/fileB.php' => true,
+                '/dir2/fileC.php' => true,
+                '/dir2/unknown' => false,
+                '/file2.php' => true,
             ],
         ];
     }


### PR DESCRIPTION
- Throws an error when a path given is invalid (file/directory does not exist)
- Non PHP files are copied as well (but are not parsed or changed)
- Throw a more meaningful error when the parsing of a file fails (give the file path)