### PR TITLE
Fix Infection tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ help:
 
 clean:		## Clean all created artifacts
 clean:
-	git clean --exclude=.idea/ -fdx
+	git clean --exclude=.idea/ -ffdx
 
 build:		## Build the PHAR
 build: bin/php-scoper src vendor vendor-bin/box/vendor scoper.inc.php box.json
@@ -154,7 +154,15 @@ e2e_020: bin/php-scoper.phar fixtures/set020-infection/vendor
 	php -d zend.enable_gc=0 $(PHPSCOPER) add-prefix --working-dir=fixtures/set020-infection --output-dir=../../build/set020-infection --force --no-interaction --stop-on-failure
 	composer --working-dir=build/set020-infection dump-autoload
 
-	php build/set020-infection/vendor/infection/infection/bin/infection
+	# Create coverage reports to be able to run Infection without running the tests
+	php -d zend.enable_gc=0 $(PHPUNIT) --coverage-clover=clover.xml --coverage-xml=dist/infection-coverage/coverage-xml --log-junit=dist/infection-coverage/phpunit.junit.xml
+
+	php fixtures/set020-infection/vendor/infection/infection/bin/infection --coverage=dist/infection-coverage > build/set020-infection/expected-output
+	php build/set020-infection/vendor/infection/infection/bin/infection --coverage=dist/infection-coverage > build/set020-infection/output
+
+	rm clover.xml
+
+	diff build/set020-infection/expected-output build/set020-infection/output
 
 tb:		## Run Blackfire profiling
 tb: vendor

--- a/fixtures/set020-infection/scoper.inc.php
+++ b/fixtures/set020-infection/scoper.inc.php
@@ -17,8 +17,26 @@ use Isolated\Symfony\Component\Finder\Finder;
 return [
     'patchers' => [
         function (string $filePath, string $prefix, string $contents): string {
+            //
+            // Infection shared global constant patch
+            // @see https://github.com/humbug/php-scoper/issues/171
+            //
             if ($filePath === realpath(__DIR__.'/vendor/infection/infection/app/bootstrap.php')) {
                 return str_replace($prefix.'\INFECTION_COMPOSER_INSTALL;', 'INFECTION_COMPOSER_INSTALL;', $contents);
+            }
+
+            return $contents;
+        },
+        function (string $filePath, string $prefix, string $contents): string {
+            //
+            // Infection IncludeInterceptor patch
+            //
+            if ($filePath === realpath(__DIR__.'/vendor/infection/infection/src/TestFramework/Config/MutationConfigBuilder.php')) {
+                return str_replace(
+                    'use Infection\\\\StreamWrapper\\\\IncludeInterceptor;',
+                    'use '.$prefix.'\\\\Infection\\\\StreamWrapper\\\\IncludeInterceptor;',
+                    $contents
+                );
             }
 
             return $contents;


### PR DESCRIPTION
Infection was "passing" only because the process was failing hard which indeeds counts as killing a mutant, but in this specific case this was not for the right reasons.

I investigated and managed to apply the right patches to make it work. The e2e tests also no runs the not prefixed Infection and compares the result with the prefixed one as they should be identical.