### PR TITLE
Fixed docs about prefixing

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,8 +144,8 @@ return [
 
 ### Prefix
 
-The prefix to be used to isolate the code. If `null` or `'''` is given, then a random
-prefix will be automatically be generated.
+The prefix to be used to isolate the code. If `null` or `''` (empty string) is given,
+then a random prefix will be automatically be generated.
 
 
 ### Finders and paths

--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ return [
 ### Prefix
 
 The prefix to be used to isolate the code. If `null` or `''` (empty string) is given,
-then a random prefix will be automatically be generated.
+then a random prefix will be automatically generated.
 
 
 ### Finders and paths


### PR DESCRIPTION
Use correct representation of empty string, removed duplicated word.