### PR TITLE
Properly parse binaries

### DIFF
--- a/src/Scoper/PhpScoper.php
+++ b/src/Scoper/PhpScoper.php
@@ -72,7 +72,7 @@ final class PhpScoper implements Scoper
         }
 
         if (1 === preg_match(self::PHP_TAG, ltrim($contents))) {
-            return false;
+            return true;
         }
 
         return 1 === preg_match(self::PHP_BINARY, $contents);

--- a/src/Scoper/PhpScoper.php
+++ b/src/Scoper/PhpScoper.php
@@ -23,6 +23,7 @@ final class PhpScoper implements Scoper
 {
     private const FILE_PATH_PATTERN = '/.*\.php$/';
     private const NOT_FILE_BINARY = '/\..+?$/';
+    private const PHP_TAG = '/^<\?php/';
     private const PHP_BINARY = '/^#!.+?php.*\n{1,}<\?php/';
 
     private $parser;
@@ -67,6 +68,10 @@ final class PhpScoper implements Scoper
         }
 
         if (1 === preg_match(self::NOT_FILE_BINARY, basename($filePath))) {
+            return false;
+        }
+
+        if (1 === preg_match(self::PHP_TAG, ltrim($contents))) {
             return false;
         }
 

--- a/src/functions.php
+++ b/src/functions.php
@@ -37,6 +37,8 @@ use PhpParser\ParserFactory;
 use Symfony\Component\Console\Application as SymfonyApplication;
 use Symfony\Component\Filesystem\Filesystem;
 
+// TODO: register this file to the list of functions if possible to be autoloaded
+
 /**
  * @private
  */
@@ -87,14 +89,14 @@ function get_version(): string
 function create_scoper(): Scoper
 {
     return new PatchScoper(
-        new JsonFileScoper(
-            new InstalledPackagesScoper(
-                new PhpScoper(
-                    create_parser(),
-                    new NullScoper(),
-                    new TraverserFactory()
+        new PhpScoper(
+            create_parser(),
+            new JsonFileScoper(
+                new InstalledPackagesScoper(
+                    new NullScoper()
                 )
-            )
+            ),
+            new TraverserFactory()
         )
     );
 }

--- a/tests/Scoper/PhpScoperTest.php
+++ b/tests/Scoper/PhpScoperTest.php
@@ -177,6 +177,33 @@ PHP;
         $this->decoratedScoperProphecy->scope(Argument::cetera())->shouldHaveBeenCalledTimes(1);
     }
 
+    public function test_can_scope_a_PHP_file_with_the_wrong_extension()
+    {
+        $prefix = 'Humbug';
+        $filePath = escape_path($this->tmp.'/file');
+        $patchers = [create_fake_patcher()];
+        $whitelist = ['Foo'];
+        $whitelister = create_fake_whitelister();
+
+        $contents = <<<'PHP'
+<?php
+
+echo "Humbug!";
+
+PHP;
+
+        $expected = <<<'PHP'
+<?php
+
+echo "Humbug!";
+
+PHP;
+
+        $actual = $this->scoper->scope($filePath, $contents, $prefix, $patchers, $whitelist, $whitelister);
+
+        $this->assertSame($expected, $actual);
+    }
+
     public function test_can_scope_PHP_binary_files()
     {
         $prefix = 'Humbug';


### PR DESCRIPTION
As now we have access to the content of the file, we can also check if a file is a PHP file based on its content. This ensure binary PHP files are scoped.

Also did a small refactoring regarding the order of the scopers registered for a micro-optimisation.