### PR TITLE
Ensure the whitelist feature works well on interfaces

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -88,7 +88,7 @@ e2e_013: bin/php-scoper.phar
 	diff src/scoper.inc.php.tpl build/set013/scoper.inc.php
 
 .PHONY: e2e_014
-e2e_014:	## Run end-to-end tests for the fixture set 014: source code case with psr-0
+e2e_014:	## Run end-to-end tests for the fixture set 014: source code case with PSR-0
 e2e_014: bin/php-scoper.phar
 	$(PHPNOGC) $(BOX) compile --working-dir fixtures/set014
 
@@ -96,7 +96,7 @@ e2e_014: bin/php-scoper.phar
 	diff fixtures/set014/expected-output build/set014/output
 
 .PHONY: e2e_015
-e2e_015:	## Run end-to-end tests for the fixture set 015: third-party code case with psr-0
+e2e_015:	## Run end-to-end tests for the fixture set 015: third-party code case with PSR-0
 e2e_015: bin/php-scoper.phar fixtures/set015/vendor
 	$(PHPNOGC) $(BOX) compile --working-dir fixtures/set015
 

--- a/fixtures/set011/scoper.inc.php
+++ b/fixtures/set011/scoper.inc.php
@@ -12,16 +12,7 @@ declare(strict_types=1);
  * file that was distributed with this source code.
  */
 
-use Isolated\Symfony\Component\Finder\Finder;
-
 return [
-    'finders' => [
-        (new Finder())
-            ->files()
-            ->in(__DIR__)
-            ->exclude('tests')
-            ->notPath('scoper.inc.php')
-    ],
     'whitelist' => [
         \Set011\Dictionary::class,
     ],

--- a/fixtures/set011/src/Dictionary.php
+++ b/fixtures/set011/src/Dictionary.php
@@ -4,10 +4,10 @@ declare(strict_types=1);
 
 namespace Set011;
 
-abstract class Dictionary
+interface Dictionary
 {
     /**
      * @return string[]
      */
-    abstract public function provideWords(): array;
+    public function provideWords(): array;
 }

--- a/fixtures/set011/src/DirectionaryLocator.php
+++ b/fixtures/set011/src/DirectionaryLocator.php
@@ -48,7 +48,7 @@ final class DirectionaryLocator
             function (array $dictionaries, string $className): array {
                 $class = new ReflectionClass($className);
 
-                if (false === $class->isAbstract() && $class->isSubclassOf(Dictionary::class)) {
+                if (false === $class->isAbstract() && $class->implementsInterface(Dictionary::class)) {
                     $dictionaries[] = $class->newInstanceWithoutConstructor();
                 }
 

--- a/fixtures/set011/tests/SalutationDictionary.php
+++ b/fixtures/set011/tests/SalutationDictionary.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Set011;
 
-final class SalutationDictionary extends Dictionary
+final class SalutationDictionary implements Dictionary
 {
     /**
      * @inheritdoc

--- a/src/Autoload/ScoperAutoloadGenerator.php
+++ b/src/Autoload/ScoperAutoloadGenerator.php
@@ -14,6 +14,8 @@ declare(strict_types=1);
 
 namespace Humbug\PhpScoper\Autoload;
 
+use function array_map;
+
 final class ScoperAutoloadGenerator
 {
     private $whitelist;
@@ -28,16 +30,7 @@ final class ScoperAutoloadGenerator
 
     public function dump(string $prefix): string
     {
-        $statements = array_map(
-            function (string $whitelist) use ($prefix): string {
-                return sprintf(
-                    'class_exists(\'%s\%s\');',
-                    $prefix,
-                    $whitelist
-                );
-            },
-            $this->whitelist
-        );
+        $statements = $this->createStatements($prefix);
 
         $statements = implode(PHP_EOL, $statements);
 
@@ -53,5 +46,22 @@ $statements
 return \$loader;
 
 PHP;
+    }
+
+    /**
+     * @return string[]
+     */
+    public function createStatements(string $prefix): array
+    {
+        return array_map(
+            function (string $whitelistedElement) use ($prefix): string {
+                return sprintf(
+                    'class_exists(\'%s\%s\');',
+                    $prefix,
+                    $whitelistedElement
+                );
+            },
+            $this->whitelist
+        );
     }
 }


### PR DESCRIPTION
Closes #188.

The current mechanism works fine since the `class_exists()` is here only to trigger the autoload.
Since the autoloading mechanism is the same for classes and interfaces, `class_exists()` works fine.