### PR TITLE
Make traverser return a new instance for each file

### DIFF
--- a/src/Scoper/PhpScoper.php
+++ b/src/Scoper/PhpScoper.php
@@ -29,11 +29,11 @@ final class PhpScoper implements Scoper
     private $decoratedScoper;
     private $traverserFactory;
 
-    public function __construct(Parser $parser, Scoper $decoratedScoper)
+    public function __construct(Parser $parser, Scoper $decoratedScoper, TraverserFactory $traverserFactory)
     {
         $this->parser = $parser;
         $this->decoratedScoper = $decoratedScoper;
-        $this->traverserFactory = new TraverserFactory();
+        $this->traverserFactory = $traverserFactory;
     }
 
     /**
@@ -51,9 +51,10 @@ final class PhpScoper implements Scoper
 
         $content = file_get_contents($filePath);
 
+        $statements = $this->parser->parse($content);
+
         $traverser = $this->traverserFactory->create($prefix, $whitelist, $globalWhitelister);
 
-        $statements = $this->parser->parse($content);
         $statements = $traverser->traverse($statements);
 
         $prettyPrinter = new Standard();

--- a/src/Scoper/TraverserFactory.php
+++ b/src/Scoper/TraverserFactory.php
@@ -21,7 +21,10 @@ use Humbug\PhpScoper\NodeVisitor\Resolver\FullyQualifiedNameResolver;
 use PhpParser\NodeTraverser;
 use PhpParser\NodeTraverserInterface;
 
-final class TraverserFactory
+/**
+ * @final
+ */
+class TraverserFactory
 {
     /**
      * Functions for which the arguments will be prefixed.
@@ -30,8 +33,6 @@ final class TraverserFactory
         'class_exists',
         'interface_exists',
     ];
-
-    private $traverser;
 
     /**
      * @param string   $prefix            Prefix to apply to the files.
@@ -44,31 +45,27 @@ final class TraverserFactory
      */
     public function create(string $prefix, array $whitelist, callable $globalWhitelister): NodeTraverserInterface
     {
-        if (null !== $this->traverser) {
-            return $this->traverser;
-        }
-
-        $this->traverser = new NodeTraverser();
+        $traverser = new NodeTraverser();
 
         $namespaceStatements = new NamespaceStmtCollection();
         $useStatements = new UseStmtCollection();
 
         $nameResolver = new FullyQualifiedNameResolver($namespaceStatements, $useStatements);
 
-        $this->traverser->addVisitor(new NodeVisitor\UseStmt\GroupUseStmtTransformer());
+        $traverser->addVisitor(new NodeVisitor\UseStmt\GroupUseStmtTransformer());
 
-        $this->traverser->addVisitor(new NodeVisitor\AppendParentNode());
+        $traverser->addVisitor(new NodeVisitor\AppendParentNode());
 
-        $this->traverser->addVisitor(new NodeVisitor\NamespaceStmtPrefixer($prefix, $namespaceStatements, $whitelist));
+        $traverser->addVisitor(new NodeVisitor\NamespaceStmtPrefixer($prefix, $namespaceStatements, $whitelist));
 
-        $this->traverser->addVisitor(new NodeVisitor\UseStmt\UseStmtCollector($namespaceStatements, $useStatements));
-        $this->traverser->addVisitor(new NodeVisitor\UseStmt\UseStmtPrefixer($prefix, $whitelist, $globalWhitelister));
+        $traverser->addVisitor(new NodeVisitor\UseStmt\UseStmtCollector($namespaceStatements, $useStatements));
+        $traverser->addVisitor(new NodeVisitor\UseStmt\UseStmtPrefixer($prefix, $whitelist, $globalWhitelister));
 
-        $this->traverser->addVisitor(new NodeVisitor\NameStmtPrefixer($prefix, $whitelist, $globalWhitelister, $nameResolver));
-        $this->traverser->addVisitor(new NodeVisitor\StringScalarPrefixer($prefix, self::WHITELISTED_FUNCTIONS, $whitelist, $globalWhitelister, $nameResolver));
+        $traverser->addVisitor(new NodeVisitor\NameStmtPrefixer($prefix, $whitelist, $globalWhitelister, $nameResolver));
+        $traverser->addVisitor(new NodeVisitor\StringScalarPrefixer($prefix, self::WHITELISTED_FUNCTIONS, $whitelist, $globalWhitelister, $nameResolver));
 
-        $this->traverser->addVisitor(new NodeVisitor\WhitelistedClassAppender($whitelist));
+        $traverser->addVisitor(new NodeVisitor\WhitelistedClassAppender($whitelist));
 
-        return $this->traverser;
+        return $traverser;
     }
 }

