### PR TITLE
Add support for class_exists('string')

### DIFF
--- a/src/NodeVisitor/ClassExistsScoperNodeVisitor.php
+++ b/src/NodeVisitor/ClassExistsScoperNodeVisitor.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the humbug/php-scoper package.
+ *
+ * Copyright (c) 2017 Théo FIDRY <theo.fidry@gmail.com>,
+ *                    Pádraic Brady <padraic.brady@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Humbug\PhpScoper\NodeVisitor;
+
+use PhpParser\Node;
+use PhpParser\Node\Name;
+use PhpParser\Node\Stmt\Namespace_;
+use PhpParser\NodeVisitorAbstract;
+
+final class ClassExistsScoperNodeVisitor extends NodeVisitorAbstract
+{
+    /**
+     * @var string
+     */
+    private $prefix;
+
+    public function __construct($prefix)
+    {
+        $this->prefix = $prefix;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function enterNode(Node $node)
+    {
+        if (!$node instanceof Node\Expr\FuncCall || null === $node->name) {
+            return $node;
+        }
+
+        if ('class_exists' !== $node->name->getFirst()) {
+            return $node;
+        }
+
+        $value = $node->args[0]->value;
+        if (!$value instanceof Node\Scalar\String_) {
+            return $node;
+        }
+
+        $value->value = $this->prefix . '\\' . $value->value;
+
+        return $node;
+    }
+}

--- a/src/NodeVisitor/ClassExistsScoperNodeVisitor.php
+++ b/src/NodeVisitor/ClassExistsScoperNodeVisitor.php
@@ -38,6 +38,10 @@ final class ClassExistsScoperNodeVisitor extends NodeVisitorAbstract
             return $node;
         }
 
+        if (!$node->name instanceof Node\Name) {
+            return $node;
+        }
+
         if ('class_exists' !== $node->name->getFirst()) {
             return $node;
         }

--- a/src/NodeVisitor/ClassExistsScoperNodeVisitor.php
+++ b/src/NodeVisitor/ClassExistsScoperNodeVisitor.php
@@ -15,8 +15,6 @@ declare(strict_types=1);
 namespace Humbug\PhpScoper\NodeVisitor;
 
 use PhpParser\Node;
-use PhpParser\Node\Name;
-use PhpParser\Node\Stmt\Namespace_;
 use PhpParser\NodeVisitorAbstract;
 
 final class ClassExistsScoperNodeVisitor extends NodeVisitorAbstract
@@ -49,7 +47,7 @@ final class ClassExistsScoperNodeVisitor extends NodeVisitorAbstract
             return $node;
         }
 
-        $value->value = $this->prefix . '\\' . $value->value;
+        $value->value = $this->prefix.'\\'.$value->value;
 
         return $node;
     }

--- a/src/NodeVisitor/FunctionCallScoperNodeVisitor.php
+++ b/src/NodeVisitor/FunctionCallScoperNodeVisitor.php
@@ -17,16 +17,23 @@ namespace Humbug\PhpScoper\NodeVisitor;
 use PhpParser\Node;
 use PhpParser\NodeVisitorAbstract;
 
