### PR TITLE
Use statement omission

### DIFF
--- a/src/NodeVisitor/IgnoreNamespaceScoperNodeVisitor.php
+++ b/src/NodeVisitor/IgnoreNamespaceScoperNodeVisitor.php
@@ -17,6 +17,7 @@ namespace Humbug\PhpScoper\NodeVisitor;
 use PhpParser\Node;
 use PhpParser\Node\Name\FullyQualified;
 use PhpParser\Node\Stmt\UseUse;
+use PhpParser\Node\Stmt\GroupUse;
 use PhpParser\NodeVisitorAbstract;
 
 final class IgnoreNamespaceScoperNodeVisitor extends NodeVisitorAbstract

--- a/src/NodeVisitor/IgnoreNamespaceScoperNodeVisitor.php
+++ b/src/NodeVisitor/IgnoreNamespaceScoperNodeVisitor.php
@@ -16,8 +16,8 @@ namespace Humbug\PhpScoper\NodeVisitor;
 
 use PhpParser\Node;
 use PhpParser\Node\Name\FullyQualified;
-use PhpParser\Node\Stmt\UseUse;
 use PhpParser\Node\Stmt\GroupUse;
+use PhpParser\Node\Stmt\UseUse;
 use PhpParser\NodeVisitorAbstract;
 
 final class IgnoreNamespaceScoperNodeVisitor extends NodeVisitorAbstract


### PR DESCRIPTION
Minor bug - doesn't cause a problem right now because it is overlapped by `GroupUse` check in `UseNamespaceScoperNodeVisitor`.