### PR TITLE
Fix the scoping of JSON files

### DIFF
--- a/src/Scoper/Composer/AutoloadPrefixer.php
+++ b/src/Scoper/Composer/AutoloadPrefixer.php
@@ -14,7 +14,7 @@ declare(strict_types=1);
 
 namespace Humbug\PhpScoper\Scoper\Composer;
 
-use function array_key_exists;
+use stdClass;
 
 /**
  * @private
@@ -22,37 +22,40 @@ use function array_key_exists;
 final class AutoloadPrefixer
 {
     /**
-     * @param array  $contents Decoded JSON
-     * @param string $prefix
+     * @param stdClass $contents Decoded JSON
+     * @param string   $prefix
      *
      * @return array Prefixed decoded JSON
      */
-    public static function prefixPackageAutoloads(array $contents, string $prefix): array
+    public static function prefixPackageAutoloads(stdClass $contents, string $prefix): stdClass
     {
-        if (isset($contents['autoload'])) {
-            $contents['autoload'] = self::prefixAutoloads($contents['autoload'], $prefix);
+        if (isset($contents->autoload)) {
+            $contents->autoload = self::prefixAutoloads($contents->autoload, $prefix);
         }
 
-        if (isset($contents['autoload-dev'])) {
-            $contents['autoload-dev'] = self::prefixAutoloads($contents['autoload-dev'], $prefix);
+        if (isset($contents->{'autoload-dev'})) {
+            $contents->{'autoload-dev'} = self::prefixAutoloads($contents->{'autoload-dev'}, $prefix);
         }
 
         return $contents;
     }
 
-    private static function prefixAutoloads(array $autoload, string $prefix): array
+    private static function prefixAutoloads(stdClass $autoload, string $prefix): stdClass
     {
-        if (false === array_key_exists('psr-4', $autoload) && false === array_key_exists('psr-0', $autoload)) {
+        if (false === isset($autoload->{'psr-4'}) && false === isset($autoload->{'psr-0'})) {
             return $autoload;
         }
 
-        if (isset($autoload['psr-0'])) {
-            $autoload['psr-4'] = self::mergePSR0And4($autoload['psr-0'], $autoload['psr-4'] ?? []);
+        if (isset($autoload->{'psr-0'})) {
+            $autoload->{'psr-4'} = self::mergePSR0And4(
+                (array) $autoload->{'psr-0'},
+                (array) ($autoload->{'psr-4'} ?? new stdClass())
+            );
         }
-        unset($autoload['psr-0']);
+        unset($autoload->{'psr-0'});
 
-        if (isset($autoload['psr-4'])) {
-            $autoload['psr-4'] = self::prefixAutoload($autoload['psr-4'], $prefix);
+        if (isset($autoload->{'psr-4'})) {
+            $autoload->{'psr-4'} = self::prefixAutoload((array) $autoload->{'psr-4'}, $prefix);
         }
 
         return $autoload;

--- a/src/Scoper/Composer/InstalledPackagesScoper.php
+++ b/src/Scoper/Composer/InstalledPackagesScoper.php
@@ -38,9 +38,9 @@ final class InstalledPackagesScoper implements Scoper
             return $this->decoratedScoper->scope($filePath, $contents, $prefix, $patchers, $whitelist);
         }
 
-        $decodedJson = json_decode($contents, true);
+        $decodedJson = json_decode($contents);
 
-        $decodedJson = $this->prefixLockPackages($decodedJson, $prefix);
+        $decodedJson = $this->prefixLockPackages((array) $decodedJson, $prefix);
 
         return json_encode(
             $decodedJson,

--- a/src/Scoper/Composer/JsonFileScoper.php
+++ b/src/Scoper/Composer/JsonFileScoper.php
@@ -36,7 +36,7 @@ final class JsonFileScoper implements Scoper
             return $this->decoratedScoper->scope($filePath, $contents, $prefix, $patchers, $whitelist);
         }
 
-        $decodedJson = json_decode($contents, true);
+        $decodedJson = json_decode($contents);
 
         $decodedJson = AutoloadPrefixer::prefixPackageAutoloads($decodedJson, $prefix);
 

--- a/tests/Scoper/Composer/InstalledPackagesScoperTest.php
+++ b/tests/Scoper/Composer/InstalledPackagesScoperTest.php
@@ -134,11 +134,8 @@ class InstalledPackagesScoperTest extends TestCase
             }
         ],
         "description": "Thin assertion library for input validation in business models.",
-        "keywords": [
-            "assert",
-            "assertion",
-            "validation"
-        ]
+        "keywords": [],
+        "platform": {}
     }
 ]
 
@@ -197,11 +194,8 @@ JSON
             }
         ],
         "description": "Thin assertion library for input validation in business models.",
-        "keywords": [
-            "assert",
-            "assertion",
-            "validation"
-        ]
+        "keywords": [],
+        "platform": {}
     }
 ]
 JSON

--- a/tests/Scoper/Composer/JsonFileScoperTest.php
+++ b/tests/Scoper/Composer/JsonFileScoperTest.php
@@ -90,7 +90,8 @@ class JsonFileScoperTest extends TestCase
         },
         "files": [
             "src/functions.php"
-        ]
+        ],
+        "classmap": []
     },
     "autoload-dev": {
         "psr-4": {
@@ -99,7 +100,8 @@ class JsonFileScoperTest extends TestCase
         "files": [
             "tests/functions.php"
         ]
-    }
+    },
+    "config": {}
 }
 
 JSON
@@ -115,7 +117,8 @@ JSON
         },
         "files": [
             "src\/functions.php"
-        ]
+        ],
+        "classmap": []
     },
     "autoload-dev": {
         "psr-4": {
@@ -124,7 +127,8 @@ JSON
         "files": [
             "tests\/functions.php"
         ]
-    }
+    },
+    "config": {}
 }
 JSON
         ];


### PR DESCRIPTION
The JSON files should be decode with `assoc` set to true. Otherwise encoding it again may change the schema as if `assoc` is set to false, both `[]` and `{}` will be decoded as an empty array so
encoding it again may change an empty object into an empty array which may screw up a JSON schema validation.