### PR TITLE
Fix Composer autoloading

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ PHPUNIT=vendor/bin/phpunit
 PHPSCOPER=bin/php-scoper.phar
 
 .DEFAULT_GOAL := help
-.PHONY: build test tu tc e2e
+.PHONY: build test tu tc e2e tb
 
 
 help:
@@ -52,11 +52,17 @@ tc: vendor
 
 e2e:			  ## Run end-to-end tests
 e2e: scoper
-	php -d zend.enable_gc=0 $(PHPSCOPER) add-prefix fixtures/set004 -o build/set004 -f
-	composer -d=build/set004 dump-autoload
-	php -d zend.enable_gc=0 $(BOX) build -c build/set004/box.json.dist
-	php build/set004/bin/greet.phar > build/output
-	diff fixtures/set004/expected-output build/output
+#	php -d zend.enable_gc=0 $(PHPSCOPER) add-prefix fixtures/set004 -o build/set004 -f
+#	composer -d=build/set004 dump-autoload
+#	php -d zend.enable_gc=0 $(BOX) build -c build/set004/box.json.dist
+#	php build/set004/bin/greet.phar > build/output
+#	diff fixtures/set004/expected-output build/output
+
+	php -d zend.enable_gc=0 bin/php-scoper.php add-prefix fixtures/set005 -o build/set005 -f
+	composer -d=build/set005 dump-autoload
+	php -d zend.enable_gc=0 $(BOX) build -c build/set005/box.json.dist
+	php build/set005/bin/greet.phar > build/output
+	diff fixtures/set005/expected-output build/output
 
 tb:				  ## Run Blackfire profiling
 tb: vendor

--- a/fixtures/set005/bin/greet.php
+++ b/fixtures/set005/bin/greet.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__.'/../vendor/autoload.php';
+
+use Assert\Assertion;
+use Set005\Greeter;
+
+Assertion::true(true);
+echo (new Greeter())->greet().PHP_EOL;

--- a/fixtures/set005/box.json.dist
+++ b/fixtures/set005/box.json.dist
@@ -1,0 +1,15 @@
+{
+    "output": "build/set005/bin/greet.phar",
+    "main": "bin/greet.php",
+    "base-path": "build/set005",
+    "directories": [
+        "src",
+        "vendor"
+    ],
+    "compression": "GZ",
+    "compactors": [
+        "Herrera\\Box\\Compactor\\Json",
+        "Herrera\\Box\\Compactor\\Php"
+    ],
+    "stub": true
+}

--- a/fixtures/set005/composer.json
+++ b/fixtures/set005/composer.json
@@ -1,0 +1,13 @@
+{
+    "bin": [
+        "bin/greet"
+    ],
+    "autoload": {
+        "psr-4": {
+            "Set005\\": "src/"
+        }
+    },
+    "require": {
+        "beberlei/assert": "^2.7"
+    }
+}

--- a/fixtures/set005/composer.lock
+++ b/fixtures/set005/composer.lock
@@ -1,0 +1,73 @@
+{
+    "_readme": [
+        "This file locks the dependencies of your project to a known state",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
+        "This file is @generated automatically"
+    ],
+    "content-hash": "11b4adb491198aed0c3548cbe9802fdd",
+    "packages": [
+        {
+            "name": "beberlei/assert",
+            "version": "v2.7.6",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/beberlei/assert.git",
+                "reference": "8726e183ebbb0169cb6cb4832e22ebd355524563"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/beberlei/assert/zipball/8726e183ebbb0169cb6cb4832e22ebd355524563",
+                "reference": "8726e183ebbb0169cb6cb4832e22ebd355524563",
+                "shasum": ""
+            },
+            "require": {
+                "ext-mbstring": "*",
+                "php": ">=5.3"
+            },
+            "require-dev": {
+                "friendsofphp/php-cs-fixer": "^2.1.1",
+                "phpunit/phpunit": "^4|^5"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Assert\\": "lib/Assert"
+                },
+                "files": [
+                    "lib/Assert/functions.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-2-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Benjamin Eberlei",
+                    "email": "kontakt@beberlei.de",
+                    "role": "Lead Developer"
+                },
+                {
+                    "name": "Richard Quadling",
+                    "email": "rquadling@gmail.com",
+                    "role": "Collaborator"
+                }
+            ],
+            "description": "Thin assertion library for input validation in business models.",
+            "keywords": [
+                "assert",
+                "assertion",
+                "validation"
+            ],
+            "time": "2017-05-04T02:00:24+00:00"
+        }
+    ],
+    "packages-dev": [],
+    "aliases": [],
+    "minimum-stability": "stable",
+    "stability-flags": [],
+    "prefer-stable": false,
+    "prefer-lowest": false,
+    "platform": [],
+    "platform-dev": []
+}

