### PR TITLE
Support longer PHP version strings

### DIFF
--- a/src/Autoload/Requirements.php
+++ b/src/Autoload/Requirements.php
@@ -42,7 +42,7 @@ final class Requirements extends RequirementCollection
         $requiredPhpVersion = $composerConfig['php'];
 
         $this->addRequirement(
-            Semver::satisfies(phpversion(), $requiredPhpVersion),
+            version_compare(phpversion(), $requiredPhpVersion, '>='),
             sprintf(
                 'PHP version must satisfy "%s" ("%s" installed)',
                 $requiredPhpVersion,


### PR DESCRIPTION
It seems that PHP version strings do not necessarily have to follow SemVer standards. Running this package on Ubuntu, for example, causes the following fatal error:
```
PHP Fatal error:  Uncaught UnexpectedValueException: Invalid version string "7.1.12-3" 
```
The full version string is: `7.1.12-3+ubuntu16.04.1+deb.sury.org+1`

Therefore, replacing composer's SemVer comparison with PHP's native `version_compare` might be a better idea to support these platforms, too.