### PR TITLE
Properly scope fully-qualified class name nodes

### DIFF
--- a/src/NodeVisitor/FullyQualifiedNamespaceUseScoperNodeVisitor.php
+++ b/src/NodeVisitor/FullyQualifiedNamespaceUseScoperNodeVisitor.php
@@ -40,7 +40,7 @@ final class FullyQualifiedNamespaceUseScoperNodeVisitor extends NodeVisitorAbstr
             && false === ($node->hasAttribute('phpscoper_ignore')
             && true === $node->getAttribute('phpscoper_ignore'))
         ) {
-            return new Name(Name::concat($this->prefix, (string) $node));
+            return new Name('\\' . Name::concat($this->prefix, (string) $node));
         }
 
         return $node;

--- a/src/NodeVisitor/FullyQualifiedNamespaceUseScoperNodeVisitor.php
+++ b/src/NodeVisitor/FullyQualifiedNamespaceUseScoperNodeVisitor.php
@@ -40,7 +40,7 @@ final class FullyQualifiedNamespaceUseScoperNodeVisitor extends NodeVisitorAbstr
             && false === ($node->hasAttribute('phpscoper_ignore')
             && true === $node->getAttribute('phpscoper_ignore'))
         ) {
-            return new Name('\\' . Name::concat($this->prefix, (string) $node));
+            return new Name('\\'.Name::concat($this->prefix, (string) $node));
         }
 
         return $node;

--- a/src/NodeVisitor/IgnoreNamespaceScoperNodeVisitor.php
+++ b/src/NodeVisitor/IgnoreNamespaceScoperNodeVisitor.php
@@ -28,7 +28,7 @@ final class IgnoreNamespaceScoperNodeVisitor extends NodeVisitorAbstract
     {
         if ($node instanceof FullyQualified
             && $node->isFullyQualified()
-            && 1 === count($node->getSubNodeNames())
+            && 1 === count($node->parts)
         ) {
             $node->setAttribute('phpscoper_ignore', true);
         }

--- a/tests/Scoper/PhpScoperTest.php
+++ b/tests/Scoper/PhpScoperTest.php
@@ -594,6 +594,28 @@ PHP
         ];
 
         //
+        // FQN usage for a name
+        //
+        // ====================
+
+        yield '[FQN usage for a name] fully qualified class' => [
+            <<<'PHP'
+<?php
+
+new \Foo\Bar();
+
+PHP
+            ,
+            'Humbug',
+            <<<'PHP'
+<?php
+
+new \Humbug\Foo\Bar();
+
+PHP
+        ];
+
+        //
         // Single part global namespace reference
         //
         // ======================================


### PR DESCRIPTION
Also fix unrelated bug stripping `\` from start of FQN after concatenating prefixes
closes #53