### PR TITLE
Fix prefixing of functions

### DIFF
--- a/specs/function/global-scope-global-func-with-single-level-use-statement-and-alias.php
+++ b/specs/function/global-scope-global-func-with-single-level-use-statement-and-alias.php
@@ -23,8 +23,7 @@ return [
     [
         'spec' => <<<'SPEC'
 Global function call imported with a use statement in the global scope
-- prefix the use statement: As it is extremely rare to use a `use function` statement for a built-in function from the
-  global scope, we can relatively safely assume it is a user-land declared function which should be prefixed.
+- prefix the use statement
 - prefix the call
 - transform the call into a FQ call
 SPEC
@@ -49,9 +48,8 @@ PHP
     [
         'spec' => <<<'SPEC'
 Global function call imported with a use statement in the global scope
-- prefix the use statement: as it is extremely rare to use a `use function` statement for a built-in function from the
-  global scope, we can relatively safely assume it is a user-land declared function which should be prefixed.
-- do not prefix the call: as the call is FQ, the use statement is irrelevant so the above assumption cannot apply
+- prefix the use statement
+- prefix the call
 SPEC
         ,
         'payload' => <<<'PHP'
@@ -66,7 +64,7 @@ use function main as foo;
 namespace Humbug;
 
 use function Humbug\main as foo;
-\foo();
+\Humbug\foo();
 
 PHP
     ],

--- a/specs/function/global-scope-global-func-with-single-level-use-statement.php
+++ b/specs/function/global-scope-global-func-with-single-level-use-statement.php
@@ -23,8 +23,7 @@ return [
     [
         'spec' => <<<'SPEC'
 Global function call imported with a use statement in the global scope
-- prefix the use statement: As it is extremely rare to use a `use function` statement for a built-in function from the
-  global scope, we can relatively safely assume it is a user-land declared function which should be prefixed.
+- prefix the use statement
 - prefix the call
 - transform the call into a FQ call
 SPEC
@@ -49,9 +48,8 @@ PHP
     [
         'spec' => <<<'SPEC'
 Global function call imported with a use statement in the global scope
-- prefix the use statement: as it is extremely rare to use a `use function` statement for a built-in function from the
-  global scope, we can relatively safely assume it is a user-land declared function which should be prefixed.
-- do not prefix the call: as the call is FQ, the use statement is irrelevant so the above assumption cannot apply
+- prefix the use statement
+- prefix the call
 SPEC
         ,
         'payload' => <<<'PHP'
@@ -66,7 +64,7 @@ use function main;
 namespace Humbug;
 
 use function Humbug\main;
-\main();
+\Humbug\main();
 
 PHP
     ],

--- a/specs/function/global-scope-global-func.php
+++ b/specs/function/global-scope-global-func.php
@@ -23,7 +23,7 @@ return [
     [
         'spec' => <<<'SPEC'
 Global function call in the global scope
-- do not prefix the call as may be part of PHP built-in functions
+- prefix the function
 - transform the call into a FQ call
 SPEC
         ,
@@ -36,15 +36,15 @@ main();
 
 namespace Humbug;
 
-\main();
+\Humbug\main();
 
 PHP
     ],
 
     [
         'spec' => <<<'SPEC'
-Global function call in the global scope
-- do not prefix the call as may be part of PHP built-in functions
+FQ global function call in the global scope
+- prefix the call
 SPEC
         ,
         'payload' => <<<'PHP'
@@ -56,7 +56,47 @@ SPEC
 
 namespace Humbug;
 
-\main();
+\Humbug\main();
+
+PHP
+    ],
+
+    [
+        'spec' => <<<'SPEC'
+Global function call in the global scope of an internal function
+- do not prefix the function
+SPEC
+        ,
+        'payload' => <<<'PHP'
+<?php
+
+is_array();
+----
+<?php
+
+namespace Humbug;
+
+\is_array();
+
+PHP
+    ],
+
+    [
+        'spec' => <<<'SPEC'
+FQ global function call in the global scope of an internal function
+- do not prefix the function
+SPEC
+        ,
+        'payload' => <<<'PHP'
+<?php
+
+\is_array();
+----
+<?php
+
+namespace Humbug;
+
+\is_array();
 
 PHP
     ],

--- a/specs/function/namespace-global-func-with-single-level-use-statement-and-alias.php
+++ b/specs/function/namespace-global-func-with-single-level-use-statement-and-alias.php
@@ -24,8 +24,7 @@ return [
         'spec' => <<<'SPEC'
 Global function call imported with a use statement in a namespace:
 - prefix the namespace
-- prefix the use statement: As it is extremely rare to use a `use function` statement for a built-in function from the
-  global scope, we can relatively safely assume it is a user-land declared function which should be prefixed.
+- prefix the use statement
 - prefix the call
 - transform the call into a FQ call
 SPEC
@@ -53,8 +52,7 @@ PHP
         'spec' => <<<'SPEC'
 Global function call imported with a use statement in a namespace:
 - prefix the namespace
-- prefix the use statement: as it is extremely rare to use a `use function` statement for a built-in function from the
-  global scope, we can relatively safely assume it is a user-land declared function which should be prefixed.
+- prefix the use statement
 - do not prefix the call: as the call is FQ, the use statement is irrelevant so the above assumption cannot apply
 SPEC
         ,
@@ -72,7 +70,7 @@ use function main as foo;
 namespace Humbug\X;
 
 use function Humbug\main as foo;
-\foo();
+\Humbug\foo();
 
 PHP
     ],

--- a/specs/function/namespace-global-func-with-single-level-use-statement.php
+++ b/specs/function/namespace-global-func-with-single-level-use-statement.php
@@ -24,8 +24,7 @@ return [
         'spec' => <<<'SPEC'
 Global function call imported with a use statement in a namespace
 - prefix the namespace
-- prefix the use statement: As it is extremely rare to use a `use function` statement for a built-in function from the
-  global scope, we can relatively safely assume it is a user-land declared function which should be prefixed.
+- prefix the use statement
 - prefix the call
 - transform the call into a FQ call
 SPEC
@@ -53,9 +52,8 @@ PHP
         'spec' => <<<'SPEC'
 Global function call imported with a use statement in a namespace
 - prefix the namespace
-- prefix the use statement: as it is extremely rare to use a `use function` statement for a built-in function from the
-  global scope, we can relatively safely assume it is a user-land declared function which should be prefixed.
-- do not prefix the call: as the call is FQ, the use statement is irrelevant so the above assumption cannot apply
+- prefix the use statement
+- prefix the call
 SPEC
         ,
         'payload' => <<<'PHP'
@@ -72,7 +70,7 @@ use function main;
 namespace Humbug\A;
 
 use function Humbug\main;
-\main();
+\Humbug\main();
 
 PHP
     ],

--- a/specs/function/namespace-global-func.php
+++ b/specs/function/namespace-global-func.php
@@ -23,7 +23,7 @@ return [
     [
         'spec' => <<<'SPEC'
 Global function call in a namespace
-- do not prefix the call as may be either be a function from the global scope or the current namespace
+- do not prefix the call: ambiguous call
 - transform the call into a FQ call
 SPEC
         ,
@@ -46,7 +46,7 @@ PHP
     [
         'spec' => <<<'SPEC'
 Global function call in a namespace
-- do not prefix the call as may be part of PHP built-in functions
+- prefix the call
 SPEC
         ,
         'payload' => <<<'PHP'
@@ -60,7 +60,7 @@ namespace A;
 
 namespace Humbug\A;
 
-\main();
+\Humbug\main();
 
 PHP
     ],

--- a/specs/function/namespace-global-scope-func.php
+++ b/specs/function/namespace-global-scope-func.php
@@ -49,7 +49,7 @@ namespace X;
 
 namespace Humbug\X;
 
-\main();
+\Humbug\main();
 
 PHP
     ,

--- a/specs/use/use-func.php
+++ b/specs/use/use-func.php
@@ -23,9 +23,8 @@ return [
     [
         'spec' => <<<'SPEC'
 Use statement for a function belonging to the global namespace:
-- prefix the use statement: as it is extremely rare to use a `use function` statement for a built-in
-function from the global scope, we can relatively safely assume it is a user-land declare static-method
-which should be prefixed.
+- wrap the code in a prefixed namespace
+- prefix the use statement
 SPEC
         ,
         'payload' => <<<'PHP'
@@ -39,6 +38,28 @@ use function foo;
 namespace Humbug;
 
 use function Humbug\foo;
+
+PHP
+    ],
+
+    [
+        'spec' => <<<'SPEC'
+Use statement for an internal function belonging to the global namespace:
+- wrap the code in a prefixed namespace
+- do not prefix the use statement
+SPEC
+        ,
+        'payload' => <<<'PHP'
+<?php
+
+use function is_array;
+
+----
+<?php
+
+namespace Humbug;
+
+use function is_array;
 
 PHP
     ],

--- a/src/NodeVisitor/NameStmtPrefixer.php
+++ b/src/NodeVisitor/NameStmtPrefixer.php
@@ -134,9 +134,14 @@ final class NameStmtPrefixer extends NodeVisitorAbstract
             return $resolvedName;
         }
 
-        if ($parentNode instanceof FuncCall
-            && 1 === count($resolvedName->parts)
-            && null === $resolvedValue->getUse()
+        if (
+            $parentNode instanceof FuncCall
+            && (
+                $this->reflector->isFunctionInternal($resolvedName->toString())
+                // Functions have a fallback autoloading so we cannot prefix them when the name is ambiguous
+                // See https://wiki.php.net/rfc/fallback-to-root-scope-deprecation
+                || false === ($resolvedName instanceof FullyQualified)
+            )
         ) {
             return $resolvedName;
         }

--- a/src/NodeVisitor/UseStmt/UseStmtPrefixer.php
+++ b/src/NodeVisitor/UseStmt/UseStmtPrefixer.php
@@ -70,10 +70,11 @@ final class UseStmtPrefixer extends NodeVisitorAbstract
         }
 
         if (1 === count($use->name->parts)) {
-            return
-                Use_::TYPE_NORMAL !== $useType
-                || false === $this->reflector->isClassInternal($use->name->getFirst())
-            ;
+            if (Use_::TYPE_FUNCTION === $useType) {
+                return false === $this->reflector->isFunctionInternal($use->name->getFirst());
+            }
+
+            return Use_::TYPE_NORMAL !== $useType || false === $this->reflector->isClassInternal($use->name->getFirst());
         }
 
         return false === (

--- a/src/Reflector.php
+++ b/src/Reflector.php
@@ -14,16 +14,21 @@ declare(strict_types=1);
 
 namespace Humbug\PhpScoper;
 
+use ReflectionException;
+use ReflectionFunction;
 use Roave\BetterReflection\Reflector\ClassReflector;
 use Roave\BetterReflection\Reflector\Exception\IdentifierNotFound;
+use Roave\BetterReflection\Reflector\FunctionReflector;
 
 final class Reflector
 {
     private $classReflector;
+    private $functionReflector;
 
-    public function __construct(ClassReflector $classReflector)
+    public function __construct(ClassReflector $classReflector, FunctionReflector $functionReflector)
     {
         $this->classReflector = $classReflector;
+        $this->functionReflector = $functionReflector;
     }
 
     public function isClassInternal(string $name): bool
@@ -31,6 +36,18 @@ final class Reflector
         try {
             return $this->classReflector->reflect($name)->isInternal();
         } catch (IdentifierNotFound $exception) {
+            return false;
+        }
+    }
+
+    public function isFunctionInternal(string $name): bool
+    {
+        try {
+            return (new ReflectionFunction($name))->isInternal();
+
+            // TODO: leverage Better Reflection instead
+            return $this->functionReflector->reflect($name)->isInternal();
+        } catch (ReflectionException $exception) {
             return false;
         }
     }

--- a/src/functions.php
+++ b/src/functions.php
@@ -35,6 +35,7 @@ use PhpParser\Node;
 use PhpParser\Parser;
 use PhpParser\ParserFactory;
 use Roave\BetterReflection\Reflector\ClassReflector;
+use Roave\BetterReflection\Reflector\FunctionReflector;
 use Roave\BetterReflection\SourceLocator\Ast\Locator;
 use Roave\BetterReflection\SourceLocator\Type\MemoizingSourceLocator;
 use Roave\BetterReflection\SourceLocator\Type\PhpInternalSourceLocator;
@@ -118,12 +119,14 @@ function create_reflector(): Reflector
     $phpParser = create_parser();
     $astLocator = new Locator($phpParser);
 
+    $sourceLocator = new MemoizingSourceLocator(
+        new PhpInternalSourceLocator($astLocator)
+    );
+    $classReflector = new ClassReflector($sourceLocator);
+
     return new Reflector(
-        new ClassReflector(
-            new MemoizingSourceLocator(
-                new PhpInternalSourceLocator($astLocator)
-            )
-        )
+        $classReflector,
+        new FunctionReflector($sourceLocator, $classReflector)
     );
 }
 

--- a/tests/Scoper/TraverserFactoryTest.php
+++ b/tests/Scoper/TraverserFactoryTest.php
@@ -30,7 +30,8 @@ class TraverserFactoryTest extends TestCase
         $whitelist = ['Foo'];
 
         $classReflector = new Reflector(
-            (new BetterReflection())->classReflector()
+            (new BetterReflection())->classReflector(),
+            (new BetterReflection())->functionReflector()
         );
 
         $traverserFactory = new TraverserFactory($classReflector);


### PR DESCRIPTION
Now prefix functions whenever possible. A function is not prefixed when is an internal function or when the function fully qualified name could not be resolved.

Related to #152.
Closes #145.

The failure on the e2e tests is unrelated.