--- a/src/functions.php
+++ b/src/functions.php
@@ -23,6 +23,7 @@ use Humbug\PhpScoper\Scoper\Composer\JsonFileScoper;
 use Humbug\PhpScoper\Scoper\NullScoper;
 use Humbug\PhpScoper\Scoper\PatchScoper;
 use Humbug\PhpScoper\Scoper\PhpScoper;
+use Humbug\PhpScoper\Scoper\TraverserFactory;
 use Humbug\SelfUpdate\Exception\RuntimeException as SelfUpdateRuntimeException;
 use Humbug\SelfUpdate\Updater;
 use PackageVersions\Versions;
@@ -100,7 +101,8 @@ function create_scoper(): Scoper
             new InstalledPackagesScoper(
                 new PhpScoper(
                     create_parser(),
-                    new NullScoper()
+                    new NullScoper(),
+                    new TraverserFactory()
                 )
             )
         )

--- a/tests/Scoper/PhpScoperTest.php
+++ b/tests/Scoper/PhpScoperTest.php
@@ -312,8 +312,8 @@ PHP;
     public function test_creates_a_new_traverser_for_each_file()
     {
         $files = [
-            'file1.php' =>  'file1',
-            'file2.php' =>  'file2',
+            'file1.php' => 'file1',
+            'file2.php' => 'file2',
         ];
 
         $prefix = 'Humbug';
@@ -340,7 +340,7 @@ PHP;
                 new Name('file2'),
             ])
         ;
-        
+
         /** @var NodeTraverserInterface|ObjectProphecy $firstTraverserProphecy */
         $firstTraverserProphecy = $this->prophesize(NodeTraverserInterface::class);
         /** @var NodeTraverserInterface $firstTraverser */
@@ -355,7 +355,7 @@ PHP;
         $this->traverserFactoryProphecy
             ->create($prefix, $whitelist, Argument::that(
                 function (...$args) use (&$i): bool {
-                    $i++;
+                    ++$i;
 
                     return 1 === $i;
                 }
@@ -365,7 +365,7 @@ PHP;
         $this->traverserFactoryProphecy
             ->create($prefix, $whitelist, Argument::that(
                 function (...$args) use (&$i): bool {
-                    $i++;
+                    ++$i;
 
                     return 4 === $i;
                 }

--- a/tests/Scoper/TraverserFactoryTest.php
+++ b/tests/Scoper/TraverserFactoryTest.php
@@ -16,11 +16,7 @@ namespace Humbug\PhpScoper\Scoper;
 
 use Humbug\PhpScoper\Scoper;
 use PHPUnit\Framework\TestCase;
-use function Humbug\PhpScoper\create_fake_patcher;
 use function Humbug\PhpScoper\create_fake_whitelister;
-use function Humbug\PhpScoper\escape_path;
-use function Humbug\PhpScoper\make_tmp_dir;
-use function Humbug\PhpScoper\remove_dir;
 
 /**
  * @covers \Humbug\PhpScoper\Scoper\TraverserFactory

--- a/tests/Scoper/TraverserFactoryTest.php
+++ b/tests/Scoper/TraverserFactoryTest.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the humbug/php-scoper package.
+ *
+ * Copyright (c) 2017 Théo FIDRY <theo.fidry@gmail.com>,
+ *                    Pádraic Brady <padraic.brady@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Humbug\PhpScoper\Scoper;
+
+use Humbug\PhpScoper\Scoper;
+use PHPUnit\Framework\TestCase;
+use function Humbug\PhpScoper\create_fake_patcher;
+use function Humbug\PhpScoper\create_fake_whitelister;
+use function Humbug\PhpScoper\escape_path;
+use function Humbug\PhpScoper\make_tmp_dir;
+use function Humbug\PhpScoper\remove_dir;
+
+/**
+ * @covers \Humbug\PhpScoper\Scoper\TraverserFactory
+ */
+class TraverserFactoryTest extends TestCase
+{
+    public function test_creates_a_new_traverser_at_each_call()
+    {
+        $prefix = 'Humbug';
+
+        $whitelist = ['Foo'];
+
+        $whitelister = create_fake_whitelister();
+
+        $traverserFactory = new TraverserFactory();
+
+        $firstTraverser = $traverserFactory->create($prefix, $whitelist, $whitelister);
+        $secondTraverser = $traverserFactory->create($prefix, $whitelist, $whitelister);
+
+        $this->assertNotSame($firstTraverser, $secondTraverser);
+    }
+}


### PR DESCRIPTION
As the traverser is now stateful, even though it won't break things
as the code is robust enough right now, it severely impacts performances.

For example, the collection of namespace was kept which led to a lot of
namespaces at some point forcing the NamespaceCollection to go through
the node parents to find the proper namespace, even though only one
namespace was found in the file.