-final class ClassExistsScoperNodeVisitor extends NodeVisitorAbstract
+final class FunctionCallScoperNodeVisitor extends NodeVisitorAbstract
 {
     /**
      * @var string
      */
     private $prefix;
 
-    public function __construct($prefix)
+    /**
+     * Function which first parameter should be prefixed
+     * @var array
+     */
+    private $functions;
+
+    public function __construct($prefix, array $functions = ['class_exists', 'interface_exists'])
     {
         $this->prefix = $prefix;
+        $this->functions = $functions;
     }
 
     /**
@@ -42,7 +49,8 @@ final class ClassExistsScoperNodeVisitor extends NodeVisitorAbstract
             return $node;
         }
 
-        if ('class_exists' !== $node->name->getFirst()) {
+
+        if (!in_array($node->name->getFirst(), $this->functions)) {
             return $node;
         }
 
@@ -51,7 +59,9 @@ final class ClassExistsScoperNodeVisitor extends NodeVisitorAbstract
             return $node;
         }
 
-        $value->value = $this->prefix.'\\'.$value->value;
+        if ($this->prefix !== $value->value) {
+            $value->value = $this->prefix.'\\'.$value->value;
+        }
 
         return $node;
     }

--- a/src/NodeVisitor/FunctionCallScoperNodeVisitor.php
+++ b/src/NodeVisitor/FunctionCallScoperNodeVisitor.php
@@ -25,7 +25,8 @@ final class FunctionCallScoperNodeVisitor extends NodeVisitorAbstract
     private $prefix;
 
     /**
-     * Function which first parameter should be prefixed
+     * Function which first parameter should be prefixed.
+     *
      * @var array
      */
     private $functions;
@@ -48,7 +49,6 @@ final class FunctionCallScoperNodeVisitor extends NodeVisitorAbstract
         if (!$node->name instanceof Node\Name) {
             return $node;
         }
-
 
         if (!in_array($node->name->getFirst(), $this->functions)) {
             return $node;

--- a/src/NodeVisitor/FunctionCallScoperNodeVisitor.php
+++ b/src/NodeVisitor/FunctionCallScoperNodeVisitor.php
@@ -19,19 +19,14 @@ use PhpParser\NodeVisitorAbstract;
 
 final class FunctionCallScoperNodeVisitor extends NodeVisitorAbstract
 {
-    /**
-     * @var string
-     */
     private $prefix;
-
-    /**
-     * Function which first parameter should be prefixed.
-     *
-     * @var array
-     */
     private $functions;
 
-    public function __construct($prefix, array $functions = ['class_exists', 'interface_exists'])
+    /**
+     * @param string $prefix
+     * @param string[] $functions Functions which first parameter should be prefixed.
+     */
+    public function __construct($prefix, array $functions)
     {
         $this->prefix = $prefix;
         $this->functions = $functions;
@@ -63,7 +58,7 @@ final class FunctionCallScoperNodeVisitor extends NodeVisitorAbstract
 
         // Do not prefix global namespace
         if (false !== strstr($stringValue, '\\')) {
-            $value->value = $this->prefix.'\\'.$stringValue;
+            $value->value = ($value->value !== $stringValue ? '\\' : '') . $this->prefix.'\\'.$stringValue;
         }
 
         return $node;

--- a/src/NodeVisitor/FunctionCallScoperNodeVisitor.php
+++ b/src/NodeVisitor/FunctionCallScoperNodeVisitor.php
@@ -23,7 +23,7 @@ final class FunctionCallScoperNodeVisitor extends NodeVisitorAbstract
     private $functions;
 
     /**
-     * @param string $prefix
+     * @param string   $prefix
      * @param string[] $functions Functions which first parameter should be prefixed.
      */
     public function __construct($prefix, array $functions)
@@ -58,7 +58,7 @@ final class FunctionCallScoperNodeVisitor extends NodeVisitorAbstract
 
         // Do not prefix global namespace
         if (false !== strstr($stringValue, '\\')) {
-            $value->value = ($value->value !== $stringValue ? '\\' : '') . $this->prefix.'\\'.$stringValue;
+            $value->value = ($value->value !== $stringValue ? '\\' : '').$this->prefix.'\\'.$stringValue;
         }
 
         return $node;

--- a/src/NodeVisitor/FunctionCallScoperNodeVisitor.php
+++ b/src/NodeVisitor/FunctionCallScoperNodeVisitor.php
@@ -59,8 +59,11 @@ final class FunctionCallScoperNodeVisitor extends NodeVisitorAbstract
             return $node;
         }
 
-        if ($this->prefix !== $value->value) {
-            $value->value = $this->prefix.'\\'.$value->value;
+        $stringValue = ltrim($value->value, '\\');
+
+        // Do not prefix global namespace
+        if (false !== strstr($stringValue, '\\')) {
+            $value->value = $this->prefix.'\\'.$stringValue;
         }
 
         return $node;

--- a/src/Scoper/PhpScoper.php
+++ b/src/Scoper/PhpScoper.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 
 namespace Humbug\PhpScoper\Scoper;
 
+use Humbug\PhpScoper\NodeVisitor\ClassExistsScoperNodeVisitor;
 use Humbug\PhpScoper\NodeVisitor\FullyQualifiedNamespaceUseScoperNodeVisitor;
 use Humbug\PhpScoper\NodeVisitor\GroupUseNamespaceScoperNodeVisitor;
 use Humbug\PhpScoper\NodeVisitor\IgnoreNamespaceScoperNodeVisitor;
@@ -95,6 +96,7 @@ final class PhpScoper implements Scoper
         $traverser->addVisitor(new IgnoreNamespaceScoperNodeVisitor());
         $traverser->addVisitor(new GroupUseNamespaceScoperNodeVisitor($prefix));
         $traverser->addVisitor(new NamespaceScoperNodeVisitor($prefix));
+        $traverser->addVisitor(new ClassExistsScoperNodeVisitor($prefix));
         $traverser->addVisitor(new UseNamespaceScoperNodeVisitor($prefix));
         $traverser->addVisitor(new FullyQualifiedNamespaceUseScoperNodeVisitor($prefix));
 

--- a/src/Scoper/PhpScoper.php
+++ b/src/Scoper/PhpScoper.php
@@ -14,8 +14,8 @@ declare(strict_types=1);
 
 namespace Humbug\PhpScoper\Scoper;
 
-use Humbug\PhpScoper\NodeVisitor\FunctionCallScoperNodeVisitor;
 use Humbug\PhpScoper\NodeVisitor\FullyQualifiedNamespaceUseScoperNodeVisitor;
+use Humbug\PhpScoper\NodeVisitor\FunctionCallScoperNodeVisitor;
 use Humbug\PhpScoper\NodeVisitor\GroupUseNamespaceScoperNodeVisitor;
 use Humbug\PhpScoper\NodeVisitor\IgnoreNamespaceScoperNodeVisitor;
 use Humbug\PhpScoper\NodeVisitor\NamespaceScoperNodeVisitor;

--- a/src/Scoper/PhpScoper.php
+++ b/src/Scoper/PhpScoper.php
@@ -14,7 +14,7 @@ declare(strict_types=1);
 
 namespace Humbug\PhpScoper\Scoper;
 
-use Humbug\PhpScoper\NodeVisitor\ClassExistsScoperNodeVisitor;
+use Humbug\PhpScoper\NodeVisitor\FunctionCallScoperNodeVisitor;
 use Humbug\PhpScoper\NodeVisitor\FullyQualifiedNamespaceUseScoperNodeVisitor;
 use Humbug\PhpScoper\NodeVisitor\GroupUseNamespaceScoperNodeVisitor;
 use Humbug\PhpScoper\NodeVisitor\IgnoreNamespaceScoperNodeVisitor;
@@ -96,7 +96,7 @@ final class PhpScoper implements Scoper
         $traverser->addVisitor(new IgnoreNamespaceScoperNodeVisitor());
         $traverser->addVisitor(new GroupUseNamespaceScoperNodeVisitor($prefix));
         $traverser->addVisitor(new NamespaceScoperNodeVisitor($prefix));
-        $traverser->addVisitor(new ClassExistsScoperNodeVisitor($prefix));
+        $traverser->addVisitor(new FunctionCallScoperNodeVisitor($prefix));
         $traverser->addVisitor(new UseNamespaceScoperNodeVisitor($prefix));
         $traverser->addVisitor(new FullyQualifiedNamespaceUseScoperNodeVisitor($prefix));
 

--- a/src/Scoper/PhpScoper.php
+++ b/src/Scoper/PhpScoper.php
@@ -96,7 +96,7 @@ final class PhpScoper implements Scoper
         $traverser->addVisitor(new IgnoreNamespaceScoperNodeVisitor());
         $traverser->addVisitor(new GroupUseNamespaceScoperNodeVisitor($prefix));
         $traverser->addVisitor(new NamespaceScoperNodeVisitor($prefix));
-        $traverser->addVisitor(new FunctionCallScoperNodeVisitor($prefix));
+        $traverser->addVisitor(new FunctionCallScoperNodeVisitor($prefix, ['class_exists', 'interface_exists']));
         $traverser->addVisitor(new UseNamespaceScoperNodeVisitor($prefix));
         $traverser->addVisitor(new FullyQualifiedNamespaceUseScoperNodeVisitor($prefix));
 

--- a/tests/Scoper/PhpScoperTest.php
+++ b/tests/Scoper/PhpScoperTest.php
@@ -965,5 +965,64 @@ new Bar\Baz();
 
 PHP
         ];
+
+        //
+        // Function parameters
+        //
+        // ====================
+
+        yield '[Function parameter] class_exists' => [
+            <<<'PHP'
+<?php
+
+class_exists('Symfony\Component\Yaml\Yaml');
+
+PHP
+            ,
+            'Humbug',
+            <<<'PHP'
+<?php
+
+class_exists('Humbug\\Symfony\\Component\\Yaml\\Yaml');
+
+PHP
+        ];
+
+        yield '[Function parameter] class_exists with constant' => [
+            <<<'PHP'
+<?php
+
+class_exists(\Symfony\Component\Yaml\Yaml::class);
+
+PHP
+            ,
+            'Humbug',
+            <<<'PHP'
+<?php
+
+class_exists(\Humbug\Symfony\Component\Yaml\Yaml::class);
+
+PHP
+        ];
+
+
+        yield '[Function parameter] class_exists with variable (no change)' => [
+            <<<'PHP'
+<?php
+
+$x = '\\Symfony\\Component\\Yaml\\Yaml';
+class_exists($x);
+
+PHP
+            ,
+            'Humbug',
+            <<<'PHP'
+<?php
+
+$x = '\\Symfony\\Component\\Yaml\\Yaml';
+class_exists($x);
+
+PHP
+        ];
     }
 }

--- a/tests/Scoper/PhpScoperTest.php
+++ b/tests/Scoper/PhpScoperTest.php
@@ -975,7 +975,7 @@ PHP
             <<<'PHP'
 <?php
 
-class_exists('Symfony\Component\Yaml\Yaml');
+class_exists('Symfony\\Component\\Yaml\\Yaml');
 
 PHP
             ,
@@ -984,6 +984,40 @@ PHP
 <?php
 
 class_exists('Humbug\\Symfony\\Component\\Yaml\\Yaml');
+
+PHP
+        ];
+
+        yield '[Function parameter] interface_exists' => [
+            <<<'PHP'
+<?php
+
+interface_exists('Foo\\Bar');
+
+PHP
+            ,
+            'Humbug',
+            <<<'PHP'
+<?php
+
+interface_exists('Humbug\\Foo\\Bar');
+
+PHP
+        ];
+
+        yield '[Function parameter] class_exists with concat strings' => [
+            <<<'PHP'
+<?php
+
+class_exists('Symfony\\Component' . '\\Yaml\\Yaml');
+
+PHP
+            ,
+            'Humbug',
+            <<<'PHP'
+<?php
+
+class_exists('Symfony\\Component' . '\\Yaml\\Yaml');
 
 PHP
         ];
