### PR TITLE
Add file contents to the Scoper

### DIFF
--- a/src/Console/Command/AddPrefixCommand.php
+++ b/src/Console/Command/AddPrefixCommand.php
@@ -246,10 +246,8 @@ final class AddPrefixCommand extends BaseCommand
         bool $stopOnFailure,
         ConsoleLogger $logger
     ): void {
-        // TODO: use $inputContents instead of doing file_get_contents in the Scopers
-
         try {
-            $scoppedContent = $this->scoper->scope($inputFilePath, $prefix, $patchers, $whitelist, $globalWhitelister);
+            $scoppedContent = $this->scoper->scope($inputFilePath, $inputContents, $prefix, $patchers, $whitelist, $globalWhitelister);
         } catch (Throwable $error) {
             $exception = new ParsingException(
                 sprintf(

--- a/src/Scoper.php
+++ b/src/Scoper.php
@@ -22,6 +22,7 @@ interface Scoper
      * Scope AKA. apply the given prefix to the file in the appropriate way.
      *
      * @param string     $filePath          File to scope
+     * @param string     $contents          File contents
      * @param string     $prefix            Prefix to apply to the file
      * @param callable[] $patchers
      * @param string[]   $whitelist         List of classes to exclude from the scoping.
@@ -31,7 +32,7 @@ interface Scoper
      *
      * @throws ParsingException
      *
-     * @return string Content of the file with the prefix applied
+     * @return string Contents of the file with the prefix applied
      */
-    public function scope(string $filePath, string $prefix, array $patchers, array $whitelist, callable $globalWhitelister): string;
+    public function scope(string $filePath, string $contents, string $prefix, array $patchers, array $whitelist, callable $globalWhitelister): string;
 }

--- a/src/Scoper/Composer/InstalledPackagesScoper.php
+++ b/src/Scoper/Composer/InstalledPackagesScoper.php
@@ -32,16 +32,13 @@ final class InstalledPackagesScoper implements Scoper
      *
      * {@inheritdoc}
      */
-    public function scope(string $filePath, string $prefix, array $patchers, array $whitelist, callable $globalWhitelister): string
+    public function scope(string $filePath, string $contents, string $prefix, array $patchers, array $whitelist, callable $globalWhitelister): string
     {
         if (1 !== preg_match(self::$filePattern, $filePath)) {
-            return $this->decoratedScoper->scope($filePath, $prefix, $patchers, $whitelist, $globalWhitelister);
+            return $this->decoratedScoper->scope($filePath, $contents, $prefix, $patchers, $whitelist, $globalWhitelister);
         }
 
-        $decodedJson = json_decode(
-            file_get_contents($filePath),
-            true
-        );
+        $decodedJson = json_decode($contents, true);
 
         $decodedJson = $this->prefixLockPackages($decodedJson, $prefix);
 

--- a/src/Scoper/Composer/JsonFileScoper.php
+++ b/src/Scoper/Composer/JsonFileScoper.php
@@ -30,16 +30,13 @@ final class JsonFileScoper implements Scoper
      *
      * {@inheritdoc}
      */
-    public function scope(string $filePath, string $prefix, array $patchers, array $whitelist, callable $globalWhitelister): string
+    public function scope(string $filePath, string $contents, string $prefix, array $patchers, array $whitelist, callable $globalWhitelister): string
     {
         if (1 !== preg_match('/composer\.json$/', $filePath)) {
-            return $this->decoratedScoper->scope($filePath, $prefix, $patchers, $whitelist, $globalWhitelister);
+            return $this->decoratedScoper->scope($filePath, $contents, $prefix, $patchers, $whitelist, $globalWhitelister);
         }
 
-        $decodedJson = json_decode(
-            file_get_contents($filePath),
-            true
-        );
+        $decodedJson = json_decode($contents, true);
 
         $decodedJson = AutoloadPrefixer::prefixPackageAutoloads($decodedJson, $prefix);
 

--- a/src/Scoper/NullScoper.php
+++ b/src/Scoper/NullScoper.php
@@ -21,8 +21,8 @@ final class NullScoper implements Scoper
     /**
      * @inheritdoc
      */
-    public function scope(string $filePath, string $prefix, array $patchers, array $whitelist, callable $globalWhitelister): string
+    public function scope(string $filePath, string $contents, string $prefix, array $patchers, array $whitelist, callable $globalWhitelister): string
     {
-        return file_get_contents($filePath);
+        return $contents;
     }
 }

--- a/src/Scoper/PatchScoper.php
+++ b/src/Scoper/PatchScoper.php
@@ -28,16 +28,16 @@ final class PatchScoper implements Scoper
     /**
      * @inheritdoc
      */
-    public function scope(string $filePath, string $prefix, array $patchers, array $whitelist, callable $globalWhitelister): string
+    public function scope(string $filePath, string $contents, string $prefix, array $patchers, array $whitelist, callable $globalWhitelister): string
     {
-        $content = $this->decoratedScoper->scope($filePath, $prefix, $patchers, $whitelist, $globalWhitelister);
+        $contents = $this->decoratedScoper->scope($filePath, $contents, $prefix, $patchers, $whitelist, $globalWhitelister);
 
         return array_reduce(
             $patchers,
-            function (string $content, callable $patcher) use ($filePath, $prefix): string {
-                return $patcher($filePath, $prefix, $content);
+            function (string $contents, callable $patcher) use ($filePath, $prefix): string {
+                return $patcher($filePath, $prefix, $contents);
             },
-            $content
+            $contents
         );
     }
 }

--- a/src/Scoper/PhpScoper.php
+++ b/src/Scoper/PhpScoper.php
@@ -19,7 +19,7 @@ use PhpParser\Error as PhpParserError;
 use PhpParser\Parser;
 use PhpParser\PrettyPrinter\Standard;
 
-final class  PhpScoper implements Scoper
+final class PhpScoper implements Scoper
 {
     private const FILE_PATH_PATTERN = '/.*\.php$/';
     private const NOT_FILE_BINARY = '/\..+?$/';

--- a/src/Scoper/PhpScoper.php
+++ b/src/Scoper/PhpScoper.php
@@ -19,7 +19,7 @@ use PhpParser\Error as PhpParserError;
 use PhpParser\Parser;
 use PhpParser\PrettyPrinter\Standard;
 
-final class PhpScoper implements Scoper
+final class  PhpScoper implements Scoper
 {
     private const FILE_PATH_PATTERN = '/.*\.php$/';
     private const NOT_FILE_BINARY = '/\..+?$/';
@@ -43,15 +43,13 @@ final class PhpScoper implements Scoper
      *
      * @throws PhpParserError
      */
-    public function scope(string $filePath, string $prefix, array $patchers, array $whitelist, callable $globalWhitelister): string
+    public function scope(string $filePath, string $contents, string $prefix, array $patchers, array $whitelist, callable $globalWhitelister): string
     {
-        if (false === $this->isPhpFile($filePath)) {
-            return $this->decoratedScoper->scope($filePath, $prefix, $patchers, $whitelist, $globalWhitelister);
+        if (false === $this->isPhpFile($filePath, $contents)) {
+            return $this->decoratedScoper->scope($filePath, $contents, $prefix, $patchers, $whitelist, $globalWhitelister);
         }
 
-        $content = file_get_contents($filePath);
-
-        $statements = $this->parser->parse($content);
+        $statements = $this->parser->parse($contents);
 
         $traverser = $this->traverserFactory->create($prefix, $whitelist, $globalWhitelister);
 
@@ -62,7 +60,7 @@ final class PhpScoper implements Scoper
         return $prettyPrinter->prettyPrintFile($statements)."\n";
     }
 
-    private function isPhpFile(string $filePath): bool
+    private function isPhpFile(string $filePath, string $contents): bool
     {
         if (1 === preg_match(self::FILE_PATH_PATTERN, $filePath)) {
             return true;
@@ -72,8 +70,6 @@ final class PhpScoper implements Scoper
             return false;
         }
 
-        $content = file_get_contents($filePath);
-
-        return 1 === preg_match(self::PHP_BINARY, $content);
+        return 1 === preg_match(self::PHP_BINARY, $contents);
     }
 }

--- a/tests/Console/Command/AddPrefixCommandTest.php
+++ b/tests/Console/Command/AddPrefixCommandTest.php
@@ -15,7 +15,6 @@ declare(strict_types=1);
 namespace Humbug\PhpScoper\Console\Command;
 
 use Closure;
-use function file_get_contents;
 use Humbug\PhpScoper\Console\Application;
 use Humbug\PhpScoper\Scoper;
 use InvalidArgumentException;
@@ -25,6 +24,7 @@ use Prophecy\Prophecy\ObjectProphecy;
 use Symfony\Component\Console\Exception\RuntimeException;
 use Symfony\Component\Console\Tester\ApplicationTester;
 use Symfony\Component\Filesystem\Filesystem;
+use function file_get_contents;
 use function Humbug\PhpScoper\escape_path;
 use function Humbug\PhpScoper\make_tmp_dir;
 use function Humbug\PhpScoper\remove_dir;

--- a/tests/Console/Command/AddPrefixCommandTest.php
+++ b/tests/Console/Command/AddPrefixCommandTest.php
@@ -15,6 +15,7 @@ declare(strict_types=1);
 namespace Humbug\PhpScoper\Console\Command;
 
 use Closure;
+use function file_get_contents;
 use Humbug\PhpScoper\Console\Application;
 use Humbug\PhpScoper\Scoper;
 use InvalidArgumentException;
@@ -195,9 +196,12 @@ EOF;
             $inputPath = escape_path($root.'/'.$expectedFile);
             $outputPath = escape_path($this->tmp.'/'.$expectedFile);
 
+            $inputContents = file_get_contents($inputPath);
+
             $this->scoperProphecy
                 ->scope(
                     $inputPath,
+                    $inputContents,
                     'MyPrefix',
                     [],
                     [],
@@ -255,10 +259,13 @@ EOF;
             $inputPath = escape_path($root.'/'.$expectedFile);
             $outputPath = escape_path($this->tmp.'/'.$expectedFile);
 
+            $inputContents = file_get_contents($inputPath);
+
             if (null !== $prefixedContents) {
                 $this->scoperProphecy
                     ->scope(
                         $inputPath,
+                        $inputContents,
                         'MyPrefix',
                         [],
                         [],
@@ -272,6 +279,7 @@ EOF;
                 $this->scoperProphecy
                     ->scope(
                         $inputPath,
+                        $inputContents,
                         'MyPrefix',
                         [],
                         [],
@@ -280,7 +288,7 @@ EOF;
                     ->willThrow(new \RuntimeException('Scoping of the file failed'))
                 ;
 
-                $this->fileSystemProphecy->dumpFile($outputPath, file_get_contents($inputPath))->shouldBeCalled();
+                $this->fileSystemProphecy->dumpFile($outputPath, $inputContents)->shouldBeCalled();
             }
         }
 
@@ -327,9 +335,12 @@ EOF;
             $inputPath = escape_path($root.'/'.$expectedFile);
             $outputPath = escape_path($this->tmp.'/'.$expectedFile);
 
+            $inputContents = file_get_contents($inputPath);
+
             $this->scoperProphecy
                 ->scope(
                     $inputPath,
+                    $inputContents,
                     'MyPrefix',
                     [],
                     [],
@@ -385,11 +396,13 @@ EOF;
             $inputPath = realpath($inputPath);
             $outputPath = escape_path($outputPath);
 
+            $inputContents = file_get_contents($inputPath);
             $prefixedFileContents = 'Random string';
 
             $this->scoperProphecy
                 ->scope(
                     $inputPath,
+                    $inputContents,
                     'MyPrefix',
                     [],
                     [],
@@ -434,6 +447,7 @@ EOF;
 
         $this->scoperProphecy
             ->scope(
+                Argument::any(),
                 Argument::any(),
                 Argument::that(
                     function (string $prefix): bool {
@@ -497,9 +511,12 @@ EOF;
             $inputPath = escape_path($root.'/'.$expectedFile);
             $outputPath = escape_path($this->tmp.'/'.$expectedFile);
 
+            $inputContents = file_get_contents($inputPath);
+
             $this->scoperProphecy
                 ->scope(
                     $inputPath,
+                    $inputContents,
                     'MyPrefix',
                     [],
                     [],
@@ -546,6 +563,7 @@ EOF;
         $this->scoperProphecy
             ->scope(
                 Argument::any(),
+                Argument::any(),
                 'MyPrefix',
                 [],
                 [],
@@ -588,6 +606,7 @@ EOF;
 
         $this->scoperProphecy
             ->scope(
+                Argument::any(),
                 Argument::any(),
                 'MyPrefix',
                 [],
@@ -642,9 +661,12 @@ EOF;
             $inputPath = escape_path($root.'/'.$expectedFile);
             $outputPath = escape_path($outDir.'/'.$expectedFile);
 
+            $inputContents = file_get_contents($inputPath);
+
             $this->scoperProphecy
                 ->scope(
                     $inputPath,
+                    $inputContents,
                     'MyPrefix',
                     [],
                     [],
@@ -702,9 +724,12 @@ EOF;
             $inputPath = escape_path($root.'/'.$expectedFile);
             $outputPath = escape_path($this->tmp.DIRECTORY_SEPARATOR.$outDir.'/'.$expectedFile);
 
+            $inputContents = file_get_contents($inputPath);
+
             $this->scoperProphecy
                 ->scope(
                     $inputPath,
+                    $inputContents,
                     'MyPrefix',
                     [],
                     [],
@@ -822,9 +847,12 @@ EOF;
             $inputPath = escape_path($root.'/'.$expectedFile);
             $outputPath = escape_path($this->tmp.'/'.$expectedFile);
 
+            $inputContents = file_get_contents($inputPath);
+
             $this->scoperProphecy
                 ->scope(
                     $inputPath,
+                    $inputContents,
                     'MyPrefix',
                     Argument::that(function ($arg) use (&$patchersFound) {
                         $patchersFound = $arg;
@@ -914,6 +942,7 @@ EOF;
             $this->scoperProphecy
                 ->scope(
                     $inputPath,
+                    $fileContents,
                     'MyPrefix',
                     [],
                     [],

--- a/tests/Scoper/Composer/InstalledPackagesScoperTest.php
+++ b/tests/Scoper/Composer/InstalledPackagesScoperTest.php
@@ -31,39 +31,6 @@ use function Humbug\PhpScoper\remove_dir;
  */
 class InstalledPackagesScoperTest extends TestCase
 {
-    /**
-     * @var string
-     */
-    private $cwd;
-
-    /**
-     * @var string
-     */
-    private $tmp;
-
-    /**
-     * @inheritdoc
-     */
-    public function setUp()
-    {
-        if (null == $this->tmp) {
-            $this->cwd = getcwd();
-            $this->tmp = make_tmp_dir('scoper', __CLASS__);
-        }
-
-        chdir($this->tmp);
-    }
-
-    /**
-     * @inheritdoc
-     */
-    public function tearDown()
-    {
-        chdir($this->cwd);
-
-        remove_dir($this->tmp);
-    }
-
     public function test_it_is_a_Scoper()
     {
         $this->assertTrue(is_a(InstalledPackagesScoper::class, Scoper::class, true));
@@ -71,19 +38,17 @@ class InstalledPackagesScoperTest extends TestCase
 
     public function test_delegates_scoping_to_the_decorated_scoper_if_is_not_a_installed_file()
     {
-        $filePath = escape_path($this->tmp.'/file.php');
+        $filePath = 'file.php';
+        $fileContents = '';
         $prefix = 'Humbug';
         $patchers = [create_fake_patcher()];
         $whitelist = ['Foo'];
         $whitelister = create_fake_whitelister();
 
-        touch($filePath);
-        file_put_contents($filePath, '');
-
         /** @var Scoper|ObjectProphecy $decoratedScoperProphecy */
         $decoratedScoperProphecy = $this->prophesize(Scoper::class);
         $decoratedScoperProphecy
-            ->scope($filePath, $prefix, $patchers, $whitelist, $whitelister)
+            ->scope($filePath, $fileContents, $prefix, $patchers, $whitelist, $whitelister)
             ->willReturn(
                 $expected = 'Scoped content'
             )
@@ -93,7 +58,7 @@ class InstalledPackagesScoperTest extends TestCase
 
         $scoper = new InstalledPackagesScoper($decoratedScoper);
 
-        $actual = $scoper->scope($filePath, $prefix, $patchers, $whitelist, $whitelister);
+        $actual = $scoper->scope($filePath, $fileContents, $prefix, $patchers, $whitelist, $whitelister);
 
         $this->assertSame($expected, $actual);
 
@@ -103,11 +68,9 @@ class InstalledPackagesScoperTest extends TestCase
     /**
      * @dataProvider provideInstalledPackagesFiles
      */
-    public function test_it_prefixes_the_composer_autoloaders(string $fileContent, string $expected)
+    public function test_it_prefixes_the_composer_autoloaders(string $fileContents, string $expected)
     {
-        mkdir(escape_path($this->tmp.'/composer'));
-        touch($filePath = escape_path($this->tmp.'/composer/installed.json'));
-        file_put_contents($filePath, $fileContent);
+        $filePath = 'composer/installed.json';
 
         $scoper = new InstalledPackagesScoper(new FakeScoper());
 
@@ -116,7 +79,7 @@ class InstalledPackagesScoperTest extends TestCase
         $whitelist = ['Foo'];
         $whitelister = create_fake_whitelister();
 
-        $actual = $scoper->scope($filePath, $prefix, $patchers, $whitelist, $whitelister);
+        $actual = $scoper->scope($filePath, $fileContents, $prefix, $patchers, $whitelist, $whitelister);
 
         $this->assertSame($expected, $actual);
     }

--- a/tests/Scoper/Composer/InstalledPackagesScoperTest.php
+++ b/tests/Scoper/Composer/InstalledPackagesScoperTest.php
@@ -21,9 +21,6 @@ use Prophecy\Argument;
 use Prophecy\Prophecy\ObjectProphecy;
 use function Humbug\PhpScoper\create_fake_patcher;
 use function Humbug\PhpScoper\create_fake_whitelister;
-use function Humbug\PhpScoper\escape_path;
-use function Humbug\PhpScoper\make_tmp_dir;
-use function Humbug\PhpScoper\remove_dir;
 
 /**
  * @covers \Humbug\PhpScoper\Scoper\Composer\InstalledPackagesScoper

--- a/tests/Scoper/Composer/JsonFileScoperTest.php
+++ b/tests/Scoper/Composer/JsonFileScoperTest.php
@@ -31,39 +31,6 @@ use function Humbug\PhpScoper\remove_dir;
  */
 class JsonFileScoperTest extends TestCase
 {
-    /**
-     * @var string
-     */
-    private $cwd;
-
-    /**
-     * @var string
-     */
-    private $tmp;
-
-    /**
-     * @inheritdoc
-     */
-    public function setUp()
-    {
-        if (null == $this->tmp) {
-            $this->cwd = getcwd();
-            $this->tmp = make_tmp_dir('scoper', __CLASS__);
-        }
-
-        chdir($this->tmp);
-    }
-
-    /**
-     * @inheritdoc
-     */
-    public function tearDown()
-    {
-        chdir($this->cwd);
-
-        remove_dir($this->tmp);
-    }
-
     public function test_it_is_a_Scoper()
     {
         $this->assertTrue(is_a(JsonFileScoper::class, Scoper::class, true));
@@ -71,19 +38,17 @@ class JsonFileScoperTest extends TestCase
 
     public function test_delegates_scoping_to_the_decorated_scoper_if_is_not_a_composer_file()
     {
-        $filePath = escape_path($this->tmp.'/file.php');
+        $filePath = 'file.php';
+        $fileContents = '';
         $prefix = 'Humbug';
         $patchers = [create_fake_patcher()];
         $whitelist = ['Foo'];
         $whitelister = create_fake_whitelister();
 
-        touch($filePath);
-        file_put_contents($filePath, '');
-
         /** @var Scoper|ObjectProphecy $decoratedScoperProphecy */
         $decoratedScoperProphecy = $this->prophesize(Scoper::class);
         $decoratedScoperProphecy
-            ->scope($filePath, $prefix, $patchers, $whitelist, $whitelister)
+            ->scope($filePath, $fileContents, $prefix, $patchers, $whitelist, $whitelister)
             ->willReturn(
                 $expected = 'Scoped content'
             )
@@ -93,7 +58,7 @@ class JsonFileScoperTest extends TestCase
 
         $scoper = new JsonFileScoper($decoratedScoper);
 
-        $actual = $scoper->scope($filePath, $prefix, $patchers, $whitelist, $whitelister);
+        $actual = $scoper->scope($filePath, $fileContents, $prefix, $patchers, $whitelist, $whitelister);
 
         $this->assertSame($expected, $actual);
 
@@ -103,10 +68,9 @@ class JsonFileScoperTest extends TestCase
     /**
      * @dataProvider provideComposerFiles
      */
-    public function test_it_prefixes_the_composer_autoloaders(string $fileContent, string $expected)
+    public function test_it_prefixes_the_composer_autoloaders(string $fileContents, string $expected)
     {
-        touch($filePath = escape_path($this->tmp.'/composer.json'));
-        file_put_contents($filePath, $fileContent);
+        $filePath = 'composer.json';
 
         $scoper = new JsonFileScoper(new FakeScoper());
 
@@ -115,7 +79,7 @@ class JsonFileScoperTest extends TestCase
         $whitelist = ['Foo'];
         $whitelister = create_fake_whitelister();
 
-        $actual = $scoper->scope($filePath, $prefix, $patchers, $whitelist, $whitelister);
+        $actual = $scoper->scope($filePath, $fileContents, $prefix, $patchers, $whitelist, $whitelister);
 
         $this->assertSame($expected, $actual);
     }
@@ -175,10 +139,9 @@ JSON
     /**
      * @dataProvider providePSR0ComposerFiles
      */
-    public function test_it_prefixes_psr0_autoloaders(string $fileContent, string $expected)
+    public function test_it_prefixes_psr0_autoloaders(string $fileContents, string $expected)
     {
-        touch($filePath = escape_path($this->tmp.'/composer.json'));
-        file_put_contents($filePath, $fileContent);
+        $filePath = 'composer.json';
 
         $scoper = new JsonFileScoper(new FakeScoper());
 
@@ -187,7 +150,7 @@ JSON
         $whitelist = ['Foo'];
         $whitelister = create_fake_whitelister();
 
-        $actual = $scoper->scope($filePath, $prefix, $patchers, $whitelist, $whitelister);
+        $actual = $scoper->scope($filePath, $fileContents, $prefix, $patchers, $whitelist, $whitelister);
 
         $this->assertSame($expected, $actual);
     }

--- a/tests/Scoper/Composer/JsonFileScoperTest.php
+++ b/tests/Scoper/Composer/JsonFileScoperTest.php
@@ -21,9 +21,6 @@ use Prophecy\Argument;
 use Prophecy\Prophecy\ObjectProphecy;
 use function Humbug\PhpScoper\create_fake_patcher;
 use function Humbug\PhpScoper\create_fake_whitelister;
-use function Humbug\PhpScoper\escape_path;
-use function Humbug\PhpScoper\make_tmp_dir;
-use function Humbug\PhpScoper\remove_dir;
 
 /**
  * @covers \Humbug\PhpScoper\Scoper\Composer\JsonFileScoper

--- a/tests/Scoper/FakeScoper.php
+++ b/tests/Scoper/FakeScoper.php
@@ -22,7 +22,7 @@ final class FakeScoper implements Scoper
     /**
      * @inheritdoc
      */
-    public function scope(string $filePath, string $prefix, array $patchers, array $whitelist, callable $globalWhitelister): string
+    public function scope(string $filePath, string $contents, string $prefix, array $patchers, array $whitelist, callable $globalWhitelister): string
     {
         throw new LogicException();
     }

--- a/tests/Scoper/NullScoperTest.php
+++ b/tests/Scoper/NullScoperTest.php
@@ -18,9 +18,6 @@ use Humbug\PhpScoper\Scoper;
 use PHPUnit\Framework\TestCase;
 use function Humbug\PhpScoper\create_fake_patcher;
 use function Humbug\PhpScoper\create_fake_whitelister;
-use function Humbug\PhpScoper\escape_path;
-use function Humbug\PhpScoper\make_tmp_dir;
-use function Humbug\PhpScoper\remove_dir;
 
 /**
  * @covers \Humbug\PhpScoper\Scoper\NullScoper

--- a/tests/Scoper/NullScoperTest.php
+++ b/tests/Scoper/NullScoperTest.php
@@ -27,39 +27,6 @@ use function Humbug\PhpScoper\remove_dir;
  */
 class NullScoperTest extends TestCase
 {
-    /**
-     * @var string
-     */
-    private $cwd;
-
-    /**
-     * @var string
-     */
-    private $tmp;
-
-    /**
-     * @inheritdoc
-     */
-    public function setUp()
-    {
-        if (null === $this->tmp) {
-            $this->cwd = getcwd();
-            $this->tmp = make_tmp_dir('scoper', __CLASS__);
-        }
-
-        chdir($this->tmp);
-    }
-
-    /**
-     * @inheritdoc
-     */
-    public function tearDown()
-    {
-        chdir($this->cwd);
-
-        remove_dir($this->tmp);
-    }
-
     public function test_is_a_Scoper()
     {
         $this->assertTrue(is_a(NullScoper::class, Scoper::class, true));
@@ -67,11 +34,8 @@ class NullScoperTest extends TestCase
 
     public function test_returns_the_file_content_unchanged()
     {
-        $filePath = escape_path($this->tmp.'/file');
-        $content = $expected = 'File content';
-
-        touch($filePath);
-        file_put_contents($filePath, $content);
+        $filePath = 'file';
+        $contents = $expected = 'File content';
 
         $prefix = 'Humbug';
 
@@ -83,7 +47,7 @@ class NullScoperTest extends TestCase
 
         $scoper = new NullScoper();
 
-        $actual = $scoper->scope($filePath, $prefix, $patchers, $whitelist, $whitelister);
+        $actual = $scoper->scope($filePath, $contents, $prefix, $patchers, $whitelist, $whitelister);
 
         $this->assertSame($expected, $actual);
     }

--- a/tests/Scoper/PatchScoperTest.php
+++ b/tests/Scoper/PatchScoperTest.php
@@ -53,21 +53,21 @@ class PatchScoperTest extends TestCase
     public function test_applies_the_list_of_patches_to_the_scoped_file()
     {
         $filePath = '/path/to/file.php';
-        $content = 'Original file content';
+        $contents = 'Original file content';
         $prefix = 'Humbug';
 
         $patchers = [
-            function (string $patcherFilePath, string $patcherPrefix, string $content) use ($filePath, $prefix): string {
+            function (string $patcherFilePath, string $patcherPrefix, string $contents) use ($filePath, $prefix): string {
                 Assert::assertSame($filePath, $patcherFilePath);
                 Assert::assertSame($prefix, $patcherPrefix);
-                Assert::assertSame('Original file content', $content);
+                Assert::assertSame('Decorated scoper contents', $contents);
 
                 return 'File content after patch 1';
             },
-            function (string $patcherFilePath, string $patcherPrefix, string $content) use ($filePath, $prefix): string {
+            function (string $patcherFilePath, string $patcherPrefix, string $contents) use ($filePath, $prefix): string {
                 Assert::assertSame($filePath, $patcherFilePath);
                 Assert::assertSame($prefix, $patcherPrefix);
-                Assert::assertSame('File content after patch 1', $content);
+                Assert::assertSame('File content after patch 1', $contents);
 
                 return 'File content after patch 2';
             },
@@ -78,15 +78,15 @@ class PatchScoperTest extends TestCase
         $whitelister = create_fake_whitelister();
 
         $this->decoratedScoperProphecy
-            ->scope($filePath, $prefix, $patchers, $whitelist, $whitelister)
-            ->willReturn($content)
+            ->scope($filePath, $contents, $prefix, $patchers, $whitelist, $whitelister)
+            ->willReturn('Decorated scoper contents')
         ;
 
         $expected = 'File content after patch 2';
 
         $scoper = new PatchScoper($this->decoratedScoper);
 
-        $actual = $scoper->scope($filePath, $prefix, $patchers, $whitelist, $whitelister);
+        $actual = $scoper->scope($filePath, $contents, $prefix, $patchers, $whitelist, $whitelister);
 
         $this->assertSame($expected, $actual);
 

--- a/tests/Scoper/PhpScoperTest.php
+++ b/tests/Scoper/PhpScoperTest.php
@@ -31,8 +31,6 @@ use function Humbug\PhpScoper\create_fake_patcher;
 use function Humbug\PhpScoper\create_fake_whitelister;
 use function Humbug\PhpScoper\create_parser;
 use function Humbug\PhpScoper\escape_path;
-use function Humbug\PhpScoper\make_tmp_dir;
-use function Humbug\PhpScoper\remove_dir;
 
 class PhpScoperTest extends TestCase
 {


### PR DESCRIPTION
Continuing some work for humbug/box#31. The Scoper now takes the file contents as an argument. This allows the scoper to be used with existent files (e.g. virtual files) or files for which we are modifying the content like in Box.

Another benefit is that it removes the Scopers dependency to the file system layer.