### PR TITLE
Allow to whitelist constants from global namespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,9 +38,10 @@ potentially very difficult to debug due to dissimilar or unsupported package ver
     - [Finders and paths](#finders-and-paths)
     - [Patchers](#patchers)
     - [Whitelist][whitelist]
-        - [Class & Constant Whitelisting](#class-constant-whitelisting)
-        - [Namespace Whitelisting](#namespace-whitelisting)
-- [Building A Scoped PHAR](#building-a-scoped-phar)
+        - [Constants from the global namespace whitelisting](#constants-from-the-global-namespace-whitelisting)
+        - [Classes & Constants whitelisting](#classes-constants-whitelisting)
+        - [Namespaces whitelisting](#namespaces-whitelisting)
+- [Building a scoped PHAR](#building-a-scoped-phar)
     - [With Box](#with-box)
         - [Step 1: Configure build location and prep vendors](#step-1-configure-build-location-and-prep-vendors)
         - [Step 2: Run PHP-Scoper](#step-2-run-php-scoper)
@@ -125,10 +126,11 @@ with a `--config` option.
 use Isolated\Symfony\Component\Finder\Finder;
 
 return [
-    'prefix' => null,
-    'finders' => [],
-    'patchers' => [],
-    'whitelist' => [],
+    'prefix' => null,                       // string|null
+    'finders' => [],                        // Finder[]
+    'patchers' => [],                       // callable[]
+    'whitelist' => [],                      // string[]
+    'whitelist-global-constants' => true,   // bool
 ];
 ```
 
@@ -261,7 +263,24 @@ a PHPUnit PHAR with isolated code, you still want the PHAR to be able to
 understand the `PHPUnit\Framework\TestCase` class.
 
 
-### Class & Constant whitelisting
+### Constants from the global namespace whitelisting
+
+By default, PHP-Scoper will not prefix the user defined constants belonging to
+the global namespace. You can however change that setting for them to be
+prefixed as usual unless explicitely whitelisted:
+
+```php
+<?php declare(strict_types=1);
+
+// scoper.inc.php
+
+return [
+    'whitelist-global-constants' => false,
+];
+```
+
+
+### Classes & Constants whitelisting
 
 You can whitelist classes, interfaces and constants like so like so:
 
@@ -282,23 +301,27 @@ This will _not_ work on traits or functions.
 
 The class aliasing mechanism is done like follows:
 - Prefix the class or interface as usual
-- Append a `class_alias()` statement at the end of the class/interface declaration to link the prefixed symbol to the
-  non prefixed one
-- Append a `class_exists()` statement right after the autoloader is registered to trigger the loading of the method
-  which will ensure the `class_alias()` statement is executed
+- Append a `class_alias()` statement at the end of the class/interface
+  declaration to link the prefixed symbol to the non prefixed one
+- Append a `class_exists()` statement right after the autoloader is
+  registered to trigger the loading of the method which will ensure the
+  `class_alias()` statement is executed
 
-It is done this way to ensure prefixed and whitelisted classes can co-exist together without breaking the autoloading.
-The `class_exists()` statements are dumped in `vendor/scoper-autoload.php`, do not forget to include this file in favour
-of `vendor/autoload.php`. This part is however sorted out by [Box][box] if you are using it with the
-[`PhpScoper` compactor][php-scoper-integration]. 
+It is done this way to ensure prefixed and whitelisted classes can co-exist
+together without breaking the autoloading. The `class_exists()` statements are
+dumped in `vendor/scoper-autoload.php`, do not forget to include this file in
+favour of `vendor/autoload.php`. This part is however sorted out by [Box][box]
+if you are using it with the [`PhpScoper` compactor][php-scoper-integration]. 
 
-The constant aliasing mechanism is done by transforming the constant declaration into a `define()` statement when this
-is not already the case. Note that there is a difference here since `define()` defines a constant at runtime whereas
-`const` defines it at compile time. You have a more details post regarding the differences
+The constant aliasing mechanism is done by transforming the constant
+declaration into a `define()` statement when this is not already the case.
+Note that there is a difference here since `define()` defines a constant at
+runtime whereas `const` defines it at compile time. You have a more details
+post regarding the differences
 [here](https://stackoverflow.com/a/3193704/3902761)
 
 
-### Namespace whitelisting
+### Namespaces whitelisting
 
 If you want to be more generic and whitelist a whole namespace, you can
 do it so like this:
@@ -331,7 +354,7 @@ return [
 ```
 
 
-## Building A Scoped PHAR
+## Building a Scoped PHAR
 
 ### With Box
 

--- a/specs/binary/simple.php
+++ b/specs/binary/simple.php
@@ -18,6 +18,7 @@ return [
         // Default values. If not specified will be the one used
         'prefix' => 'Humbug',
         'whitelist' => [],
+        'whitelist-global-constants' => true,
     ],
 
     'some statements made directly in the global namespace: wrap them in a namespace statement' => <<<'PHP'

--- a/specs/class-FQ.php
+++ b/specs/class-FQ.php
@@ -18,6 +18,7 @@ return [
         // Default values. If not specified will be the one used
         'prefix' => 'Humbug',
         'whitelist' => [],
+        'whitelist-global-constants' => true,
     ],
 
     [

--- a/specs/class-const/global-scope-single-level-with-single-level-use-statement-and-alias.php
+++ b/specs/class-const/global-scope-single-level-with-single-level-use-statement-and-alias.php
@@ -18,6 +18,7 @@ return [
         // Default values. If not specified will be the one used
         'prefix' => 'Humbug',
         'whitelist' => [],
+        'whitelist-global-constants' => true,
     ],
 
     [

--- a/specs/class-const/global-scope-single-level-with-single-level-use-statement.php
+++ b/specs/class-const/global-scope-single-level-with-single-level-use-statement.php
@@ -18,6 +18,7 @@ return [
         // Default values. If not specified will be the one used
         'prefix' => 'Humbug',
         'whitelist' => [],
+        'whitelist-global-constants' => true,
     ],
 
     [

--- a/specs/class-const/global-scope-single-level.php
+++ b/specs/class-const/global-scope-single-level.php
@@ -18,6 +18,7 @@ return [
         // Default values. If not specified will be the one used
         'prefix' => 'Humbug',
         'whitelist' => [],
+        'whitelist-global-constants' => true,
     ],
 
     [

--- a/specs/class-const/global-scope-two-level-with-single-level-use-and-alias.php
+++ b/specs/class-const/global-scope-two-level-with-single-level-use-and-alias.php
@@ -18,6 +18,7 @@ return [
         // Default values. If not specified will be the one used
         'prefix' => 'Humbug',
         'whitelist' => [],
+        'whitelist-global-constants' => true,
     ],
 
     [

--- a/specs/class-const/global-scope-two-level-with-single-level-use.php
+++ b/specs/class-const/global-scope-two-level-with-single-level-use.php
@@ -18,6 +18,7 @@ return [
         // Default values. If not specified will be the one used
         'prefix' => 'Humbug',
         'whitelist' => [],
+        'whitelist-global-constants' => true,
     ],
 
     [

--- a/specs/class-const/global-scope-two-level.php
+++ b/specs/class-const/global-scope-two-level.php
@@ -18,6 +18,7 @@ return [
         // Default values. If not specified will be the one used
         'prefix' => 'Humbug',
         'whitelist' => [],
+        'whitelist-global-constants' => true,
     ],
 
     [

--- a/specs/class-const/namespace-scope-single-level-with-single-level-use-statement-and-alias.php
+++ b/specs/class-const/namespace-scope-single-level-with-single-level-use-statement-and-alias.php
@@ -18,6 +18,7 @@ return [
         // Default values. If not specified will be the one used
         'prefix' => 'Humbug',
         'whitelist' => [],
+        'whitelist-global-constants' => true,
     ],
 
     [

--- a/specs/class-const/namespace-scope-single-level.php
+++ b/specs/class-const/namespace-scope-single-level.php
@@ -18,6 +18,7 @@ return [
         // Default values. If not specified will be the one used
         'prefix' => 'Humbug',
         'whitelist' => [],
+        'whitelist-global-constants' => true,
     ],
 
     [

--- a/specs/class-const/namespace-scope-two-level-with-single-level-use-and-alias.php
+++ b/specs/class-const/namespace-scope-two-level-with-single-level-use-and-alias.php
@@ -18,6 +18,7 @@ return [
         // Default values. If not specified will be the one used
         'prefix' => 'Humbug',
         'whitelist' => [],
+        'whitelist-global-constants' => true,
     ],
 
     [

--- a/specs/class-const/namespace-scope-two-level-with-single-level-use.php
+++ b/specs/class-const/namespace-scope-two-level-with-single-level-use.php
@@ -18,6 +18,7 @@ return [
         // Default values. If not specified will be the one used
         'prefix' => 'Humbug',
         'whitelist' => [],
+        'whitelist-global-constants' => true,
     ],
 
     [

--- a/specs/class-const/namespace-scope-two-level.php
+++ b/specs/class-const/namespace-scope-two-level.php
@@ -18,6 +18,7 @@ return [
         // Default values. If not specified will be the one used
         'prefix' => 'Humbug',
         'whitelist' => [],
+        'whitelist-global-constants' => true,
     ],
 
     [

--- a/specs/class-const/namespace-single-part-with-single-level-use-statement.php
+++ b/specs/class-const/namespace-single-part-with-single-level-use-statement.php
@@ -18,6 +18,7 @@ return [
         // Default values. If not specified will be the one used
         'prefix' => 'Humbug',
         'whitelist' => [],
+        'whitelist-global-constants' => true,
     ],
 
     [

--- a/specs/class-static-prop/global-scope-single-level-with-single-level-use-statement-and-alias.php
+++ b/specs/class-static-prop/global-scope-single-level-with-single-level-use-statement-and-alias.php
@@ -18,6 +18,7 @@ return [
         // Default values. If not specified will be the one used
         'prefix' => 'Humbug',
         'whitelist' => [],
+        'whitelist-global-constants' => true,
     ],
 
     [

--- a/specs/class-static-prop/global-scope-single-level-with-single-level-use-statement.php
+++ b/specs/class-static-prop/global-scope-single-level-with-single-level-use-statement.php
@@ -18,6 +18,7 @@ return [
         // Default values. If not specified will be the one used
         'prefix' => 'Humbug',
         'whitelist' => [],
+        'whitelist-global-constants' => true,
     ],
 
     [

--- a/specs/class-static-prop/global-scope-single-level.php
+++ b/specs/class-static-prop/global-scope-single-level.php
@@ -18,6 +18,7 @@ return [
         // Default values. If not specified will be the one used
         'prefix' => 'Humbug',
         'whitelist' => [],
+        'whitelist-global-constants' => true,
     ],
 
     [

--- a/specs/class-static-prop/global-scope-two-level-with-single-level-use-and-alias.php
+++ b/specs/class-static-prop/global-scope-two-level-with-single-level-use-and-alias.php
@@ -18,6 +18,7 @@ return [
         // Default values. If not specified will be the one used
         'prefix' => 'Humbug',
         'whitelist' => [],
+        'whitelist-global-constants' => true,
     ],
 
     [

--- a/specs/class-static-prop/global-scope-two-level-with-single-level-use.php
+++ b/specs/class-static-prop/global-scope-two-level-with-single-level-use.php
@@ -18,6 +18,7 @@ return [
         // Default values. If not specified will be the one used
         'prefix' => 'Humbug',
         'whitelist' => [],
+        'whitelist-global-constants' => true,
     ],
 
     [

--- a/specs/class-static-prop/global-scope-two-level.php
+++ b/specs/class-static-prop/global-scope-two-level.php
@@ -18,6 +18,7 @@ return [
         // Default values. If not specified will be the one used
         'prefix' => 'Humbug',
         'whitelist' => [],
+        'whitelist-global-constants' => true,
     ],
 
     [

--- a/specs/class-static-prop/namespace-scope-single-level-with-single-level-use-statement-and-alias.php
+++ b/specs/class-static-prop/namespace-scope-single-level-with-single-level-use-statement-and-alias.php
@@ -18,6 +18,7 @@ return [
         // Default values. If not specified will be the one used
         'prefix' => 'Humbug',
         'whitelist' => [],
+        'whitelist-global-constants' => true,
     ],
 
     [

--- a/specs/class-static-prop/namespace-scope-single-level.php
+++ b/specs/class-static-prop/namespace-scope-single-level.php
@@ -18,6 +18,7 @@ return [
         // Default values. If not specified will be the one used
         'prefix' => 'Humbug',
         'whitelist' => [],
+        'whitelist-global-constants' => true,
     ],
 
     [

--- a/specs/class-static-prop/namespace-scope-two-level-with-single-level-use-and-alias.php
+++ b/specs/class-static-prop/namespace-scope-two-level-with-single-level-use-and-alias.php
@@ -18,6 +18,7 @@ return [
         // Default values. If not specified will be the one used
         'prefix' => 'Humbug',
         'whitelist' => [],
+        'whitelist-global-constants' => true,
     ],
 
     [

--- a/specs/class-static-prop/namespace-scope-two-level-with-single-level-use.php
+++ b/specs/class-static-prop/namespace-scope-two-level-with-single-level-use.php
@@ -18,6 +18,7 @@ return [
         // Default values. If not specified will be the one used
         'prefix' => 'Humbug',
         'whitelist' => [],
+        'whitelist-global-constants' => true,
     ],
 
     [

--- a/specs/class-static-prop/namespace-scope-two-level.php
+++ b/specs/class-static-prop/namespace-scope-two-level.php
@@ -18,6 +18,7 @@ return [
         // Default values. If not specified will be the one used
         'prefix' => 'Humbug',
         'whitelist' => [],
+        'whitelist-global-constants' => true,
     ],
 
     [

--- a/specs/class-static-prop/namespace-single-part-with-single-level-use-statement.php
+++ b/specs/class-static-prop/namespace-single-part-with-single-level-use-statement.php
@@ -18,6 +18,7 @@ return [
         // Default values. If not specified will be the one used
         'prefix' => 'Humbug',
         'whitelist' => [],
+        'whitelist-global-constants' => true,
     ],
 
     [

--- a/specs/class/abstract.php
+++ b/specs/class/abstract.php
@@ -18,6 +18,7 @@ return [
         // Default values. If not specified will be the one used
         'prefix' => 'Humbug',
         'whitelist' => [],
+        'whitelist-global-constants' => true,
     ],
 
     'Declaration in the global namespace: add prefixed namespace' => <<<'PHP'

--- a/specs/class/anonymous.php
+++ b/specs/class/anonymous.php
@@ -18,6 +18,7 @@ return [
         // Default values. If not specified will be the one used
         'prefix' => 'Humbug',
         'whitelist' => [],
+        'whitelist-global-constants' => true,
     ],
 
     'Declaration in the global namespace: prefix non-internal classes' => <<<'PHP'

--- a/specs/class/conditional.php
+++ b/specs/class/conditional.php
@@ -18,6 +18,7 @@ return [
         // Default values. If not specified will be the one used
         'prefix' => 'Humbug',
         'whitelist' => [],
+        'whitelist-global-constants' => true,
     ],
 
     'Declaration in the global namespace: warp in a prefixed namespace.' => <<<'PHP'

--- a/specs/class/final.php
+++ b/specs/class/final.php
@@ -18,6 +18,7 @@ return [
         // Default values. If not specified will be the one used
         'prefix' => 'Humbug',
         'whitelist' => [],
+        'whitelist-global-constants' => true,
     ],
 
     'Declaration in the global namespace: add prefixed namespace.' => <<<'PHP'

--- a/specs/class/interface.php
+++ b/specs/class/interface.php
@@ -18,6 +18,7 @@ return [
         // Default values. If not specified will be the one used
         'prefix' => 'Humbug',
         'whitelist' => [],
+        'whitelist-global-constants' => true,
     ],
 
     'Declaration in the global namespace: add a prefixed namespace.' => <<<'PHP'

--- a/specs/class/regular-extend.php
+++ b/specs/class/regular-extend.php
@@ -18,6 +18,7 @@ return [
         // Default values. If not specified will be the one used
         'prefix' => 'Humbug',
         'whitelist' => [],
+        'whitelist-global-constants' => true,
     ],
 
     'Declaration in the global namespace: prefix only non-internal classes.' => <<<'PHP'

--- a/specs/class/regular.php
+++ b/specs/class/regular.php
@@ -18,6 +18,7 @@ return [
         // Default values. If not specified will be the one used
         'prefix' => 'Humbug',
         'whitelist' => [],
+        'whitelist-global-constants' => true,
     ],
 
     'Declaration in the global namespace: add a prefixed namespace.' => <<<'PHP'

--- a/specs/class/trait.php
+++ b/specs/class/trait.php
@@ -18,6 +18,7 @@ return [
         // Default values. If not specified will be the one used
         'prefix' => 'Humbug',
         'whitelist' => [],
+        'whitelist-global-constants' => true,
     ],
 
     'Declaration in the global namespace: add prefixed namespace.' => <<<'PHP'

--- a/specs/const/const-declaration-with-global-whitelisting.php
+++ b/specs/const/const-declaration-with-global-whitelisting.php
@@ -14,11 +14,11 @@ declare(strict_types=1);
 
 return [
     'meta' => [
-        'title' => 'Global constant usage in the global scope',
+        'title' => 'Global constant usage in the global scope with the global constants whitelisted',
         // Default values. If not specified will be the one used
         'prefix' => 'Humbug',
         'whitelist' => [],
-        'whitelist-global-constants' => false,
+        'whitelist-global-constants' => true,
     ],
 
     'Constants declaration in the global namespace' => [
@@ -39,8 +39,8 @@ namespace Humbug;
 const FOO_CONST = \Humbug\foo();
 \define('BAR_CONST', \Humbug\foo());
 \define('Humbug\\Acme\\BAR_CONST', \Humbug\foo());
-\define(\Humbug\FOO_CONST, \Humbug\foo());
-\define(\Humbug\FOO_CONST, \Humbug\foo());
+\define(\FOO_CONST, \Humbug\foo());
+\define(\FOO_CONST, \Humbug\foo());
 \define(\Humbug\Acme\BAR_CONST, \Humbug\foo());
 
 PHP
@@ -119,7 +119,7 @@ const FOO_CONST = foo();
 \define('BAR_CONST', foo());
 \define('Humbug\\Acme\\BAR_CONST', foo());
 \define(FOO_CONST, foo());
-\define(\Humbug\FOO_CONST, foo());
+\define(\FOO_CONST, foo());
 \define(\Humbug\Acme\FOO_CONST, foo());
 
 PHP
@@ -147,7 +147,7 @@ const FOO_CONST = foo();
 \define('BAR_CONST', foo());
 \define('Acme\\BAR_CONST', foo());
 \define(FOO_CONST, foo());
-\define(\Humbug\FOO_CONST, foo());
+\define(\FOO_CONST, foo());
 \define(\Acme\BAR_CONST, foo());
 
 PHP
@@ -175,7 +175,7 @@ const FOO_CONST = foo();
 \define('BAR_CONST', foo());
 \define('Acme\\BAR_CONST', foo());
 \define(FOO_CONST, foo());
-\define(\Humbug\FOO_CONST, foo());
+\define(\FOO_CONST, foo());
 \define(\Acme\BAR_CONST, foo());
 
 PHP

--- a/specs/const/const-declaration.php
+++ b/specs/const/const-declaration.php
@@ -18,6 +18,7 @@ return [
         // Default values. If not specified will be the one used
         'prefix' => 'Humbug',
         'whitelist' => [],
+        'whitelist-global-constants' => true,
     ],
 
     'Constants declaration in the global namespace' => [

--- a/specs/const/global-scope-global-with-global-whitelisting.php
+++ b/specs/const/global-scope-global-with-global-whitelisting.php
@@ -14,11 +14,11 @@ declare(strict_types=1);
 
 return [
     'meta' => [
-        'title' => 'Global constant usage in the global scope',
+        'title' => 'Global constant usage in the global scope with the global constants whitelisted',
         // Default values. If not specified will be the one used
         'prefix' => 'Humbug',
         'whitelist' => [],
-        'whitelist-global-constants' => false,
+        'whitelist-global-constants' => true,
     ],
 
     [
@@ -37,7 +37,7 @@ DUMMY_CONST;
 
 namespace Humbug;
 
-\Humbug\DUMMY_CONST;
+\DUMMY_CONST;
 
 PHP
     ],
@@ -116,7 +116,7 @@ DUMMY_CONST;
 
 namespace Humbug;
 
-\Humbug\DUMMY_CONST;
+\DUMMY_CONST;
 
 PHP
     ],

--- a/specs/const/global-scope-global-with-single-level-use-statement-and-alias.php
+++ b/specs/const/global-scope-global-with-single-level-use-statement-and-alias.php
@@ -18,7 +18,7 @@ return [
         // Default values. If not specified will be the one used
         'prefix' => 'Humbug',
         'whitelist' => [],
-        'whitelist-global-constants' => true,
+        'whitelist-global-constants' => false,
     ],
 
     [

--- a/specs/const/global-scope-global-with-single-level-use-statement-and-alias.php
+++ b/specs/const/global-scope-global-with-single-level-use-statement-and-alias.php
@@ -18,6 +18,7 @@ return [
         // Default values. If not specified will be the one used
         'prefix' => 'Humbug',
         'whitelist' => [],
+        'whitelist-global-constants' => true,
     ],
 
     [

--- a/specs/const/global-scope-global-with-single-level-use-statement-with-global-whitelisting.php
+++ b/specs/const/global-scope-global-with-single-level-use-statement-with-global-whitelisting.php
@@ -14,102 +14,81 @@ declare(strict_types=1);
 
 return [
     'meta' => [
-        'title' => 'Global constant usage in a namespace',
+        'title' => 'Global constant imported with a use statement used in the global scope with the global constants whitelisted',
         // Default values. If not specified will be the one used
         'prefix' => 'Humbug',
         'whitelist' => [],
-        'whitelist-global-constants' => false,
+        'whitelist-global-constants' => true,
     ],
 
     [
         'spec' => <<<'SPEC'
-Constant call in a namespace:
-- prefix the namespace
-- do nothing: the constant can either belong to the same namespace or the global namespace
+Constant call imported with a use statement:
+- prefix the use statement
+- prefix the call
+- transforms the call into a FQ call
 SPEC
         ,
         'payload' => <<<'PHP'
 <?php
 
-namespace A;
+use const DUMMY_CONST;
 
 DUMMY_CONST;
 ----
 <?php
 
-namespace Humbug\A;
+namespace Humbug;
 
-DUMMY_CONST;
+use const Humbug\DUMMY_CONST;
+\DUMMY_CONST;
 
 PHP
     ],
 
     [
         'spec' => <<<'SPEC'
-Whitelisted constant call in a namespace:
-- prefix the namespace
-- do nothing: the constant can either belong to the same namespace or the global namespace
+Whitelisted constant call imported with a use statement:
+- add prefixed namespace
+- transforms the call into a FQ call
 SPEC
         ,
         'whitelist' => ['DUMMY_CONST'],
         'payload' => <<<'PHP'
 <?php
 
-namespace A;
+use const DUMMY_CONST;
 
 DUMMY_CONST;
 ----
 <?php
 
-namespace Humbug\A;
+namespace Humbug;
 
-DUMMY_CONST;
+use const DUMMY_CONST;
+\DUMMY_CONST;
 
 PHP
     ],
 
     [
         'spec' => <<<'SPEC'
-FQ constant call in a namespace:
-- prefix the namespace
-- prefix the constant call
+FQ constant call imported with a use statement:
+- prefix the use statement
 SPEC
-    ,
+        ,
         'payload' => <<<'PHP'
 <?php
 
-namespace A;
+use const DUMMY_CONST;
 
 \DUMMY_CONST;
 ----
 <?php
 
-namespace Humbug\A;
+namespace Humbug;
 
-\Humbug\DUMMY_CONST;
-
-PHP
-    ],
-
-    [
-        'spec' => <<<'SPEC'
-Whitelisted FQ constant call in a namespace:
-- prefix the namespace
-- prefix the constant call
-SPEC
-    ,
-        'whitelist' => ['DUMMY_CONST'],
-        'payload' => <<<'PHP'
-<?php
-
-namespace A;
-
-\DUMMY_CONST;
-----
-<?php
-
-namespace Humbug\A;
-
+use const Humbug\DUMMY_CONST;
 \DUMMY_CONST;
 
 PHP

--- a/specs/const/global-scope-global-with-single-level-use-statement.php
+++ b/specs/const/global-scope-global-with-single-level-use-statement.php
@@ -18,7 +18,7 @@ return [
         // Default values. If not specified will be the one used
         'prefix' => 'Humbug',
         'whitelist' => [],
-        'whitelist-global-constants' => true,
+        'whitelist-global-constants' => false,
     ],
 
     [

--- a/specs/const/global-scope-global-with-single-level-use-statement.php
+++ b/specs/const/global-scope-global-with-single-level-use-statement.php
@@ -18,6 +18,7 @@ return [
         // Default values. If not specified will be the one used
         'prefix' => 'Humbug',
         'whitelist' => [],
+        'whitelist-global-constants' => true,
     ],
 
     [

--- a/specs/const/global-scope-global.php
+++ b/specs/const/global-scope-global.php
@@ -18,6 +18,7 @@ return [
         // Default values. If not specified will be the one used
         'prefix' => 'Humbug',
         'whitelist' => [],
+        'whitelist-global-constants' => true,
     ],
 
     [

--- a/specs/const/global-scope-single-part-namespaced-with-single-level-use-alias.php
+++ b/specs/const/global-scope-single-part-namespaced-with-single-level-use-alias.php
@@ -18,7 +18,7 @@ return [
         // Default values. If not specified will be the one used
         'prefix' => 'Humbug',
         'whitelist' => [],
-        'whitelist-global-constants' => true,
+        'whitelist-global-constants' => false,
     ],
 
     [

--- a/specs/const/global-scope-single-part-namespaced-with-single-level-use-alias.php
+++ b/specs/const/global-scope-single-part-namespaced-with-single-level-use-alias.php
@@ -18,6 +18,7 @@ return [
         // Default values. If not specified will be the one used
         'prefix' => 'Humbug',
         'whitelist' => [],
+        'whitelist-global-constants' => true,
     ],
 
     [

--- a/specs/const/global-scope-single-part-namespaced-with-single-level-use.php
+++ b/specs/const/global-scope-single-part-namespaced-with-single-level-use.php
@@ -18,7 +18,7 @@ return [
         // Default values. If not specified will be the one used
         'prefix' => 'Humbug',
         'whitelist' => [],
-        'whitelist-global-constants' => true,
+        'whitelist-global-constants' => false,
     ],
 
     [

--- a/specs/const/global-scope-single-part-namespaced-with-single-level-use.php
+++ b/specs/const/global-scope-single-part-namespaced-with-single-level-use.php
@@ -18,6 +18,7 @@ return [
         // Default values. If not specified will be the one used
         'prefix' => 'Humbug',
         'whitelist' => [],
+        'whitelist-global-constants' => true,
     ],
 
     [

--- a/specs/const/global-scope-single-part-namespaced.php
+++ b/specs/const/global-scope-single-part-namespaced.php
@@ -18,7 +18,7 @@ return [
         // Default values. If not specified will be the one used
         'prefix' => 'Humbug',
         'whitelist' => [],
-        'whitelist-global-constants' => true,
+        'whitelist-global-constants' => false,
     ],
 
     [

--- a/specs/const/global-scope-single-part-namespaced.php
+++ b/specs/const/global-scope-single-part-namespaced.php
@@ -18,6 +18,7 @@ return [
         // Default values. If not specified will be the one used
         'prefix' => 'Humbug',
         'whitelist' => [],
+        'whitelist-global-constants' => true,
     ],
 
     [

--- a/specs/const/global-scope-two-parts-namespaced-with-single-level-use-and-alias.php
+++ b/specs/const/global-scope-two-parts-namespaced-with-single-level-use-and-alias.php
@@ -18,7 +18,7 @@ return [
         // Default values. If not specified will be the one used
         'prefix' => 'Humbug',
         'whitelist' => [],
-        'whitelist-global-constants' => true,
+        'whitelist-global-constants' => false,
     ],
 
     [

--- a/specs/const/global-scope-two-parts-namespaced-with-single-level-use-and-alias.php
+++ b/specs/const/global-scope-two-parts-namespaced-with-single-level-use-and-alias.php
@@ -18,6 +18,7 @@ return [
         // Default values. If not specified will be the one used
         'prefix' => 'Humbug',
         'whitelist' => [],
+        'whitelist-global-constants' => true,
     ],
 
     [

--- a/specs/const/global-scope-two-parts-namespaced-with-single-level-use.php
+++ b/specs/const/global-scope-two-parts-namespaced-with-single-level-use.php
@@ -18,7 +18,7 @@ return [
         // Default values. If not specified will be the one used
         'prefix' => 'Humbug',
         'whitelist' => [],
-        'whitelist-global-constants' => true,
+        'whitelist-global-constants' => false,
     ],
 
     [

--- a/specs/const/global-scope-two-parts-namespaced-with-single-level-use.php
+++ b/specs/const/global-scope-two-parts-namespaced-with-single-level-use.php
@@ -18,6 +18,7 @@ return [
         // Default values. If not specified will be the one used
         'prefix' => 'Humbug',
         'whitelist' => [],
+        'whitelist-global-constants' => true,
     ],
 
     [

--- a/specs/const/global-scope-two-parts-namespaced.php
+++ b/specs/const/global-scope-two-parts-namespaced.php
@@ -18,7 +18,7 @@ return [
         // Default values. If not specified will be the one used
         'prefix' => 'Humbug',
         'whitelist' => [],
-        'whitelist-global-constants' => true,
+        'whitelist-global-constants' => false,
     ],
 
     [

--- a/specs/const/global-scope-two-parts-namespaced.php
+++ b/specs/const/global-scope-two-parts-namespaced.php
@@ -18,6 +18,7 @@ return [
         // Default values. If not specified will be the one used
         'prefix' => 'Humbug',
         'whitelist' => [],
+        'whitelist-global-constants' => true,
     ],
 
     [

--- a/specs/const/namespace-global-with-global-whitelisting.php
+++ b/specs/const/namespace-global-with-global-whitelisting.php
@@ -14,19 +14,18 @@ declare(strict_types=1);
 
 return [
     'meta' => [
-        'title' => 'Single-level namespaced constant call in a namespace',
+        'title' => 'Global constant usage in a namespace with the global constants whitelisted',
         // Default values. If not specified will be the one used
         'prefix' => 'Humbug',
         'whitelist' => [],
-        'whitelist-global-constants' => false,
+        'whitelist-global-constants' => true,
     ],
 
     [
         'spec' => <<<'SPEC'
-Namespaced constant call
+Constant call in a namespace:
 - prefix the namespace
-- prefix the call
-- transform the call into a FQ call
+- do nothing: the constant can either belong to the same namespace or the global namespace
 SPEC
         ,
         'payload' => <<<'PHP'
@@ -34,84 +33,84 @@ SPEC
 
 namespace A;
 
-PHPUnit\DUMMY_CONST;
+DUMMY_CONST;
 ----
 <?php
 
 namespace Humbug\A;
 
-\Humbug\A\PHPUnit\DUMMY_CONST;
+DUMMY_CONST;
 
 PHP
     ],
 
     [
         'spec' => <<<'SPEC'
-FQ namespaced constant call
+Whitelisted constant call in a namespace:
 - prefix the namespace
-- prefix the call
+- do nothing: the constant can either belong to the same namespace or the global namespace
 SPEC
         ,
+        'whitelist' => ['DUMMY_CONST'],
         'payload' => <<<'PHP'
 <?php
 
 namespace A;
 
-\PHPUnit\DUMMY_CONST;
+DUMMY_CONST;
 ----
 <?php
 
 namespace Humbug\A;
 
-\Humbug\PHPUnit\DUMMY_CONST;
+DUMMY_CONST;
 
 PHP
     ],
 
     [
         'spec' => <<<'SPEC'
-Whitelisted namespaced constant call on a whitelisted constant
+FQ constant call in a namespace:
 - prefix the namespace
-- prefix the call: the whitelist only works for classes
+- prefix the constant call
 SPEC
-        ,
-        'whitelist' => ['PHPUnit\DUMMY_CONST'],
+    ,
         'payload' => <<<'PHP'
 <?php
 
 namespace A;
 
-PHPUnit\DUMMY_CONST;
+\DUMMY_CONST;
 ----
 <?php
 
 namespace Humbug\A;
 
-\Humbug\A\PHPUnit\DUMMY_CONST;
+\DUMMY_CONST;
 
 PHP
     ],
 
     [
         'spec' => <<<'SPEC'
-Whitelisted FQ namespaced constant call on a whitelisted constant
+Whitelisted FQ constant call in a namespace:
 - prefix the namespace
-- prefix the call: the whitelist only works for classes
+- prefix the constant call
 SPEC
-        ,
-        'whitelist' => ['PHPUnit\DUMMY_CONST'],
+    ,
+        'whitelist' => ['DUMMY_CONST'],
         'payload' => <<<'PHP'
 <?php
 
 namespace A;
 
-\PHPUnit\DUMMY_CONST;
+\DUMMY_CONST;
 ----
 <?php
 
 namespace Humbug\A;
 
-\PHPUnit\DUMMY_CONST;
+\DUMMY_CONST;
 
 PHP
     ],

--- a/specs/const/namespace-global-with-single-level-use-statement-and-alias.php
+++ b/specs/const/namespace-global-with-single-level-use-statement-and-alias.php
@@ -18,6 +18,7 @@ return [
         // Default values. If not specified will be the one used
         'prefix' => 'Humbug',
         'whitelist' => [],
+        'whitelist-global-constants' => true,
     ],
 
     // As it is extremely rare to use a `use const` statement for a built-in constant from the

--- a/specs/const/namespace-global-with-single-level-use-statement-and-alias.php
+++ b/specs/const/namespace-global-with-single-level-use-statement-and-alias.php
@@ -18,7 +18,7 @@ return [
         // Default values. If not specified will be the one used
         'prefix' => 'Humbug',
         'whitelist' => [],
-        'whitelist-global-constants' => true,
+        'whitelist-global-constants' => false,
     ],
 
     // As it is extremely rare to use a `use const` statement for a built-in constant from the

--- a/specs/const/namespace-global-with-single-level-use-statement.php
+++ b/specs/const/namespace-global-with-single-level-use-statement.php
@@ -18,6 +18,7 @@ return [
         // Default values. If not specified will be the one used
         'prefix' => 'Humbug',
         'whitelist' => [],
+        'whitelist-global-constants' => true,
     ],
 
     // As it is extremely rare to use a `use const` statement for a built-in constant from the

--- a/specs/const/namespace-global-with-single-level-use-statement.php
+++ b/specs/const/namespace-global-with-single-level-use-statement.php
@@ -18,7 +18,7 @@ return [
         // Default values. If not specified will be the one used
         'prefix' => 'Humbug',
         'whitelist' => [],
-        'whitelist-global-constants' => true,
+        'whitelist-global-constants' => false,
     ],
 
     // As it is extremely rare to use a `use const` statement for a built-in constant from the

--- a/specs/const/namespace-global.php
+++ b/specs/const/namespace-global.php
@@ -18,6 +18,7 @@ return [
         // Default values. If not specified will be the one used
         'prefix' => 'Humbug',
         'whitelist' => [],
+        'whitelist-global-constants' => true,
     ],
 
     [

--- a/specs/const/namespace-single-part-namespaced.php
+++ b/specs/const/namespace-single-part-namespaced.php
@@ -18,6 +18,7 @@ return [
         // Default values. If not specified will be the one used
         'prefix' => 'Humbug',
         'whitelist' => [],
+        'whitelist-global-constants' => true,
     ],
 
     [

--- a/specs/const/native-const-with-global-whitelisting.php
+++ b/specs/const/native-const-with-global-whitelisting.php
@@ -14,11 +14,11 @@ declare(strict_types=1);
 
 return [
     'meta' => [
-        'title' => 'Native constant calls',
+        'title' => 'Native constant calls with the global constants whitelisted',
         // Default values. If not specified will be the one used
         'prefix' => 'Humbug',
         'whitelist' => [],
-        'whitelist-global-constants' => false,
+        'whitelist-global-constants' => true,
     ],
 
     'Internal function in a namespace: make the call into a FQ call' => <<<'PHP'

--- a/specs/const/native-const.php
+++ b/specs/const/native-const.php
@@ -18,6 +18,7 @@ return [
         // Default values. If not specified will be the one used
         'prefix' => 'Humbug',
         'whitelist' => [],
+        'whitelist-global-constants' => true,
     ],
 
     'Internal function in a namespace: make the call into a FQ call' => <<<'PHP'

--- a/specs/exp/cast.php
+++ b/specs/exp/cast.php
@@ -18,6 +18,7 @@ return [
         // Default values. If not specified will be the one used
         'prefix' => 'Humbug',
         'whitelist' => [],
+        'whitelist-global-constants' => true,
     ],
 
     'Cast variable' => <<<'PHP'

--- a/specs/exp/catch.php
+++ b/specs/exp/catch.php
@@ -18,6 +18,7 @@ return [
         // Default values. If not specified will be the one used
         'prefix' => 'Humbug',
         'whitelist' => [],
+        'whitelist-global-constants' => true,
     ],
 
     'Catch an internal class' => <<<'PHP'

--- a/specs/exp/instanceof.php
+++ b/specs/exp/instanceof.php
@@ -18,6 +18,7 @@ return [
         // Default values. If not specified will be the one used
         'prefix' => 'Humbug',
         'whitelist' => [],
+        'whitelist-global-constants' => true,
     ],
 
     'Instance of an internal class' => <<<'PHP'

--- a/specs/func-declaration/global.php
+++ b/specs/func-declaration/global.php
@@ -18,7 +18,7 @@ return [
         // Default values. If not specified will be the one used
         'prefix' => 'Humbug',
         'whitelist' => [],
-        'whitelist-global-constants' => true,
+        'whitelist-global-constants' => false,
     ],
 
     [
@@ -85,6 +85,30 @@ namespace Humbug;
 const FOO_CONST = 'foo';
 \define('BAR_CONST', 'foo');
 function foo(\Humbug\Foo $arg0, \Humbug\Foo $arg1, \Humbug\Foo\Bar $arg2, \Humbug\Foo\Bar $arg3, \ArrayIterator $arg4, \ArrayIterator $arg5, \Humbug\X\Y $arg6, \Humbug\X\Y $arg7, string $foo = \Humbug\FOO_CONST, string $bar = \BAR_CONST)
+{
+}
+
+PHP
+    ],
+
+    [
+        'spec' => <<<'SPEC'
+Function declaration in the global namespace:
+- prefix the namespace statements
+- prefix the appropriate classes
+SPEC
+        ,
+        'whitelist-global-constants' => true,
+        'payload' => <<<'PHP'
+<?php
+
+function foo(string $foo = FOO_CONST) {}
+----
+<?php
+
+namespace Humbug;
+
+function foo(string $foo = \FOO_CONST)
 {
 }
 

--- a/specs/func-declaration/global.php
+++ b/specs/func-declaration/global.php
@@ -18,6 +18,7 @@ return [
         // Default values. If not specified will be the one used
         'prefix' => 'Humbug',
         'whitelist' => [],
+        'whitelist-global-constants' => true,
     ],
 
     [

--- a/specs/func-declaration/method.php
+++ b/specs/func-declaration/method.php
@@ -18,6 +18,7 @@ return [
         // Default values. If not specified will be the one used
         'prefix' => 'Humbug',
         'whitelist' => [],
+        'whitelist-global-constants' => true,
     ],
 
     [

--- a/specs/func-declaration/namespace.php
+++ b/specs/func-declaration/namespace.php
@@ -18,6 +18,7 @@ return [
         // Default values. If not specified will be the one used
         'prefix' => 'Humbug',
         'whitelist' => [],
+        'whitelist-global-constants' => true,
     ],
 
     [

--- a/specs/function/global-scope-global-func-with-single-level-use-statement-and-alias.php
+++ b/specs/function/global-scope-global-func-with-single-level-use-statement-and-alias.php
@@ -18,6 +18,7 @@ return [
         // Default values. If not specified will be the one used
         'prefix' => 'Humbug',
         'whitelist' => [],
+        'whitelist-global-constants' => true,
     ],
 
     [

--- a/specs/function/global-scope-global-func-with-single-level-use-statement.php
+++ b/specs/function/global-scope-global-func-with-single-level-use-statement.php
@@ -18,6 +18,7 @@ return [
         // Default values. If not specified will be the one used
         'prefix' => 'Humbug',
         'whitelist' => [],
+        'whitelist-global-constants' => true,
     ],
 
     [

--- a/specs/function/global-scope-global-func.php
+++ b/specs/function/global-scope-global-func.php
@@ -18,6 +18,7 @@ return [
         // Default values. If not specified will be the one used
         'prefix' => 'Humbug',
         'whitelist' => [],
+        'whitelist-global-constants' => true,
     ],
 
     [

--- a/specs/function/global-scope-single-part-namespaced-func-with-single-level-use-and-alias.php
+++ b/specs/function/global-scope-single-part-namespaced-func-with-single-level-use-and-alias.php
@@ -18,6 +18,7 @@ return [
         // Default values. If not specified will be the one used
         'prefix' => 'Humbug',
         'whitelist' => [],
+        'whitelist-global-constants' => true,
     ],
 
     [

--- a/specs/function/global-scope-single-part-namespaced-func-with-single-level-use.php
+++ b/specs/function/global-scope-single-part-namespaced-func-with-single-level-use.php
@@ -18,6 +18,7 @@ return [
         // Default values. If not specified will be the one used
         'prefix' => 'Humbug',
         'whitelist' => [],
+        'whitelist-global-constants' => true,
     ],
 
     [

--- a/specs/function/global-scope-single-part-namespaced-func.php
+++ b/specs/function/global-scope-single-part-namespaced-func.php
@@ -18,6 +18,7 @@ return [
         // Default values. If not specified will be the one used
         'prefix' => 'Humbug',
         'whitelist' => [],
+        'whitelist-global-constants' => true,
     ],
 
     [

--- a/specs/function/namespace-global-func-with-single-level-use-statement-and-alias.php
+++ b/specs/function/namespace-global-func-with-single-level-use-statement-and-alias.php
@@ -18,6 +18,7 @@ return [
         // Default values. If not specified will be the one used
         'prefix' => 'Humbug',
         'whitelist' => [],
+        'whitelist-global-constants' => true,
     ],
 
     [

--- a/specs/function/namespace-global-func-with-single-level-use-statement.php
+++ b/specs/function/namespace-global-func-with-single-level-use-statement.php
@@ -18,6 +18,7 @@ return [
         // Default values. If not specified will be the one used
         'prefix' => 'Humbug',
         'whitelist' => [],
+        'whitelist-global-constants' => true,
     ],
 
     [

--- a/specs/function/namespace-global-func.php
+++ b/specs/function/namespace-global-func.php
@@ -18,6 +18,7 @@ return [
         // Default values. If not specified will be the one used
         'prefix' => 'Humbug',
         'whitelist' => [],
+        'whitelist-global-constants' => true,
     ],
 
     [

--- a/specs/function/namespace-global-scope-func.php
+++ b/specs/function/namespace-global-scope-func.php
@@ -18,6 +18,7 @@ return [
         // Default values. If not specified will be the one used
         'prefix' => 'Humbug',
         'whitelist' => [],
+        'whitelist-global-constants' => true,
     ],
 
     // We don't do anything as there is no ways to distinguish between a namespaced function call

--- a/specs/function/namespace-single-part-namespaced-func.php
+++ b/specs/function/namespace-single-part-namespaced-func.php
@@ -18,6 +18,7 @@ return [
         // Default values. If not specified will be the one used
         'prefix' => 'Humbug',
         'whitelist' => [],
+        'whitelist-global-constants' => true,
     ],
 
     [

--- a/specs/function/native-func.php
+++ b/specs/function/native-func.php
@@ -18,6 +18,7 @@ return [
         // Default values. If not specified will be the one used
         'prefix' => 'Humbug',
         'whitelist' => [],
+        'whitelist-global-constants' => true,
     ],
 
     'Internal function in a namespace: make the call into a FQ call' => <<<'PHP'

--- a/specs/misc.php
+++ b/specs/misc.php
@@ -18,6 +18,7 @@ return [
         // Default values. If not specified will be the one used
         'prefix' => 'Humbug',
         'whitelist' => [],
+        'whitelist-global-constants' => true,
     ],
 
     'Empty file: do nothing' => <<<'PHP'

--- a/specs/namespace/after-hashbang.php
+++ b/specs/namespace/after-hashbang.php
@@ -18,6 +18,7 @@ return [
         // Default values. If not specified will be the one used
         'prefix' => 'Humbug',
         'whitelist' => [],
+        'whitelist-global-constants' => true,
     ],
 
     <<<'PHP'

--- a/specs/namespace/braces.php
+++ b/specs/namespace/braces.php
@@ -18,6 +18,7 @@ return [
         // Default values. If not specified will be the one used
         'prefix' => 'Humbug',
         'whitelist' => [],
+        'whitelist-global-constants' => true,
     ],
 
     'One level namespace: prefix it' => <<<'PHP'

--- a/specs/namespace/creation-for-whitelist.php
+++ b/specs/namespace/creation-for-whitelist.php
@@ -18,6 +18,7 @@ return [
         // Default values. If not specified will be the one used
         'prefix' => 'Humbug',
         'whitelist' => [],
+        'whitelist-global-constants' => true,
     ],
 
     'Single class should receive namespace' => <<<'PHP'

--- a/specs/namespace/no-braces.php
+++ b/specs/namespace/no-braces.php
@@ -18,6 +18,7 @@ return [
         // Default values. If not specified will be the one used
         'prefix' => 'Humbug',
         'whitelist' => [],
+        'whitelist-global-constants' => true,
     ],
 
     'Root namespace: prefix the namespace' => <<<'PHP'

--- a/specs/namespace/outside-statements.php
+++ b/specs/namespace/outside-statements.php
@@ -18,6 +18,7 @@ return [
         // Default values. If not specified will be the one used
         'prefix' => 'Humbug',
         'whitelist' => [],
+        'whitelist-global-constants' => true,
     ],
 
     'Declare statement' => <<<'PHP'

--- a/specs/new/global-scope-single-part-with-single-level-use-statement-an-alias.php
+++ b/specs/new/global-scope-single-part-with-single-level-use-statement-an-alias.php
@@ -18,6 +18,7 @@ return [
         // Default values. If not specified will be the one used
         'prefix' => 'Humbug',
         'whitelist' => [],
+        'whitelist-global-constants' => true,
     ],
 
     [

--- a/specs/new/global-scope-single-part-with-single-level-use-statement.php
+++ b/specs/new/global-scope-single-part-with-single-level-use-statement.php
@@ -18,6 +18,7 @@ return [
         // Default values. If not specified will be the one used
         'prefix' => 'Humbug',
         'whitelist' => [],
+        'whitelist-global-constants' => true,
     ],
 
     [

--- a/specs/new/global-scope-single-part.php
+++ b/specs/new/global-scope-single-part.php
@@ -18,6 +18,7 @@ return [
         // Default values. If not specified will be the one used
         'prefix' => 'Humbug',
         'whitelist' => [],
+        'whitelist-global-constants' => true,
     ],
 
     [

--- a/specs/new/global-scope-two-parts-with-single-level-use-and-alias.php
+++ b/specs/new/global-scope-two-parts-with-single-level-use-and-alias.php
@@ -18,6 +18,7 @@ return [
         // Default values. If not specified will be the one used
         'prefix' => 'Humbug',
         'whitelist' => [],
+        'whitelist-global-constants' => true,
     ],
 
     [

--- a/specs/new/global-scope-two-parts-with-single-level-use.php
+++ b/specs/new/global-scope-two-parts-with-single-level-use.php
@@ -18,6 +18,7 @@ return [
         // Default values. If not specified will be the one used
         'prefix' => 'Humbug',
         'whitelist' => [],
+        'whitelist-global-constants' => true,
     ],
 
     [

--- a/specs/new/global-scope-two-parts.php
+++ b/specs/new/global-scope-two-parts.php
@@ -18,6 +18,7 @@ return [
         // Default values. If not specified will be the one used
         'prefix' => 'Humbug',
         'whitelist' => [],
+        'whitelist-global-constants' => true,
     ],
 
     [

--- a/specs/new/namespace-single-part-with-single-level-use-statement.php
+++ b/specs/new/namespace-single-part-with-single-level-use-statement.php
@@ -19,6 +19,7 @@ return [
         // Default values. If not specified will be the one used
         'prefix' => 'Humbug',
         'whitelist' => [],
+        'whitelist-global-constants' => true,
     ],
 
     [

--- a/specs/new/namespace-single-part.php
+++ b/specs/new/namespace-single-part.php
@@ -18,6 +18,7 @@ return [
         // Default values. If not specified will be the one used
         'prefix' => 'Humbug',
         'whitelist' => [],
+        'whitelist-global-constants' => true,
     ],
 
     [

--- a/specs/new/namespace-two-parts-with-single-level-use.php
+++ b/specs/new/namespace-two-parts-with-single-level-use.php
@@ -18,6 +18,7 @@ return [
         // Default values. If not specified will be the one used
         'prefix' => 'Humbug',
         'whitelist' => [],
+        'whitelist-global-constants' => true,
     ],
 
     [

--- a/specs/new/namespace-two-parts-with-two-level-use.php
+++ b/specs/new/namespace-two-parts-with-two-level-use.php
@@ -18,6 +18,7 @@ return [
         // Default values. If not specified will be the one used
         'prefix' => 'Humbug',
         'whitelist' => [],
+        'whitelist-global-constants' => true,
     ],
 
     [

--- a/specs/new/namespace-two-parts.php
+++ b/specs/new/namespace-two-parts.php
@@ -18,6 +18,7 @@ return [
         // Default values. If not specified will be the one used
         'prefix' => 'Humbug',
         'whitelist' => [],
+        'whitelist-global-constants' => true,
     ],
 
     [

--- a/specs/special-keywords/self-static-parent-const.php
+++ b/specs/special-keywords/self-static-parent-const.php
@@ -18,6 +18,7 @@ return [
         // Default values. If not specified will be the one used
         'prefix' => 'Humbug',
         'whitelist' => [],
+        'whitelist-global-constants' => true,
     ],
 
     [

--- a/specs/special-keywords/self-static-parent-method.php
+++ b/specs/special-keywords/self-static-parent-method.php
@@ -18,6 +18,7 @@ return [
         // Default values. If not specified will be the one used
         'prefix' => 'Humbug',
         'whitelist' => [],
+        'whitelist-global-constants' => true,
     ],
 
     [

--- a/specs/special-keywords/self-static-parent-static-var.php
+++ b/specs/special-keywords/self-static-parent-static-var.php
@@ -18,6 +18,7 @@ return [
         // Default values. If not specified will be the one used
         'prefix' => 'Humbug',
         'whitelist' => [],
+        'whitelist-global-constants' => true,
     ],
 
     [

--- a/specs/static-method/global-scope-single-part-with-single-level-use-statement-and-alias.php
+++ b/specs/static-method/global-scope-single-part-with-single-level-use-statement-and-alias.php
@@ -18,6 +18,7 @@ return [
         // Default values. If not specified will be the one used
         'prefix' => 'Humbug',
         'whitelist' => [],
+        'whitelist-global-constants' => true,
     ],
 
     [

--- a/specs/static-method/global-scope-single-part-with-single-level-use-statement.php
+++ b/specs/static-method/global-scope-single-part-with-single-level-use-statement.php
@@ -18,6 +18,7 @@ return [
         // Default values. If not specified will be the one used
         'prefix' => 'Humbug',
         'whitelist' => [],
+        'whitelist-global-constants' => true,
     ],
 
     [

--- a/specs/static-method/global-scope-single-part.php
+++ b/specs/static-method/global-scope-single-part.php
@@ -18,6 +18,7 @@ return [
         // Default values. If not specified will be the one used
         'prefix' => 'Humbug',
         'whitelist' => [],
+        'whitelist-global-constants' => true,
     ],
 
     [

--- a/specs/static-method/global-scope-two-parts-with-single-level-use-and-alias.php
+++ b/specs/static-method/global-scope-two-parts-with-single-level-use-and-alias.php
@@ -18,6 +18,7 @@ return [
         // Default values. If not specified will be the one used
         'prefix' => 'Humbug',
         'whitelist' => [],
+        'whitelist-global-constants' => true,
     ],
 
     [

--- a/specs/static-method/global-scope-two-parts-with-single-level-use.php
+++ b/specs/static-method/global-scope-two-parts-with-single-level-use.php
@@ -18,6 +18,7 @@ return [
         // Default values. If not specified will be the one used
         'prefix' => 'Humbug',
         'whitelist' => [],
+        'whitelist-global-constants' => true,
     ],
 
     [

--- a/specs/static-method/global-scope-two-parts.php
+++ b/specs/static-method/global-scope-two-parts.php
@@ -18,6 +18,7 @@ return [
         // Default values. If not specified will be the one used
         'prefix' => 'Humbug',
         'whitelist' => [],
+        'whitelist-global-constants' => true,
     ],
 
     [

--- a/specs/static-method/namespace-single-part-with-single-level-use-statement.php
+++ b/specs/static-method/namespace-single-part-with-single-level-use-statement.php
@@ -19,6 +19,7 @@ return [
         // Default values. If not specified will be the one used
         'prefix' => 'Humbug',
         'whitelist' => [],
+        'whitelist-global-constants' => true,
     ],
 
     [

--- a/specs/static-method/namespace-single-part.php
+++ b/specs/static-method/namespace-single-part.php
@@ -18,6 +18,7 @@ return [
         // Default values. If not specified will be the one used
         'prefix' => 'Humbug',
         'whitelist' => [],
+        'whitelist-global-constants' => true,
     ],
 
     [

--- a/specs/static-method/namespace-two-parts-with-single-level-use.php
+++ b/specs/static-method/namespace-two-parts-with-single-level-use.php
@@ -18,6 +18,7 @@ return [
         // Default values. If not specified will be the one used
         'prefix' => 'Humbug',
         'whitelist' => [],
+        'whitelist-global-constants' => true,
     ],
 
     [

--- a/specs/static-method/namespace-two-parts-with-two-level-use.php
+++ b/specs/static-method/namespace-two-parts-with-two-level-use.php
@@ -18,6 +18,7 @@ return [
         // Default values. If not specified will be the one used
         'prefix' => 'Humbug',
         'whitelist' => [],
+        'whitelist-global-constants' => true,
     ],
 
     [

--- a/specs/static-method/namespace-two-parts.php
+++ b/specs/static-method/namespace-two-parts.php
@@ -18,6 +18,7 @@ return [
         // Default values. If not specified will be the one used
         'prefix' => 'Humbug',
         'whitelist' => [],
+        'whitelist-global-constants' => true,
     ],
 
     [

--- a/specs/string-literal/array-var.php
+++ b/specs/string-literal/array-var.php
@@ -18,6 +18,7 @@ return [
         // Default values. If not specified will be the one used
         'prefix' => 'Humbug',
         'whitelist' => [],
+        'whitelist-global-constants' => true,
     ],
 
     'String argument: transform into a FQCN and prefix it' => <<<'PHP'

--- a/specs/string-literal/class-const-array.php
+++ b/specs/string-literal/class-const-array.php
@@ -18,6 +18,7 @@ return [
         // Default values. If not specified will be the one used
         'prefix' => 'Humbug',
         'whitelist' => [],
+        'whitelist-global-constants' => true,
     ],
 
     'FQCN string argument: transform into a FQCN and prefix it' => <<<'PHP'

--- a/specs/string-literal/class-const.php
+++ b/specs/string-literal/class-const.php
@@ -18,6 +18,7 @@ return [
         // Default values. If not specified will be the one used
         'prefix' => 'Humbug',
         'whitelist' => [],
+        'whitelist-global-constants' => true,
     ],
 
     'FQCN string argument: transform into a FQCN and prefix it' => <<<'PHP'

--- a/specs/string-literal/class-prop.php
+++ b/specs/string-literal/class-prop.php
@@ -18,6 +18,7 @@ return [
         // Default values. If not specified will be the one used
         'prefix' => 'Humbug',
         'whitelist' => [],
+        'whitelist-global-constants' => true,
     ],
 
     'FQCN string argument: transform into a FQCN and prefix it' => <<<'PHP'

--- a/specs/string-literal/class-var.php
+++ b/specs/string-literal/class-var.php
@@ -18,6 +18,7 @@ return [
         // Default values. If not specified will be the one used
         'prefix' => 'Humbug',
         'whitelist' => [],
+        'whitelist-global-constants' => true,
     ],
 
     'FQCN string argument: transform into a FQCN and prefix it' => <<<'PHP'

--- a/specs/string-literal/const.php
+++ b/specs/string-literal/const.php
@@ -18,6 +18,7 @@ return [
         // Default values. If not specified will be the one used
         'prefix' => 'Humbug',
         'whitelist' => [],
+        'whitelist-global-constants' => true,
     ],
 
     'FQCN string argument: transform into a FQCN and prefix it' => <<<'PHP'

--- a/specs/string-literal/func-arg.php
+++ b/specs/string-literal/func-arg.php
@@ -18,6 +18,7 @@ return [
         // Default values. If not specified will be the one used
         'prefix' => 'Humbug',
         'whitelist' => [],
+        'whitelist-global-constants' => true,
     ],
 
     'FQCN string argument: transform into a FQCN and prefix it' => <<<'PHP'

--- a/specs/string-literal/func-arg.php
+++ b/specs/string-literal/func-arg.php
@@ -57,8 +57,8 @@ foo('\\Humbug\\Symfony\\Component\\Yaml\\Yaml');
 
 namespace Humbug;
 
-\Humbug\foo('Humbug\\Symfony\\Component\\Yaml\\Yaml');
-\Humbug\foo('Humbug\\Symfony\\Component\\Yaml\\Yaml');
+\Humbug\foo('Symfony\\Component\\Yaml\\Yaml');
+\Humbug\foo('Symfony\\Component\\Yaml\\Yaml');
 \Humbug\foo('Humbug\\Symfony\\Component\\Yaml\\Yaml');
 \Humbug\foo('Humbug\\Symfony\\Component\\Yaml\\Yaml');
 

--- a/specs/string-literal/method-arg.php
+++ b/specs/string-literal/method-arg.php
@@ -18,6 +18,7 @@ return [
         // Default values. If not specified will be the one used
         'prefix' => 'Humbug',
         'whitelist' => [],
+        'whitelist-global-constants' => true,
     ],
 
     'FQCN string argument: transform into a FQCN and prefix it' => <<<'PHP'

--- a/specs/string-literal/var.php
+++ b/specs/string-literal/var.php
@@ -18,6 +18,7 @@ return [
         // Default values. If not specified will be the one used
         'prefix' => 'Humbug',
         'whitelist' => [],
+        'whitelist-global-constants' => true,
     ],
 
     'FQCN string argument: transform into a FQCN and prefix it' => <<<'PHP'

--- a/specs/string-literal/var.php
+++ b/specs/string-literal/var.php
@@ -82,8 +82,8 @@ $x = '\\Humbug\\Symfony\\Component\\Yaml\\Yaml';
 
 namespace Humbug;
 
-$x = 'Humbug\\Symfony\\Component\\Yaml\\Yaml';
-$x = 'Humbug\\Symfony\\Component\\Yaml\\Yaml';
+$x = 'Symfony\\Component\\Yaml\\Yaml';
+$x = 'Symfony\\Component\\Yaml\\Yaml';
 $x = 'Humbug\\Symfony\\Component\\Yaml\\Yaml';
 $x = 'Humbug\\Symfony\\Component\\Yaml\\Yaml';
 

--- a/specs/use/use-class-alias.php
+++ b/specs/use/use-class-alias.php
@@ -18,6 +18,7 @@ return [
         // Default values. If not specified will be the one used
         'prefix' => 'Humbug',
         'whitelist' => [],
+        'whitelist-global-constants' => true,
     ],
 
     [

--- a/specs/use/use-class-group.php
+++ b/specs/use/use-class-group.php
@@ -18,6 +18,7 @@ return [
         // Default values. If not specified will be the one used
         'prefix' => 'Humbug',
         'whitelist' => [],
+        'whitelist-global-constants' => true,
     ],
 
     [

--- a/specs/use/use-class.php
+++ b/specs/use/use-class.php
@@ -18,6 +18,7 @@ return [
         // Default values. If not specified will be the one used
         'prefix' => 'Humbug',
         'whitelist' => [],
+        'whitelist-global-constants' => true,
     ],
 
     [

--- a/specs/use/use-const-alias.php
+++ b/specs/use/use-const-alias.php
@@ -18,6 +18,7 @@ return [
         // Default values. If not specified will be the one used
         'prefix' => 'Humbug',
         'whitelist' => [],
+        'whitelist-global-constants' => true,
     ],
 
     [

--- a/specs/use/use-const-group.php
+++ b/specs/use/use-const-group.php
@@ -18,6 +18,7 @@ return [
         // Default values. If not specified will be the one used
         'prefix' => 'Humbug',
         'whitelist' => [],
+        'whitelist-global-constants' => true,
     ],
 
     <<<'PHP'

--- a/specs/use/use-const.php
+++ b/specs/use/use-const.php
@@ -18,6 +18,7 @@ return [
         // Default values. If not specified will be the one used
         'prefix' => 'Humbug',
         'whitelist' => [],
+        'whitelist-global-constants' => true,
     ],
 
     [

--- a/specs/use/use-func-alias.php
+++ b/specs/use/use-func-alias.php
@@ -18,6 +18,7 @@ return [
         // Default values. If not specified will be the one used
         'prefix' => 'Humbug',
         'whitelist' => [],
+        'whitelist-global-constants' => true,
     ],
 
     [

--- a/specs/use/use-func-group.php
+++ b/specs/use/use-func-group.php
@@ -18,6 +18,7 @@ return [
         // Default values. If not specified will be the one used
         'prefix' => 'Humbug',
         'whitelist' => [],
+        'whitelist-global-constants' => true,
     ],
 
     <<<'PHP'

--- a/specs/use/use-func.php
+++ b/specs/use/use-func.php
@@ -18,6 +18,7 @@ return [
         // Default values. If not specified will be the one used
         'prefix' => 'Humbug',
         'whitelist' => [],
+        'whitelist-global-constants' => true,
     ],
 
     [

--- a/specs/use/use-mix-group.php
+++ b/specs/use/use-mix-group.php
@@ -18,6 +18,7 @@ return [
         // Default values. If not specified will be the one used
         'prefix' => 'Humbug',
         'whitelist' => [],
+        'whitelist-global-constants' => true,
     ],
 
     <<<'PHP'

--- a/src/PhpParser/NodeVisitor/NameStmtPrefixer.php
+++ b/src/PhpParser/NodeVisitor/NameStmtPrefixer.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 
 namespace Humbug\PhpScoper\PhpParser\NodeVisitor;
 
+use function count;
 use Humbug\PhpScoper\PhpParser\NodeVisitor\Resolver\FullyQualifiedNameResolver;
 use Humbug\PhpScoper\Reflector;
 use Humbug\PhpScoper\Whitelist;
@@ -171,6 +172,10 @@ final class NameStmtPrefixer extends NodeVisitorAbstract
             // See https://wiki.php.net/rfc/fallback-to-root-scope-deprecation
             if (false === ($resolvedName instanceof FullyQualified)) {
                 return $resolvedName;
+            }
+
+            if (count($resolvedName->parts) === 1 && $this->whitelist->whitelistGlobalConstants()) {
+                return new FullyQualified($resolvedName->toString(), $resolvedName->getAttributes());
             }
         }
 

--- a/src/PhpParser/NodeVisitor/StringScalarPrefixer.php
+++ b/src/PhpParser/NodeVisitor/StringScalarPrefixer.php
@@ -117,6 +117,7 @@ final class StringScalarPrefixer extends NodeVisitorAbstract
         } elseif (
             1 === count($stringName->parts)
             || $this->reflector->isClassInternal($stringName->toString())
+            || $this->whitelist->isClassWhitelisted((string) $stringName)
             || $this->whitelist->isNamespaceWhitelisted((string) $stringName)
         ) {
             $newStringName = $stringName;

--- a/src/Whitelist.php
+++ b/src/Whitelist.php
@@ -29,8 +29,9 @@ final class Whitelist implements Countable
 {
     private $classes;
     private $namespaces;
+    private $whitelistGlobalConstants;
 
-    public static function create(string ...$elements): self
+    public static function create(bool $whitelistGlobalConstants, string ...$elements): self
     {
         $classes = [];
         $namespaces = [];
@@ -59,6 +60,7 @@ final class Whitelist implements Countable
         }
 
         return new self(
+            $whitelistGlobalConstants,
             array_unique($classes),
             array_unique($namespaces)
         );
@@ -68,10 +70,16 @@ final class Whitelist implements Countable
      * @param string[] $classes
      * @param string[] $namespaces
      */
-    private function __construct(array $classes, array $namespaces)
+    private function __construct(bool $whitelistGlobalConstants, array $classes, array $namespaces)
     {
+        $this->whitelistGlobalConstants = $whitelistGlobalConstants;
         $this->classes = $classes;
         $this->namespaces = $namespaces;
+    }
+
+    public function whitelistGlobalConstants(): bool
+    {
+        return $this->whitelistGlobalConstants;
     }
 
     public function isClassWhitelisted(string $name): bool

--- a/src/scoper.inc.php.tpl
+++ b/src/scoper.inc.php.tpl
@@ -57,6 +57,13 @@ return [
     //
     // Fore more see https://github.com/humbug/php-scoper#whitelist
     'whitelist' => [
-        'PHPUnit\Framework\TestCase',
+        // 'PHPUnit\Framework\TestCase',   // A specific class
+        // 'PHPUnit\Framework\*',          // The whole namespace
+        // '*',                            // Everything
     ],
+
+    // If `true` then the user defined constants belonging to the global namespace will not be prefixed.
+    //
+    // For more see https://github.com/humbug/php-scoper#constants-from-the-global-namespace-whitelisting
+    'whitelist-global-constants' => true,
 ];

--- a/tests/Autoload/ScoperAutoloadGeneratorTest.php
+++ b/tests/Autoload/ScoperAutoloadGeneratorTest.php
@@ -21,7 +21,7 @@ class ScoperAutoloadGeneratorTest extends TestCase
 {
     public function test_generate_the_autoload()
     {
-        $whitelist = Whitelist::create('A\Foo', 'B\Bar');
+        $whitelist = Whitelist::create(true, 'A\Foo', 'B\Bar');
 
         $prefix = 'Humbug';
 

--- a/tests/Console/Command/AddPrefixCommandTest.php
+++ b/tests/Console/Command/AddPrefixCommandTest.php
@@ -174,7 +174,7 @@ EOF;
                     $inputContents,
                     'MyPrefix',
                     [],
-                    Whitelist::create()
+                    Whitelist::create(true)
                 )
                 ->willReturn($prefixedContents)
             ;
@@ -237,7 +237,7 @@ EOF;
                         $inputContents,
                         'MyPrefix',
                         [],
-                        Whitelist::create()
+                        Whitelist::create(true)
                     )
                     ->willReturn($prefixedContents)
                 ;
@@ -250,7 +250,7 @@ EOF;
                         $inputContents,
                         'MyPrefix',
                         [],
-                        Whitelist::create()
+                        Whitelist::create(true)
                     )
                     ->willThrow(new \RuntimeException('Scoping of the file failed'))
                 ;
@@ -310,7 +310,7 @@ EOF;
                     $inputContents,
                     'MyPrefix',
                     [],
-                    Whitelist::create()
+                    Whitelist::create(true)
                 )
                 ->willReturn($prefixedContents)
             ;
@@ -371,7 +371,7 @@ EOF;
                     $inputContents,
                     'MyPrefix',
                     [],
-                    Whitelist::create()
+                    Whitelist::create(true)
                 )
                 ->willReturn($prefixedFileContents)
             ;
@@ -425,7 +425,7 @@ EOF;
                     }
                 ),
                 [],
-                Whitelist::create()
+                Whitelist::create(true)
             )
             ->willReturn('')
         ;
@@ -483,7 +483,7 @@ EOF;
                     $inputContents,
                     'MyPrefix',
                     [],
-                    Whitelist::create()
+                    Whitelist::create(true)
                 )
                 ->willReturn($prefixedContents)
             ;
@@ -529,7 +529,7 @@ EOF;
                 Argument::any(),
                 'MyPrefix',
                 [],
-                Whitelist::create()
+                Whitelist::create(true)
             )
             ->willReturn('')
         ;
@@ -572,7 +572,7 @@ EOF;
                 Argument::any(),
                 'MyPrefix',
                 [],
-                Whitelist::create()
+                Whitelist::create(true)
             )
             ->willReturn('')
         ;
@@ -630,7 +630,7 @@ EOF;
                     $inputContents,
                     'MyPrefix',
                     [],
-                    Whitelist::create()
+                    Whitelist::create(true)
                 )
                 ->willReturn($prefixedContents)
             ;
@@ -692,7 +692,7 @@ EOF;
                     $inputContents,
                     'MyPrefix',
                     [],
-                    Whitelist::create()
+                    Whitelist::create(true)
                 )
                 ->willReturn($prefixedContents)
             ;
@@ -783,7 +783,7 @@ EOF;
 
                         return true;
                     }),
-                    Whitelist::create()
+                    Whitelist::create(true)
                 )
                 ->willReturn($prefixedContents)
             ;
@@ -868,7 +868,7 @@ EOF;
                     $fileContents,
                     'MyPrefix',
                     [],
-                    Whitelist::create()
+                    Whitelist::create(true)
                 )
                 ->willThrow($scopingException = new RuntimeException('Could not scope file'))
             ;

--- a/tests/PhpParser/TraverserFactoryTest.php
+++ b/tests/PhpParser/TraverserFactoryTest.php
@@ -28,7 +28,7 @@ class TraverserFactoryTest extends TestCase
     {
         $prefix = 'Humbug';
 
-        $whitelist = Whitelist::create('Foo');
+        $whitelist = Whitelist::create(true, 'Foo');
 
         $classReflector = new Reflector(
             (new BetterReflection())->classReflector(),

--- a/tests/Scoper/Composer/InstalledPackagesScoperTest.php
+++ b/tests/Scoper/Composer/InstalledPackagesScoperTest.php
@@ -39,7 +39,7 @@ class InstalledPackagesScoperTest extends TestCase
         $fileContents = '';
         $prefix = 'Humbug';
         $patchers = [create_fake_patcher()];
-        $whitelist = Whitelist::create('Foo');
+        $whitelist = Whitelist::create(true, 'Foo');
 
         /** @var Scoper|ObjectProphecy $decoratedScoperProphecy */
         $decoratedScoperProphecy = $this->prophesize(Scoper::class);
@@ -72,7 +72,7 @@ class InstalledPackagesScoperTest extends TestCase
 
         $prefix = 'Foo';
         $patchers = [create_fake_patcher()];
-        $whitelist = Whitelist::create('Foo');
+        $whitelist = Whitelist::create(true, 'Foo');
 
         $actual = $scoper->scope($filePath, $fileContents, $prefix, $patchers, $whitelist);
 

--- a/tests/Scoper/Composer/JsonFileScoperTest.php
+++ b/tests/Scoper/Composer/JsonFileScoperTest.php
@@ -39,7 +39,7 @@ class JsonFileScoperTest extends TestCase
         $fileContents = '';
         $prefix = 'Humbug';
         $patchers = [create_fake_patcher()];
-        $whitelist = Whitelist::create('Foo');
+        $whitelist = Whitelist::create(true, 'Foo');
 
         /** @var Scoper|ObjectProphecy $decoratedScoperProphecy */
         $decoratedScoperProphecy = $this->prophesize(Scoper::class);
@@ -72,7 +72,7 @@ class JsonFileScoperTest extends TestCase
 
         $prefix = 'Foo';
         $patchers = [create_fake_patcher()];
-        $whitelist = Whitelist::create('Foo');
+        $whitelist = Whitelist::create(true, 'Foo');
 
         $actual = $scoper->scope($filePath, $fileContents, $prefix, $patchers, $whitelist);
 
@@ -146,7 +146,7 @@ JSON
 
         $prefix = 'Foo';
         $patchers = [create_fake_patcher()];
-        $whitelist = Whitelist::create('Foo');
+        $whitelist = Whitelist::create(true, 'Foo');
 
         $actual = $scoper->scope($filePath, $fileContents, $prefix, $patchers, $whitelist);
 

--- a/tests/Scoper/NullScoperTest.php
+++ b/tests/Scoper/NullScoperTest.php
@@ -38,7 +38,7 @@ class NullScoperTest extends TestCase
 
         $patchers = [create_fake_patcher()];
 
-        $whitelist = Whitelist::create('Foo');
+        $whitelist = Whitelist::create(true, 'Foo');
 
         $scoper = new NullScoper();
 

--- a/tests/Scoper/PatchScoperTest.php
+++ b/tests/Scoper/PatchScoperTest.php
@@ -73,7 +73,7 @@ class PatchScoperTest extends TestCase
             },
         ];
 
-        $whitelist = Whitelist::create('Foo');
+        $whitelist = Whitelist::create(true, 'Foo');
 
         $this->decoratedScoperProphecy
             ->scope($filePath, $contents, $prefix, $patchers, $whitelist)

--- a/tests/Scoper/PhpScoperTest.php
+++ b/tests/Scoper/PhpScoperTest.php
@@ -450,10 +450,12 @@ PHP;
 
         $actual = $this->scoper->scope($filePath, $contents, $prefix, $patchers, $whitelist);
 
-        $formatedWhitelist = 0 === count($whitelist)
+        $formattedWhitelist = 0 === count($whitelist)
             ? '[]'
             : sprintf('[%s]', implode(', ', $whitelist->toArray()))
         ;
+
+        $formattedWhitelistGlobalConstants = $whitelist->whitelistGlobalConstants() ? 'true' : 'false';
 
         $titleSeparator = str_repeat(
             '=',
@@ -474,7 +476,8 @@ $spec
 
 $titleSeparator
 INPUT
-whitelist: $formatedWhitelist
+whitelist: $formattedWhitelist
+whitelist global constants: $formattedWhitelistGlobalConstants
 $titleSeparator
 $contents
 

--- a/tests/Scoper/PhpScoperTest.php
+++ b/tests/Scoper/PhpScoperTest.php
@@ -156,7 +156,7 @@ class PhpScoperTest extends TestCase
         $prefix = 'Humbug';
         $filePath = 'file.php';
         $patchers = [create_fake_patcher()];
-        $whitelist = Whitelist::create('Foo');
+        $whitelist = Whitelist::create(true, 'Foo');
 
         $contents = <<<'PHP'
 <?php
@@ -184,7 +184,7 @@ PHP;
         $fileContents = '';
         $prefix = 'Humbug';
         $patchers = [create_fake_patcher()];
-        $whitelist = Whitelist::create('Foo');
+        $whitelist = Whitelist::create(true, 'Foo');
 
         $this->decoratedScoperProphecy
             ->scope($filePath, $fileContents, $prefix, $patchers, $whitelist)
@@ -216,7 +216,7 @@ PHP;
         $prefix = 'Humbug';
         $filePath = 'file';
         $patchers = [create_fake_patcher()];
-        $whitelist = Whitelist::create('Foo');
+        $whitelist = Whitelist::create(true, 'Foo');
 
         $contents = <<<'PHP'
 <?php
@@ -244,7 +244,7 @@ PHP;
         $prefix = 'Humbug';
         $filePath = 'hello';
         $patchers = [create_fake_patcher()];
-        $whitelist = Whitelist::create('Foo');
+        $whitelist = Whitelist::create(true, 'Foo');
 
         $contents = <<<'PHP'
 #!/usr/bin/env php
@@ -275,7 +275,7 @@ PHP;
 
         $patchers = [create_fake_patcher()];
 
-        $whitelist = Whitelist::create('Foo');
+        $whitelist = Whitelist::create(true, 'Foo');
 
         $contents = <<<'PHP'
 #!/usr/bin/env bash
@@ -321,7 +321,7 @@ PHP;
 
         $prefix = 'Humbug';
         $patchers = [create_fake_patcher()];
-        $whitelist = Whitelist::create('Foo');
+        $whitelist = Whitelist::create(true, 'Foo');
 
         try {
             $this->scoper->scope($filePath, $contents, $prefix, $patchers, $whitelist);
@@ -346,7 +346,7 @@ PHP;
 
         $prefix = 'Humbug';
         $patchers = [create_fake_patcher()];
-        $whitelist = Whitelist::create('Foo');
+        $whitelist = Whitelist::create(true, 'Foo');
 
         $this->decoratedScoperProphecy
             ->scope(Argument::any(), Argument::any(), $prefix, $patchers, $whitelist)
@@ -552,7 +552,10 @@ OUTPUT
             $spec,
             $payloadParts[0],   // Input
             $fixtureSet['prefix'] ?? $meta['prefix'],
-            Whitelist::create(...($fixtureSet['whitelist'] ?? $meta['whitelist'])),
+            Whitelist::create(
+                $fixtureSet['whitelist-global-constants'] ?? $meta['whitelist-global-constants'],
+                ...($fixtureSet['whitelist'] ?? $meta['whitelist'])
+            ),
             $payloadParts[1],   // Expected output
         ];
     }

--- a/tests/WhitelistTest.php
+++ b/tests/WhitelistTest.php
@@ -30,7 +30,7 @@ class WhitelistTest extends TestCase
         array $expectedClasses,
         array $expectedNamespaces
     ) {
-        $whitelistObject = Whitelist::create(...$whitelist);
+        $whitelistObject = Whitelist::create(true, ...$whitelist);
 
         $whitelistReflection = new ReflectionClass(Whitelist::class);
 
@@ -40,6 +40,14 @@ class WhitelistTest extends TestCase
         $whitelistNamespaceReflection->setAccessible(true);
         $actualNamespaces = $whitelistNamespaceReflection->getValue($whitelistObject);
 
+        $this->assertTrue($whitelistObject->whitelistGlobalConstants());
+        $this->assertSame($expectedClasses, $actualClasses);
+        $this->assertSame($expectedNamespaces, $actualNamespaces);
+
+
+        $whitelistObject = Whitelist::create(false, ...$whitelist);
+
+        $this->assertFalse($whitelistObject->whitelistGlobalConstants());
         $this->assertSame($expectedClasses, $actualClasses);
         $this->assertSame($expectedNamespaces, $actualNamespaces);
     }
@@ -94,37 +102,37 @@ class WhitelistTest extends TestCase
     public function provideClassWhitelists()
     {
         yield [
-            Whitelist::create(),
+            Whitelist::create(true),
             'Acme\Foo',
             false,
         ];
 
         yield [
-            Whitelist::create('Acme\Foo'),
+            Whitelist::create(true, 'Acme\Foo'),
             'Acme\Foo',
             true,
         ];
 
         yield [
-            Whitelist::create('Acme\Foo'),
+            Whitelist::create(true, 'Acme\Foo'),
             'Acme\Foo\Bar',
             false,
         ];
 
         yield [
-            Whitelist::create('Acme\Foo'),
+            Whitelist::create(true, 'Acme\Foo'),
             'Acme',
             false,
         ];
 
         yield [
-            Whitelist::create('Acme'),
+            Whitelist::create(true, 'Acme'),
             'Acme',
             true,
         ];
 
         yield [
-            Whitelist::create('Acme\*'),
+            Whitelist::create(true, 'Acme\*'),
             'Acme',
             false,
         ];
@@ -133,37 +141,37 @@ class WhitelistTest extends TestCase
     public function provideNamespaceWhitelists()
     {
         yield [
-            Whitelist::create(),
+            Whitelist::create(true),
             'Acme\Foo',
             false,
         ];
 
         yield [
-            Whitelist::create('Acme\Foo\*'),
+            Whitelist::create(true, 'Acme\Foo\*'),
             'Acme\Foo',
             true,
         ];
 
         yield [
-            Whitelist::create('Acme\*'),
+            Whitelist::create(true, 'Acme\*'),
             'Acme\Foo',
             true,
         ];
 
         yield [
-            Whitelist::create('Acme\Foo\*'),
+            Whitelist::create(true, 'Acme\Foo\*'),
             'Acme\Foo\Bar',
             true,
         ];
 
         yield [
-            Whitelist::create('\*'),
+            Whitelist::create(true, '\*'),
             'Acme',
             true,
         ];
 
         yield [
-            Whitelist::create('\*'),
+            Whitelist::create(true, '\*'),
             'Acme\Foo',
             true,
         ];
@@ -172,47 +180,47 @@ class WhitelistTest extends TestCase
     public function provideWhitelistToConvert()
     {
         yield [
-            Whitelist::create(),
+            Whitelist::create(true),
             [],
         ];
 
         yield [
-            Whitelist::create('Acme\Foo'),
+            Whitelist::create(true, 'Acme\Foo'),
             ['Acme\Foo'],
         ];
 
         yield [
-            Whitelist::create('\Acme\Foo'),
+            Whitelist::create(true, '\Acme\Foo'),
             ['Acme\Foo'],
         ];
 
         yield [
-            Whitelist::create('Acme\Foo\*'),
+            Whitelist::create(true, 'Acme\Foo\*'),
             ['Acme\Foo\*'],
         ];
 
         yield [
-            Whitelist::create('\Acme\Foo\*'),
+            Whitelist::create(true, '\Acme\Foo\*'),
             ['Acme\Foo\*'],
         ];
 
         yield [
-            Whitelist::create('*'),
+            Whitelist::create(true, '*'),
             ['*'],
         ];
 
         yield [
-            Whitelist::create('\*'),
+            Whitelist::create(true, '\*'),
             ['*'],
         ];
 
         yield [
-            Whitelist::create('Acme', 'Acme\Foo', 'Acme\Foo\*', '*'),
+            Whitelist::create(true, 'Acme', 'Acme\Foo', 'Acme\Foo\*', '*'),
             ['Acme', 'Acme\Foo', 'Acme\Foo\*', '*'],
         ];
 
         yield [
-            Whitelist::create('Acme', 'Acme'),
+            Whitelist::create(true, 'Acme', 'Acme'),
             ['Acme'],
         ];
     }


### PR DESCRIPTION
Closes #175

**BC Break:** constants from the global namespace are now whitelisted by default