@@ -1020,6 +1054,23 @@ PHP
 
 $x = '\\Symfony\\Component\\Yaml\\Yaml';
 class_exists($x);
+
+PHP
+        ];
+
+        yield '[Function parameter] Skip when prefix is the same' => [
+            <<<'PHP'
+<?php
+
+class_exists('Humbug');
+
+PHP
+            ,
+            'Humbug',
+            <<<'PHP'
+<?php
+
+class_exists('Humbug');
 
 PHP
         ];

--- a/tests/Scoper/PhpScoperTest.php
+++ b/tests/Scoper/PhpScoperTest.php
@@ -1005,7 +1005,6 @@ class_exists(\Humbug\Symfony\Component\Yaml\Yaml::class);
 PHP
         ];
 
-
         yield '[Function parameter] class_exists with variable (no change)' => [
             <<<'PHP'
 <?php

--- a/tests/Scoper/PhpScoperTest.php
+++ b/tests/Scoper/PhpScoperTest.php
@@ -985,7 +985,7 @@ PHP
 <?php
 
 class_exists('Humbug\\Symfony\\Component\\Yaml\\Yaml');
-class_exists('Humbug\\Symfony\\Component\\Yaml\\Yaml');
+class_exists('\\Humbug\\Symfony\\Component\\Yaml\\Yaml');
 
 PHP
         ];

