### PR TITLE
Ensure string literals in define statements are properly prefixed

### DIFF
--- a/specs/string-literal/define.php
+++ b/specs/string-literal/define.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the humbug/php-scoper package.
+ *
+ * Copyright (c) 2017 Théo FIDRY <theo.fidry@gmail.com>,
+ *                    Pádraic Brady <padraic.brady@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+return [
+    'meta' => [
+        'title' => 'String literal assigned as a constant declared with `define()`',
+        // Default values. If not specified will be the one used
+        'prefix' => 'Humbug',
+        'whitelist' => [],
+        'whitelist-global-constants' => true,
+    ],
+
+    'FQCN string argument: transform into a FQCN and prefix it' => <<<'PHP'
+<?php
+
+define('X', 'Symfony\\Component\\Yaml\\Yaml');
+define('X', '\\Symfony\\Component\\Yaml\\Yaml');
+define('X', 'Humbug\\Symfony\\Component\\Yaml\\Yaml');
+define('X', '\\Humbug\\Symfony\\Component\\Yaml\\Yaml');
+
+----
+<?php
+
+namespace Humbug;
+
+\define('X', 'Humbug\\Symfony\\Component\\Yaml\\Yaml');
+\define('X', 'Humbug\\Symfony\\Component\\Yaml\\Yaml');
+\define('X', 'Humbug\\Symfony\\Component\\Yaml\\Yaml');
+\define('X', 'Humbug\\Symfony\\Component\\Yaml\\Yaml');
+
+PHP
+    ,
+];


### PR DESCRIPTION
Closes #209

The remaining cases are checked by the other tests in `specs/string-literal/`