### PR TITLE
StyleCI: new line checks

### DIFF
--- a/.styleci.yml
+++ b/.styleci.yml
@@ -8,6 +8,7 @@ disabled:
     - phpdoc_annotation_without_dot # This is still buggy: https://github.com/symfony/symfony/pull/19198
     - phpdoc_inline_tag
     - property_separation
+    - const_separation
 
 finder:
   exclude:

--- a/.styleci.yml
+++ b/.styleci.yml
@@ -7,6 +7,7 @@ enabled:
 disabled:
     - phpdoc_annotation_without_dot # This is still buggy: https://github.com/symfony/symfony/pull/19198
     - phpdoc_inline_tag
+    - property_separation
 
 finder:
   exclude:


### PR DESCRIPTION
Added the desired StyleCI disables to remove the checks on property separation and const separation.

This will prevent the check from failing.