--- a/tests/Scoper/PhpScoperTest.php
+++ b/tests/Scoper/PhpScoperTest.php
@@ -976,6 +976,7 @@ PHP
 <?php
 
 class_exists('Symfony\\Component\\Yaml\\Yaml');
+class_exists('\\Symfony\\Component\\Yaml\\Yaml');
 
 PHP
             ,
@@ -983,6 +984,7 @@ PHP
             <<<'PHP'
 <?php
 
+class_exists('Humbug\\Symfony\\Component\\Yaml\\Yaml');
 class_exists('Humbug\\Symfony\\Component\\Yaml\\Yaml');
 
 PHP
@@ -1058,11 +1060,12 @@ class_exists($x);
 PHP
         ];
 
-        yield '[Function parameter] Skip when prefix is the same' => [
+        yield '[Function parameter] Do not prepend global namespace' => [
             <<<'PHP'
 <?php
 
-class_exists('Humbug');
+class_exists('Closure');
+class_exists('\\Closure');
 
 PHP
             ,
@@ -1070,7 +1073,8 @@ PHP
             <<<'PHP'
 <?php
 
-class_exists('Humbug');
+class_exists('Closure');
+class_exists('\\Closure');
 
 PHP
         ];


### PR DESCRIPTION
We should support `class_exists('\\Symfony\\Component\\Yaml\\Yaml')`. 

(Im having some issues running this lib over Symfony code base.)

This will fix #73 