### PR TITLE
Fix Travis build for PRs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,14 +17,17 @@ matrix:
   fast_finish: true
 
 before_install:
+    - set -euof pipefail
     - phpenv config-rm xdebug.ini || true
-    - openssl aes-256-cbc -K $encrypted_22e6e244c213_key -iv $encrypted_22e6e244c213_iv -in .travis/secrets.tar.enc -out .travis/secrets.tar -d
-    - tar xvf .travis/secrets.tar -C .travis
+    - |
+      if [ 'false' == "$TRAVIS_PULL_REQUEST" ]; then
+        cp box.json.dist box.json
+        openssl aes-256-cbc -K $encrypted_22e6e244c213_key -iv $encrypted_22e6e244c213_iv -in .travis/secrets.tar.enc -out .travis/secrets.tar -d
+        tar xvf .travis/secrets.tar -C .travis
+      fi;
 
 install:
-  - set -eo pipefail
   - composer install --no-interaction --no-progress --no-suggest --prefer-dist $COMPOSER_FLAGS
-  - cp box.json.dist box.json
 
 script:
   - |

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,6 @@ matrix:
   fast_finish: true
 
 before_install:
-    - set -euof pipefail
     - phpenv config-rm xdebug.ini || true
     - |
       if [ 'false' == "$TRAVIS_PULL_REQUEST" ]; then


### PR DESCRIPTION
Builds for PRs are currently failing due to being unable to decrypt encrypted files. Indeed the secured files are bound to this repository so this cannot work for fork builds which are bound to the fork repository.

See https://github.com/pockethub/PocketHub/issues/884 for more