### PR TITLE
Fix PHPUnit coverage

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -26,6 +26,10 @@ file that was distributed with this source code.
             <directory suffix=".php">./src/</directory>
             <exclude>
                 <file>src/Console/Application.php</file>
+                <file>src/Console/Configuration.php</file>
+                <directory>src/Logger</directory>
+                <directory>src/NodeVisitor</directory>
+                <file>src/functions.php</file>
             </exclude>
         </whitelist>
     </filter>

--- a/src/Scoper/Composer/InstalledPackagesScoper.php
+++ b/src/Scoper/Composer/InstalledPackagesScoper.php
@@ -15,7 +15,6 @@ declare(strict_types=1);
 namespace Humbug\PhpScoper\Scoper\Composer;
 
 use Humbug\PhpScoper\Scoper;
-use LogicException;
 
 final class InstalledPackagesScoper implements Scoper
 {

--- a/src/Scoper/Composer/InstalledPackagesScoper.php
+++ b/src/Scoper/Composer/InstalledPackagesScoper.php
@@ -19,23 +19,12 @@ use LogicException;
 
 final class InstalledPackagesScoper implements Scoper
 {
-    /**
-     * @var string
-     */
-    private static $filePattern;
+    private static $filePattern = '/composer\/installed\.json/';
 
     private $decoratedScoper;
 
     public function __construct(Scoper $decoratedScoper)
     {
-        if (null === self::$filePattern) {
-            self::$filePattern = str_replace(
-                '/',
-                DIRECTORY_SEPARATOR,
-                '~composer/installed\.json~'
-            );
-        }
-
         $this->decoratedScoper = $decoratedScoper;
     }
 
@@ -46,10 +35,6 @@ final class InstalledPackagesScoper implements Scoper
      */
     public function scope(string $filePath, string $prefix, array $patchers, callable $globalWhitelister): string
     {
-        if (null === self::$filePattern) {
-            throw new LogicException('Cannot be used without being initialised first.');
-        }
-
         if (1 !== preg_match(self::$filePattern, $filePath)) {
             return $this->decoratedScoper->scope($filePath, $prefix, $patchers, $globalWhitelister);
         }

--- a/tests/Console/Command/AddPrefixCommandIntegrationTest.php
+++ b/tests/Console/Command/AddPrefixCommandIntegrationTest.php
@@ -234,7 +234,7 @@ EOF;
 PHP Scoper version 12ccf1ac8c7ae8eaf502bd30f95630a112dc713f
 
  * [NO] /path/to/composer/installed.json
-	Could not parse the file "/path/to/composer/installed.json".: TypeError: Argument 1 passed to Humbug\PhpScoper\Scoper\Composer\AutoloadPrefixer::prefixPackageAutoloads() must be of the type array, string given, called in $dir/src/Scoper/Composer/InstalledPackagesScoper.php on line 73 and defined in $dir/src/Scoper/Composer/AutoloadPrefixer.php:28
+	Could not parse the file "/path/to/composer/installed.json".: TypeError
 Stack trace:
 #0
 #1
@@ -264,7 +264,7 @@ Stack trace:
 #25
  * [OK] /path/to/file.php
  * [NO] /path/to/invalid-file.php
-	Could not parse the file "/path/to/invalid-file.php".: PhpParser\Error: Syntax error, unexpected EOF on line 3 in $dir/vendor/nikic/php-parser/lib/PhpParser/ParserAbstract.php:293
+	Could not parse the file "/path/to/invalid-file.php".: PhpParser
 Stack trace:
 #0
 #1
@@ -302,7 +302,8 @@ Stack trace:
 EOF;
 
         $actual = $this->getNormalizeDisplay($this->appTester->getDisplay(true));
-        $actual = preg_replace('/(#\d+)(.*)(\n)/', '$1$3', $actual);
+        $actual = preg_replace('/(Could not parse the file ".+?"\.: \w+).*(\n)/', '$1$2', $actual);
+        $actual = preg_replace('/(#\d+).*(\n)/', '$1$2', $actual);
 
         $this->assertSame($expected, $actual);
         $this->assertSame(0, $this->appTester->getStatusCode());

--- a/tests/Scoper/Composer/InstalledPackagesScoperTest.php
+++ b/tests/Scoper/Composer/InstalledPackagesScoperTest.php
@@ -27,6 +27,7 @@ use function Humbug\PhpScoper\remove_dir;
 
 /**
  * @covers \Humbug\PhpScoper\Scoper\Composer\InstalledPackagesScoper
+ * @covers \Humbug\PhpScoper\Scoper\Composer\AutoloadPrefixer
  */
 class InstalledPackagesScoperTest extends TestCase
 {

--- a/tests/Scoper/Composer/JsonFileScoperTest.php
+++ b/tests/Scoper/Composer/JsonFileScoperTest.php
@@ -27,6 +27,7 @@ use function Humbug\PhpScoper\remove_dir;
 
 /**
  * @covers \Humbug\PhpScoper\Scoper\Composer\JsonFileScoper
+ * @covers \Humbug\PhpScoper\Scoper\Composer\AutoloadPrefixer
  */
 class JsonFileScoperTest extends TestCase
 {

--- a/tests/Scoper/PatchScoperTest.php
+++ b/tests/Scoper/PatchScoperTest.php
@@ -17,13 +17,9 @@ namespace Humbug\PhpScoper\Scoper;
 use Humbug\PhpScoper\Scoper;
 use PHPUnit\Framework\Assert;
 use PHPUnit\Framework\TestCase;
-use function Humbug\PhpScoper\create_fake_patcher;
-use function Humbug\PhpScoper\create_fake_whitelister;
-use function Humbug\PhpScoper\escape_path;
-use function Humbug\PhpScoper\make_tmp_dir;
-use function Humbug\PhpScoper\remove_dir;
 use Prophecy\Argument;
 use Prophecy\Prophecy\ObjectProphecy;
+use function Humbug\PhpScoper\create_fake_whitelister;
 
 /**
  * @covers \Humbug\PhpScoper\Scoper\PatchScoper

--- a/tests/Scoper/PatchScoperTest.php
+++ b/tests/Scoper/PatchScoperTest.php
@@ -1,0 +1,97 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the humbug/php-scoper package.
+ *
+ * Copyright (c) 2017 Théo FIDRY <theo.fidry@gmail.com>,
+ *                    Pádraic Brady <padraic.brady@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Humbug\PhpScoper\Scoper;
+
+use Humbug\PhpScoper\Scoper;
+use PHPUnit\Framework\Assert;
+use PHPUnit\Framework\TestCase;
+use function Humbug\PhpScoper\create_fake_patcher;
+use function Humbug\PhpScoper\create_fake_whitelister;
+use function Humbug\PhpScoper\escape_path;
+use function Humbug\PhpScoper\make_tmp_dir;
+use function Humbug\PhpScoper\remove_dir;
+use Prophecy\Argument;
+use Prophecy\Prophecy\ObjectProphecy;
+
+/**
+ * @covers \Humbug\PhpScoper\Scoper\PatchScoper
+ */
+class PatchScoperTest extends TestCase
+{
+    /**
+     * @var Scoper|ObjectProphecy
+     */
+    private $decoratedScoperProphecy;
+
+    /**
+     * @var Scoper
+     */
+    private $decoratedScoper;
+
+    /**
+     * @inheritdoc
+     */
+    public function setUp()
+    {
+        $this->decoratedScoperProphecy = $this->prophesize(Scoper::class);
+        $this->decoratedScoper = $this->decoratedScoperProphecy->reveal();
+    }
+
+    public function test_is_a_Scoper()
+    {
+        $this->assertTrue(is_a(PatchScoper::class, Scoper::class, true));
+    }
+
+    public function test_applies_the_list_of_patches_to_the_scoped_file()
+    {
+        $filePath = '/path/to/file.php';
+        $content = 'Original file content';
+        $prefix = 'Humbug';
+
+        $patchers = [
+            function (string $patcherFilePath, string $patcherPrefix, string $content) use ($filePath, $prefix): string {
+                Assert::assertSame($filePath, $patcherFilePath);
+                Assert::assertSame($prefix, $patcherPrefix);
+                Assert::assertSame('Original file content', $content);
+
+                return 'File content after patch 1';
+            },
+            function (string $patcherFilePath, string $patcherPrefix, string $content) use ($filePath, $prefix): string {
+                Assert::assertSame($filePath, $patcherFilePath);
+                Assert::assertSame($prefix, $patcherPrefix);
+                Assert::assertSame('File content after patch 1', $content);
+
+                return 'File content after patch 2';
+            },
+        ];
+
+        $whitelister = create_fake_whitelister();
+
+        $this->decoratedScoperProphecy
+            ->scope($filePath, $prefix, $patchers, $whitelister)
+            ->willReturn($content)
+        ;
+
+        $expected = 'File content after patch 2';
+
+        $scoper = new PatchScoper($this->decoratedScoper);
+
+        $actual = $scoper->scope($filePath, $prefix, $patchers, $whitelister);
+
+        $this->assertSame($expected, $actual);
+
+        $this->decoratedScoperProphecy->scope(Argument::cetera())->shouldHaveBeenCalledTimes(1);
+    }
+}


### PR DESCRIPTION
- Remove useless code
- Whitelist code that should not be unit tested (they are covered by integration tests)
- Add missing tests