--- a/fixtures/set005/expected-output
+++ b/fixtures/set005/expected-output
@@ -1,0 +1,1 @@
+Hello world!

--- a/fixtures/set005/src/Greeter.php
+++ b/fixtures/set005/src/Greeter.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Set005;
+
+class Greeter
+{
+    public function greet(): string
+    {
+        return 'Hello world!';
+    }
+}

--- a/src/NodeVisitor/IgnoreNamespaceScoperNodeVisitor.php
+++ b/src/NodeVisitor/IgnoreNamespaceScoperNodeVisitor.php
@@ -36,7 +36,8 @@ final class IgnoreNamespaceScoperNodeVisitor extends NodeVisitorAbstract
         if ($node instanceof UseUse
             && $node->hasAttribute('parent')
             && false === ($node->getAttribute('parent') instanceof GroupUse)
-            && (1 === count($node->name->parts) || 'Composer' === $node->name->getFirst())
+            && 1 === count($node->name->parts)
+//            && (1 === count($node->name->parts) || 'Composer' === $node->name->getFirst())
         ) {
             $node->setAttribute('phpscoper_ignore', true);
         }

--- a/tests/Scoper/ComposerScoperTest.php
+++ b/tests/Scoper/ComposerScoperTest.php
@@ -65,21 +65,6 @@ class ComposerScoperTest extends TestCase
         $this->assertTrue(is_a(ComposerScoper::class, Scoper::class, true));
     }
 
-    public function test_returns_the_file_content_if_file_is_a_composerlock_file()
-    {
-        $filePath = escape_path($this->tmp.'/composer.lock');
-        $expected = 'Lock content';
-
-        touch($filePath);
-        file_put_contents($filePath, $expected);
-
-        $scoper = new ComposerScoper(new FakeScoper());
-
-        $actual = $scoper->scope($filePath, 'Foo');
-
-        $this->assertSame($expected, $actual);
-    }
-
     public function test_delegates_scoping_to_the_decorated_scoper_if_is_not_a_composer_file()
     {
         $filePath = escape_path($this->tmp.'/file.php');
@@ -114,6 +99,21 @@ class ComposerScoperTest extends TestCase
     public function test_it_prefixes_the_composer_autoloader(string $fileContent, string $expected)
     {
         touch($filePath = escape_path($this->tmp.'/composer.json'));
+        file_put_contents($filePath, $fileContent);
+
+        $scoper = new ComposerScoper(new FakeScoper());
+
+        $actual = $scoper->scope($filePath, 'Foo');
+
+        $this->assertSame($expected, $actual);
+    }
+
+    /**
+     * @dataProvider provideComposerLockFiles
+     */
+    public function test_it_prefixes_the_composer_dependencies_autoloader(string $fileContent, string $expected)
+    {
+        touch($filePath = escape_path($this->tmp.'/composer.lock'));
         file_put_contents($filePath, $fileContent);
 
         $scoper = new ComposerScoper(new FakeScoper());
@@ -170,6 +170,413 @@ JSON
             "tests\/functions.php"
         ]
     }
+}
+JSON
+        ];
+    }
+
+    public function provideComposerLockFiles()
+    {
+        yield [
+            <<<'JSON'
+{
+    "_readme": [
+        "This file locks the dependencies of your project to a known state",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
+        "This file is @generated automatically"
+    ],
+    "content-hash": "86085ec14509d593461f6364ebca9e2b",
+    "packages": [
+        {
+            "name": "beberlei/assert",
+            "version": "v2.7.6",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/beberlei/assert.git",
+                "reference": "8726e183ebbb0169cb6cb4832e22ebd355524563"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/beberlei/assert/zipball/8726e183ebbb0169cb6cb4832e22ebd355524563",
+                "reference": "8726e183ebbb0169cb6cb4832e22ebd355524563",
+                "shasum": ""
+            },
+            "require": {
+                "ext-mbstring": "*",
+                "php": ">=5.3"
+            },
+            "require-dev": {
+                "friendsofphp/php-cs-fixer": "^2.1.1",
+                "phpunit/phpunit": "^4|^5"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Assert\\": "lib/Assert"
+                },
+                "files": [
+                    "lib/Assert/functions.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-2-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Benjamin Eberlei",
+                    "email": "kontakt@beberlei.de",
+                    "role": "Lead Developer"
+                },
+                {
+                    "name": "Richard Quadling",
+                    "email": "rquadling@gmail.com",
+                    "role": "Collaborator"
+                }
+            ],
+            "description": "Thin assertion library for input validation in business models.",
+            "keywords": [
+                "assert",
+                "assertion",
+                "validation"
+            ],
+            "time": "2017-05-04T02:00:24+00:00"
+        }
+    ],
+    "packages-dev": [
+        {
+            "name": "composer/ca-bundle",
+            "version": "1.0.7",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/composer/ca-bundle.git",
+                "reference": "b17e6153cb7f33c7e44eb59578dc12eee5dc8e12"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/composer/ca-bundle/zipball/b17e6153cb7f33c7e44eb59578dc12eee5dc8e12",
+                "reference": "b17e6153cb7f33c7e44eb59578dc12eee5dc8e12",
+                "shasum": ""
+            },
+            "require": {
+                "ext-openssl": "*",
+                "ext-pcre": "*",
+                "php": "^5.3.2 || ^7.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.5",
+                "psr/log": "^1.0",
+                "symfony/process": "^2.5 || ^3.0"
+            },
+            "suggest": {
+                "symfony/process": "This is necessary to reliably check whether openssl_x509_parse is vulnerable on older php versions, but can be ignored on PHP 5.5.6+"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Composer\\CaBundle\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jordi Boggiano",
+                    "email": "j.boggiano@seld.be",
+                    "homepage": "http://seld.be"
+                }
+            ],
+            "description": "Lets you find a path to the system CA bundle, and includes a fallback to the Mozilla CA bundle.",
+            "keywords": [
+                "cabundle",
+                "cacert",
+                "certificate",
+                "ssl",
+                "tls"
+            ],
+            "time": "2017-03-06T11:59:08+00:00"
+        },
+        {
+            "name": "padraic/humbug_get_contents",
+            "version": "1.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/humbug/file_get_contents.git",
+                "reference": "279ff67be5b3bd0229326a917c3e262c644b98d6"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/humbug/file_get_contents/zipball/279ff67be5b3bd0229326a917c3e262c644b98d6",
+                "reference": "279ff67be5b3bd0229326a917c3e262c644b98d6",
+                "shasum": ""
+            },
+            "require": {
+                "composer/ca-bundle": "^1.0",
+                "ext-openssl": "*",
+                "php": "^5.3 || ^7.0"
+            },
+            "require-dev": {
+                "bamarni/composer-bin-plugin": "^1.1",
+                "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0"
+            },
+            "type": "library",
+            "extra": {
+                "bamarni-bin": {
+                    "bin-links": false
+                },
+                "branch-alias": {
+                    "dev-master": "2.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Humbug\\": "src/"
+                },
+                "files": [
+                    "src/function.php",
+                    "src/functions.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Pádraic Brady",
+                    "email": "padraic.brady@gmail.com",
+                    "homepage": "http://blog.astrumfutura.com"
+                }
+            ],
+            "description": "Secure wrapper for accessing HTTPS resources with file_get_contents for PHP 5.3+",
+            "homepage": "https://github.com/padraic/file_get_contents",
+            "keywords": [
+                "download",
+                "file_get_contents",
+                "http",
+                "https",
+                "ssl",
+                "tls"
+            ],
+            "time": "2017-06-02T10:18:25+00:00"
+        }
+    ],
+    "aliases": [],
+    "minimum-stability": "stable",
+    "stability-flags": [],
+    "prefer-stable": false,
+    "prefer-lowest": false,
+    "platform": [],
+    "platform-dev": []
+}
+
+
+JSON
+            ,
+            <<<'JSON'
+{
+    "_readme": [
+        "This file locks the dependencies of your project to a known state",
+        "Read more about it at https:\/\/getcomposer.org\/doc\/01-basic-usage.md#composer-lock-the-lock-file",
+        "This file is @generated automatically"
+    ],
+    "content-hash": "86085ec14509d593461f6364ebca9e2b",
+    "packages": [
+        {
+            "name": "beberlei\/assert",
+            "version": "v2.7.6",
+            "source": {
+                "type": "git",
+                "url": "https:\/\/github.com\/beberlei\/assert.git",
+                "reference": "8726e183ebbb0169cb6cb4832e22ebd355524563"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https:\/\/api.github.com\/repos\/beberlei\/assert\/zipball\/8726e183ebbb0169cb6cb4832e22ebd355524563",
+                "reference": "8726e183ebbb0169cb6cb4832e22ebd355524563",
+                "shasum": ""
+            },
+            "require": {
+                "ext-mbstring": "*",
+                "php": ">=5.3"
+            },
+            "require-dev": {
+                "friendsofphp\/php-cs-fixer": "^2.1.1",
+                "phpunit\/phpunit": "^4|^5"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Foo\\Assert\\": "lib\/Assert"
+                },
+                "files": [
+                    "lib\/Assert\/functions.php"
+                ]
+            },
+            "notification-url": "https:\/\/packagist.org\/downloads\/",
+            "license": [
+                "BSD-2-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Benjamin Eberlei",
+                    "email": "kontakt@beberlei.de",
+                    "role": "Lead Developer"
+                },
+                {
+                    "name": "Richard Quadling",
+                    "email": "rquadling@gmail.com",
+                    "role": "Collaborator"
+                }
+            ],
+            "description": "Thin assertion library for input validation in business models.",
+            "keywords": [
+                "assert",
+                "assertion",
+                "validation"
+            ],
+            "time": "2017-05-04T02:00:24+00:00"
+        }
+    ],
+    "packages-dev": [
+        {
+            "name": "composer\/ca-bundle",
+            "version": "1.0.7",
+            "source": {
+                "type": "git",
+                "url": "https:\/\/github.com\/composer\/ca-bundle.git",
+                "reference": "b17e6153cb7f33c7e44eb59578dc12eee5dc8e12"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https:\/\/api.github.com\/repos\/composer\/ca-bundle\/zipball\/b17e6153cb7f33c7e44eb59578dc12eee5dc8e12",
+                "reference": "b17e6153cb7f33c7e44eb59578dc12eee5dc8e12",
+                "shasum": ""
+            },
+            "require": {
+                "ext-openssl": "*",
+                "ext-pcre": "*",
+                "php": "^5.3.2 || ^7.0"
+            },
+            "require-dev": {
+                "phpunit\/phpunit": "^4.5",
+                "psr\/log": "^1.0",
+                "symfony\/process": "^2.5 || ^3.0"
+            },
+            "suggest": {
+                "symfony\/process": "This is necessary to reliably check whether openssl_x509_parse is vulnerable on older php versions, but can be ignored on PHP 5.5.6+"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Foo\\Composer\\CaBundle\\": "src"
+                }
+            },
+            "notification-url": "https:\/\/packagist.org\/downloads\/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jordi Boggiano",
+                    "email": "j.boggiano@seld.be",
+                    "homepage": "http:\/\/seld.be"
+                }
+            ],
+            "description": "Lets you find a path to the system CA bundle, and includes a fallback to the Mozilla CA bundle.",
+            "keywords": [
+                "cabundle",
+                "cacert",
+                "certificate",
+                "ssl",
+                "tls"
+            ],
+            "time": "2017-03-06T11:59:08+00:00"
+        },
+        {
+            "name": "padraic\/humbug_get_contents",
+            "version": "1.1.0",
+            "source": {
+                "type": "git",
+                "url": "https:\/\/github.com\/humbug\/file_get_contents.git",
+                "reference": "279ff67be5b3bd0229326a917c3e262c644b98d6"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https:\/\/api.github.com\/repos\/humbug\/file_get_contents\/zipball\/279ff67be5b3bd0229326a917c3e262c644b98d6",
+                "reference": "279ff67be5b3bd0229326a917c3e262c644b98d6",
+                "shasum": ""
+            },
+            "require": {
+                "composer\/ca-bundle": "^1.0",
+                "ext-openssl": "*",
+                "php": "^5.3 || ^7.0"
+            },
+            "require-dev": {
+                "bamarni\/composer-bin-plugin": "^1.1",
+                "phpunit\/phpunit": "^4.0 || ^5.0 || ^6.0"
+            },
+            "type": "library",
+            "extra": {
+                "bamarni-bin": {
+                    "bin-links": false
+                },
+                "branch-alias": {
+                    "dev-master": "2.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Foo\\Humbug\\": "src\/"
+                },
+                "files": [
+                    "src\/function.php",
+                    "src\/functions.php"
+                ]
+            },
+            "notification-url": "https:\/\/packagist.org\/downloads\/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "P\u00e1draic Brady",
+                    "email": "padraic.brady@gmail.com",
+                    "homepage": "http:\/\/blog.astrumfutura.com"
+                }
+            ],
+            "description": "Secure wrapper for accessing HTTPS resources with file_get_contents for PHP 5.3+",
+            "homepage": "https:\/\/github.com\/padraic\/file_get_contents",
+            "keywords": [
+                "download",
+                "file_get_contents",
+                "http",
+                "https",
+                "ssl",
+                "tls"
+            ],
+            "time": "2017-06-02T10:18:25+00:00"
+        }
+    ],
+    "aliases": [],
+    "minimum-stability": "stable",
+    "stability-flags": [],
+    "prefer-stable": false,
+    "prefer-lowest": false,
+    "platform": [],
+    "platform-dev": []
 }
 JSON
         ];


### PR DESCRIPTION
Another stab at #46.

@padraic I'm a bit blocked really, seems like Composer gets its metadata from somewhere else. I hoped fixing `composer.lock` would be enough but that's not the case as I can still see:

```php
<?php

// autoload_psr4.php @generated by Composer

$vendorDir = dirname(dirname(__FILE__));
$baseDir = dirname($vendorDir);

return array(
    'PhpScoper59431c8baf5d3\\Set005\\' => array($baseDir . '/src'),
    'Assert\\' => array($vendorDir . '/beberlei/assert/lib/Assert'),
);

```