### PR TITLE
Remove usages of 'spec' in the specifications

### DIFF
--- a/specs/binary/simple.php
+++ b/specs/binary/simple.php
@@ -22,7 +22,7 @@ return [
         'whitelist-global-functions' => true,
     ],
 
-    'some statements made directly in the global namespace: wrap them in a namespace statement' => <<<'PHP'
+    'Some statements made directly in the global namespace' => <<<'PHP'
 <?php declare(strict_types=1);
 
 /*
@@ -66,7 +66,7 @@ if (\false) {
 PHP
     ,
 
-    'some statements made directly in the global namespace with a shebang: wrap them in a namespace statement' => <<<'PHP'
+    'Some statements made directly in the global namespace with a shebang' => <<<'PHP'
 #!/usr/bin/env php
 <?php declare(strict_types=1);
 

--- a/specs/class-FQ.php
+++ b/specs/class-FQ.php
@@ -22,14 +22,7 @@ return [
         'whitelist-global-functions' => true,
     ],
 
-    [
-        'spec' => <<<'SPEC'
-Different kind of whitelisted class constant calls in the global scope:
-- prefix the whitelisted classes and append their class aliases
-- transforms the call into a FQ
-- resolve the aliases
-SPEC
-        ,
+    'Different kind of whitelisted class constant calls in the global scope' => [
         'whitelist' => ['Foo\Bar', 'Foo\Bar\Poz'],
         'payload' => <<<'PHP'
 <?php
@@ -105,15 +98,7 @@ use Humbug\Foo\Bar\Poz as Z;
 PHP
     ],
 
-    [
-        'spec' => <<<'SPEC'
-Different kind of class constant calls in the global scope:
-- prefix the whitelisted classes and append their class aliases
-- transforms the call into a FQ
-- resolve the aliases
-SPEC
-        ,
-        'payload' => <<<'PHP'
+    'Different kind of class constant calls in the global scope' => <<<'PHP'
 <?php
 
 namespace {
@@ -182,16 +167,9 @@ use Humbug\Foo\Bar\Poz as Z;
 \Humbug\Foo\Bar\Poz::MAIN_CONST;
 
 PHP
-    ],
+    ,
 
-    [
-        'spec' => <<<'SPEC'
-Different kind of class constant calls in a namespace:
-- prefix the whitelisted classes and append their class aliases
-- transforms the call into a FQ
-- resolve the aliases
-SPEC
-        ,
+    'Different kind of class constant calls in a namespace' => [
         'whitelist' => [
             'Foo\Bar',
             'Foo\Bar\Poz',

--- a/specs/class-const/global-scope-single-level.php
+++ b/specs/class-const/global-scope-single-level.php
@@ -42,7 +42,7 @@ class Command
 PHP
     ],
 
-    'Constant call on a class belonging to the global namespace which is whitelisted: add root namespace statement' => [
+    'Constant call on a class belonging to the global namespace which is whitelisted' => [
         'whitelist' => ['\*'],
         'payload' => <<<'PHP'
 <?php

--- a/specs/class-static-prop/global-scope-single-level-with-single-level-use-statement-and-alias.php
+++ b/specs/class-static-prop/global-scope-single-level-with-single-level-use-statement-and-alias.php
@@ -22,14 +22,7 @@ return [
         'whitelist-global-functions' => true,
     ],
 
-    [
-        'spec' => <<<'SPEC'
-Constant call on a aliased class which is imported via an aliased use statement and which belongs to the global namespace:
-- prefix the use statement (cf. class belonging to the global scope tests)
-- prefix the constant
-SPEC
-        ,
-        'payload' => <<<'PHP'
+    'Constant call on a aliased class which is imported via an aliased use statement and which belongs to the global namespace' => <<<'PHP'
 <?php
 
 class Foo {}
@@ -49,16 +42,9 @@ use Humbug\Foo as X;
 \Humbug\Foo::$mainStaticProp;
 
 PHP
-    ],
+    ,
 
-    [
-        'spec' => <<<'SPEC'
-FQ constant call on a aliased class which is imported via an aliased use statement and which belongs to the global namespace:
-- do not prefix the class (cf. class belonging to the global scope tests)
-- do nothing
-SPEC
-        ,
-        'payload' => <<<'PHP'
+    'FQ constant call on a aliased class which is imported via an aliased use statement and which belongs to the global namespace' => <<<'PHP'
 <?php
 
 class Foo {}
@@ -82,16 +68,9 @@ use Humbug\Foo as X;
 \Humbug\X::$mainStaticProp;
 
 PHP
-    ],
+    ,
 
-    [
-        'spec' => <<<'SPEC'
-Constant call on a whitelisted class which is imported via an aliased use statement and which belongs to the global namespace:
-- prefix the use statement (cf. class belonging to the global scope tests and `scope.inc.php` for the built-in global whitelisted classes)
-- transform the call into a FQ call
-SPEC
-        ,
-        'payload' => <<<'PHP'
+    'Constant call on a whitelisted class which is imported via an aliased use statement and which belongs to the global namespace' => <<<'PHP'
 <?php
 
 use Reflector as X;
@@ -106,16 +85,9 @@ use Reflector as X;
 \Reflector::$mainStaticProp;
 
 PHP
-    ],
+    ,
 
-    [
-        'spec' => <<<'SPEC'
-FQ constant call on a whitelisted class which is imported via an aliased use statement and which belongs to the global namespace:
-- prefix the use statement (cf. class belonging to the global scope tests and `scope.inc.php` for the built-in global whitelisted classes)
-- do nothing
-SPEC
-        ,
-        'payload' => <<<'PHP'
+    'FQ constant call on a whitelisted class which is imported via an aliased use statement and which belongs to the global namespace' => <<<'PHP'
 <?php
 
 class X {}
@@ -135,5 +107,5 @@ use Reflector as X;
 \Humbug\X::$mainStaticProp;
 
 PHP
-    ],
+    ,
 ];

--- a/specs/class-static-prop/global-scope-single-level-with-single-level-use-statement.php
+++ b/specs/class-static-prop/global-scope-single-level-with-single-level-use-statement.php
@@ -22,14 +22,7 @@ return [
         'whitelist-global-functions' => true,
     ],
 
-    [
-        'spec' => <<<'SPEC'
-Constant call on a class which is imported via a use statement and which belongs to the global namespace:
-- do not prefix the use statement (cf. class belonging to the global scope tests)
-- transforms the call into a FQ call
-SPEC
-        ,
-        'payload' => <<<'PHP'
+    'Constant call on a class which is imported via a use statement and which belongs to the global namespace' => <<<'PHP'
 <?php
 
 class Command {}
@@ -49,16 +42,9 @@ use Humbug\Command;
 \Humbug\Command::$mainStaticProp;
 
 PHP
-    ],
+    ,
 
-    [
-        'spec' => <<<'SPEC'
-FQ constant call on a class which is imported via a use statement and which belongs to the global namespace:
-- do not prefix the use statement (cf. class belonging to the global scope tests)
-- do nothing
-SPEC
-        ,
-        'payload' => <<<'PHP'
+    'FQ constant call on a class which is imported via a use statement and which belongs to the global namespace' => <<<'PHP'
 <?php
 
 class Command {}
@@ -78,16 +64,9 @@ use Humbug\Command;
 \Humbug\Command::$mainStaticProp;
 
 PHP
-    ],
-
-    [
-        'spec' => <<<'SPEC'
-Constant call on a whitelisted class which is imported via a use statement and which belongs to the global namespace:
-- transform the call in a FQ call (cf. class belonging to the global scope tests and `scope.inc.php` for the built-in
-  global whitelisted classes)
-SPEC
     ,
-        'payload' => <<<'PHP'
+
+    'Constant call on a whitelisted class which is imported via a use statement and which belongs to the global namespace' => <<<'PHP'
 <?php
 
 use Reflector;
@@ -102,16 +81,9 @@ use Reflector;
 \Reflector::$mainStaticProp;
 
 PHP
-    ],
+    ,
 
-    [
-        'spec' => <<<'SPEC'
-FQ constant call on a whitelisted class which is imported via a use statement and which belongs to the global namespace:
-- prefix the class (cf. class belonging to the global scope tests and `scope.inc.php` for the built-in global
-  whitelisted classes)
-SPEC
-        ,
-        'payload' => <<<'PHP'
+    'FQ constant call on a whitelisted class which is imported via a use statement and which belongs to the global namespace' => <<<'PHP'
 <?php
 
 use Reflector;
@@ -126,5 +98,5 @@ use Reflector;
 \Reflector::$mainStaticProp;
 
 PHP
-    ],
+    ,
 ];

--- a/specs/class-static-prop/global-scope-single-level.php
+++ b/specs/class-static-prop/global-scope-single-level.php
@@ -22,14 +22,7 @@ return [
         'whitelist-global-functions' => true,
     ],
 
-    [
-        'spec' => <<<'SPEC'
-Constant call on a class belonging to the global namespace:
-- do not prefix the class (cf. class belonging to the global scope tests)
-- transforms the call into a FQ call to avoid autoloading issues
-SPEC
-        ,
-        'payload' => <<<'PHP'
+    'Constant call on a class belonging to the global namespace' => <<<'PHP'
 <?php
 
 class Command {}
@@ -46,9 +39,9 @@ class Command
 \Humbug\Command::$mainStaticProp;
 
 PHP
-    ],
+    ,
 
-    'Constant call on a class belonging to the global namespace which is whitelisted: add root namespace statement' => [
+    'Constant call on a class belonging to the global namespace which is whitelisted' => [
         'whitelist' => ['\*'],
         'payload' => <<<'PHP'
 <?php
@@ -69,14 +62,7 @@ namespace {
 PHP
     ],
 
-    [
-        'spec' => <<<'SPEC'
-FQ constant call on a class belonging to the global namespace:
-- do not prefix the class (cf. class belonging to the global scope tests)
-- do not touch the call
-SPEC
-        ,
-        'payload' => <<<'PHP'
+    'FQ constant call on a class belonging to the global namespace' => <<<'PHP'
 <?php
 
 class Command {}
@@ -93,16 +79,9 @@ class Command
 \Humbug\Command::$mainStaticProp;
 
 PHP
-    ],
+    ,
 
-    [
-        'spec' => <<<'SPEC'
-Constant call on a whitelisted class belonging to the global namespace:
-- prefix the class (cf. class belonging to the global scope tests and `scope.inc.php` for the built-in global whitelisted classes)
-- transforms the call into a FQ call to avoid autoloading issues
-SPEC
-        ,
-        'payload' => <<<'PHP'
+    'Constant call on a whitelisted class belonging to the global namespace' => <<<'PHP'
 <?php
 
 Reflector::$mainStaticProp;
@@ -114,16 +93,9 @@ namespace Humbug;
 \Reflector::$mainStaticProp;
 
 PHP
-    ],
+    ,
 
-    [
-        'spec' => <<<'SPEC'
-FQ constant call on a whitelisted class belonging to the global namespace:
-- prefix the class (cf. class belonging to the global scope tests and `scope.inc.php` for the built-in global whitelisted classes)
-- transforms the call into a FQ call to avoid autoloading issues
-SPEC
-        ,
-        'payload' => <<<'PHP'
+    'FQ constant call on a whitelisted class belonging to the global namespace' => <<<'PHP'
 <?php
 
 \Reflector::$mainStaticProp;
@@ -135,5 +107,5 @@ namespace Humbug;
 \Reflector::$mainStaticProp;
 
 PHP
-    ],
+    ,
 ];

--- a/specs/class-static-prop/global-scope-two-level-with-single-level-use-and-alias.php
+++ b/specs/class-static-prop/global-scope-two-level-with-single-level-use-and-alias.php
@@ -22,14 +22,7 @@ return [
         'whitelist-global-functions' => true,
     ],
 
-    [
-        'spec' => <<<'SPEC'
-Constant call on a namespaced class partially imported with an aliased use statement:
-- prefix the class only (not the use statement)
-- transforms the call into a FQ call to avoid autoloading issues
-SPEC
-        ,
-        'payload' => <<<'PHP'
+    'Constant call on a namespaced class partially imported with an aliased use statement' => <<<'PHP'
 <?php
 
 namespace {
@@ -64,16 +57,9 @@ use Humbug\Foo as X;
 \Humbug\Foo\Bar::$mainStaticProp;
 
 PHP
-    ],
+    ,
 
-    [
-        'spec' => <<<'SPEC'
-Constant call on a namespaced class imported with an aliased use statement:
-- prefix the use statement
-- transform the call into a FQ call
-SPEC
-        ,
-        'payload' => <<<'PHP'
+    'Constant call on a namespaced class imported with an aliased use statement' => <<<'PHP'
 <?php
 
 namespace Foo {
@@ -99,15 +85,9 @@ use Humbug\Foo\Bar as X;
 \Humbug\Foo\Bar::$mainStaticProp;
 
 PHP
-    ],
+    ,
 
-    [
-        'spec' => <<<'SPEC'
-FQ constant call on a namespaced class imported with an aliased use statement:
-- prefix the class only (not the use statement, cf. tests related to classes belonging to the global namespace)
-SPEC
-        ,
-        'payload' => <<<'PHP'
+    'FQ constant call on a namespaced class imported with an aliased use statement' => <<<'PHP'
 <?php
 
 namespace {
@@ -142,15 +122,9 @@ use Humbug\Foo as X;
 \Humbug\X\Bar::$mainStaticProp;
 
 PHP
-    ],
+    ,
 
-    [
-        'spec' => <<<'SPEC'
-FQ Constant call on a whitelisted namespaced class partially imported with an aliased use statement:
-- do not prefix the class neither the use statement
-- transforms the call into a FQ call to avoid autoloading issues
-SPEC
-        ,
+    'FQ Constant call on a whitelisted namespaced class partially imported with an aliased use statement' => [
         'whitelist' => ['Foo\Bar'],
         'payload' => <<<'PHP'
 <?php
@@ -190,12 +164,7 @@ use Humbug\Foo as X;
 PHP
     ],
 
-    [
-        'spec' => <<<'SPEC'
-FQ constant call on a whitelisted namespaced class imported with an aliased use statement:
-- prefix the class only (not the use statement, cf. tests related to classes belonging to the global namespace)
-SPEC
-        ,
+    'FQ constant call on a whitelisted namespaced class imported with an aliased use statement' => [
         'whitelist' => ['Foo\Bar'],
         'payload' => <<<'PHP'
 <?php

--- a/specs/class-static-prop/global-scope-two-level-with-single-level-use.php
+++ b/specs/class-static-prop/global-scope-two-level-with-single-level-use.php
@@ -22,14 +22,7 @@ return [
         'whitelist-global-functions' => true,
     ],
 
-    [
-        'spec' => <<<'SPEC'
-Constant call on a namespaced class partially imported with a use statement:
-- prefix the class only (not the use statement)
-- transforms the call into a FQ call to avoid autoloading issues
-SPEC
-        ,
-        'payload' => <<<'PHP'
+    'Constant call on a namespaced class partially imported with a use statement' => <<<'PHP'
 <?php
 
 namespace {
@@ -64,16 +57,9 @@ use Humbug\Foo;
 \Humbug\Foo\Bar::$mainStaticProp;
 
 PHP
-    ],
+    ,
 
-    [
-        'spec' => <<<'SPEC'
-Constant call on a namespaced class imported with a use statement:
-- prefix the use statement
-- transform the call into a FQ call
-SPEC
-        ,
-        'payload' => <<<'PHP'
+    'Constant call on a namespaced class imported with a use statement' => <<<'PHP'
 <?php
 
 namespace Foo {
@@ -108,16 +94,9 @@ use Humbug\Foo\Bar;
 \Humbug\Foo\Bar\X::$mainStaticProp;
 
 PHP
-    ],
+    ,
 
-    [
-        'spec' => <<<'SPEC'
-FQ constant call on a namespaced class imported with a use statement:
-- prefix the class only (not the use statement)
-- transforms the call into a FQ call to avoid autoloading issues
-SPEC
-        ,
-        'payload' => <<<'PHP'
+    'FQ constant call on a namespaced class imported with a use statement' =>  <<<'PHP'
 <?php
 
 namespace {
@@ -152,15 +131,9 @@ use Humbug\Foo;
 \Humbug\Foo\Bar::$mainStaticProp;
 
 PHP
-    ],
+    ,
 
-    [
-        'spec' => <<<'SPEC'
-FQ Constant call on a whitelisted namespaced class partially imported with a use statement:
-- do not prefix the class neither the use statement
-- transforms the call into a FQ call to avoid autoloading issues
-SPEC
-        ,
+    'FQ Constant call on a whitelisted namespaced class partially imported with a use statement' => [
         'whitelist' => ['Foo\Bar'],
         'payload' => <<<'PHP'
 <?php
@@ -200,13 +173,7 @@ use Humbug\Foo;
 PHP
     ],
 
-    [
-        'spec' => <<<'SPEC'
-FQ constant call on a whitelisted namespaced class imported with a use statement:
-- prefix the class only (not the use statement)
-- transforms the call into a FQ call to avoid autoloading issues
-SPEC
-        ,
+    'FQ constant call on a whitelisted namespaced class imported with a use statement' => [
         'whitelist' => ['Foo\Bar'],
         'payload' => <<<'PHP'
 <?php

--- a/specs/class-static-prop/global-scope-two-level-with-single-level-use.php
+++ b/specs/class-static-prop/global-scope-two-level-with-single-level-use.php
@@ -96,7 +96,7 @@ use Humbug\Foo\Bar;
 PHP
     ,
 
-    'FQ constant call on a namespaced class imported with a use statement' =>  <<<'PHP'
+    'FQ constant call on a namespaced class imported with a use statement' => <<<'PHP'
 <?php
 
 namespace {

--- a/specs/class-static-prop/global-scope-two-level.php
+++ b/specs/class-static-prop/global-scope-two-level.php
@@ -22,14 +22,7 @@ return [
         'whitelist-global-functions' => true,
     ],
 
-    [
-        'spec' => <<<'SPEC'
-Constant call on a namespaced class:
-- prefix the class
-- transforms the call into a FQ call to avoid autoloading issues
-SPEC
-        ,
-        'payload' => <<<'PHP'
+    'Constant call on a namespaced class' => <<<'PHP'
 <?php
 
 namespace PHPUnit {
@@ -52,16 +45,9 @@ namespace Humbug;
 \Humbug\PHPUnit\Command::$mainStaticProp;
 
 PHP
-    ],
+    ,
 
-    [
-        'spec' => <<<'SPEC'
-FQ constant call on a namespaced class:
-- prefix the class
-- transforms the call into a FQ call to avoid autoloading issues
-SPEC
-        ,
-        'payload' => <<<'PHP'
+    'FQ constant call on a namespaced class' => <<<'PHP'
 <?php
 
 namespace PHPUnit {
@@ -84,15 +70,9 @@ namespace Humbug;
 \Humbug\PHPUnit\Command::$mainStaticProp;
 
 PHP
-    ],
+    ,
 
-    [
-        'spec' => <<<'SPEC'
-Constant call on a whitelisted namespaced class:
-- do not prefix the class
-- transforms the call into a FQ call to avoid autoloading issues
-SPEC
-        ,
+    'Constant call on a whitelisted namespaced class' => [
         'whitelist' => ['PHPUnit\Command'],
         'payload' => <<<'PHP'
 <?php
@@ -120,13 +100,7 @@ namespace Humbug;
 PHP
     ],
 
-    [
-        'spec' => <<<'SPEC'
-FQ constant call on a whitelisted namespaced class:
-- do not prefix the class
-- transforms the call into a FQ call to avoid autoloading issues
-SPEC
-        ,
+    'FQ constant call on a whitelisted namespaced class' => [
         'whitelist' => ['PHPUnit\Command'],
         'payload' => <<<'PHP'
 <?php

--- a/specs/class-static-prop/namespace-scope-single-level-with-single-level-use-statement-and-alias.php
+++ b/specs/class-static-prop/namespace-scope-single-level-with-single-level-use-statement-and-alias.php
@@ -22,15 +22,7 @@ return [
         'whitelist-global-functions' => true,
     ],
 
-    [
-        'spec' => <<<'SPEC'
-Constant call on a aliased class which is imported via an aliased use statement and which belongs to the global namespace:
-- prefix the namespace
-- do not prefix the use statement (cf. class belonging to the global scope tests)
-- transform the call into a FQ call
-SPEC
-        ,
-        'payload' => <<<'PHP'
+    'Constant call on a aliased class which is imported via an aliased use statement and which belongs to the global namespace' => <<<'PHP'
 <?php
 
 namespace {
@@ -56,16 +48,9 @@ use Humbug\Foo as X;
 \Humbug\Foo::$mainStaticProp;
 
 PHP
-    ],
+    ,
 
-    [
-        'spec' => <<<'SPEC'
-FQ constant call on a aliased class which is imported via an aliased use statement and which belongs to the global namespace:
-- prefix the namespace
-- do not prefix the class (cf. class belonging to the global scope tests)
-SPEC
-        ,
-        'payload' => <<<'PHP'
+    'FQ constant call on a aliased class which is imported via an aliased use statement and which belongs to the global namespace' => <<<'PHP'
 <?php
 
 namespace {
@@ -95,17 +80,9 @@ use Humbug\Foo as X;
 \Humbug\X::$mainStaticProp;
 
 PHP
-    ],
+    ,
 
-    [
-        'spec' => <<<'SPEC'
-Constant call on a whitelisted class which is imported via an aliased use statement and which belongs to the global namespace:
-- prefix the namespace
-- prefix the use statement (cf. class belonging to the global scope tests and `scope.inc.php` for the built-in global whitelisted classes)
-- transform the call into a FQ call
-SPEC
-        ,
-        'payload' => <<<'PHP'
+    'Constant call on a whitelisted class which is imported via an aliased use statement and which belongs to the global namespace' => <<<'PHP'
 <?php
 
 namespace A;
@@ -122,17 +99,9 @@ use Reflector as X;
 \Reflector::$mainStaticProp;
 
 PHP
-    ],
+    ,
 
-    [
-        'spec' => <<<'SPEC'
-FQ constant call on a whitelisted class which is imported via an aliased use statement and which belongs to the global namespace:
-- prefix the namespace
-- prefix the use statement (cf. class belonging to the global scope tests and `scope.inc.php` for the built-in global whitelisted classes)
-- do not touch the call
-SPEC
-        ,
-        'payload' => <<<'PHP'
+    'FQ constant call on a whitelisted class which is imported via an aliased use statement and which belongs to the global namespace' => <<<'PHP'
 <?php
 
 namespace {
@@ -158,5 +127,5 @@ use Reflector as X;
 \Humbug\X::$mainStaticProp;
 
 PHP
-    ],
+    ,
 ];

--- a/specs/class-static-prop/namespace-scope-single-level.php
+++ b/specs/class-static-prop/namespace-scope-single-level.php
@@ -22,14 +22,7 @@ return [
         'whitelist-global-functions' => true,
     ],
 
-    [
-        'spec' => <<<'SPEC'
-Constant call on a class belonging to the global namespace or the current namespace:
-- prefix the namespace
-- transform the call into a FQ call
-SPEC
-        ,
-        'payload' => <<<'PHP'
+    'Constant call on a class belonging to the global namespace or the current namespace' => <<<'PHP'
 <?php
 
 namespace X;
@@ -48,16 +41,9 @@ class Command
 \Humbug\X\Command::$mainStaticProp;
 
 PHP
-    ],
+    ,
 
-    [
-        'spec' => <<<'SPEC'
-FQ constant call on a class belonging to the global namespace or the current namespace:
-- prefix the namespace
-- do not touch the call
-SPEC
-        ,
-        'payload' => <<<'PHP'
+    'FQ constant call on a class belonging to the global namespace or the current namespace' => <<<'PHP'
 <?php
 
 namespace {
@@ -80,16 +66,9 @@ namespace Humbug\X;
 \Humbug\Command::$mainStaticProp;
 
 PHP
-    ],
+    ,
 
-    [
-        'spec' => <<<'SPEC'
-Constant call on a whitelisted class belonging to the global namespace:
-- prefix the namespace
-- transforms the call into a FQ call to avoid autoloading issues
-SPEC
-        ,
-        'payload' => <<<'PHP'
+    'Constant call on a whitelisted class belonging to the global namespace' => <<<'PHP'
 <?php
 
 namespace X;
@@ -106,5 +85,5 @@ use Reflector;
 \Reflector::$mainStaticProp;
 
 PHP
-    ],
+    ,
 ];

--- a/specs/class-static-prop/namespace-scope-two-level-with-single-level-use-and-alias.php
+++ b/specs/class-static-prop/namespace-scope-two-level-with-single-level-use-and-alias.php
@@ -22,15 +22,7 @@ return [
         'whitelist-global-functions' => true,
     ],
 
-    [
-        'spec' => <<<'SPEC'
-Constant call on a namespaced class partially imported with an aliased use statement:
-- prefix the namespace
-- prefix the class only (not the use statement)
-- transforms the call into a FQ call to avoid autoloading issues
-SPEC
-        ,
-        'payload' => <<<'PHP'
+    'Constant call on a namespaced class partially imported with an aliased use statement' => <<<'PHP'
 <?php
 
 namespace {
@@ -65,17 +57,9 @@ use Humbug\Foo as X;
 \Humbug\Foo\Bar::$mainStaticProp;
 
 PHP
-    ],
+    ,
 
-    [
-        'spec' => <<<'SPEC'
-Constant call on a namespaced class imported with an aliased use statement:
-- prefix the namespace
-- prefix the use statement
-- transform the call into a FQ call
-SPEC
-        ,
-        'payload' => <<<'PHP'
+    'Constant call on a namespaced class imported with an aliased use statement' => <<<'PHP'
 <?php
 
 namespace Foo {
@@ -101,16 +85,9 @@ use Humbug\Foo\Bar as X;
 \Humbug\Foo\Bar::$mainStaticProp;
 
 PHP
-    ],
+    ,
 
-    [
-        'spec' => <<<'SPEC'
-FQ constant call on a namespaced class imported with an aliased use statement:
-- prefix the namespace
-- prefix the class only (not the use statement, cf. tests related to classes from the global scope)
-SPEC
-        ,
-        'payload' => <<<'PHP'
+    'FQ constant call on a namespaced class imported with an aliased use statement' => <<<'PHP'
 <?php
 
 namespace {
@@ -145,16 +122,9 @@ use Humbug\Foo as X;
 \Humbug\X\Bar::$mainStaticProp;
 
 PHP
-    ],
+    ,
 
-    [
-        'spec' => <<<'SPEC'
-FQ Constant call on a whitelisted namespaced class partially imported with an aliased use statement:
-- prefix the namespace
-- do not prefix the class neither the use statement
-- transforms the call into a FQ call to avoid autoloading issues
-SPEC
-        ,
+    'FQ Constant call on a whitelisted namespaced class partially imported with an aliased use statement' => [
         'whitelist' => ['Foo\Bar'],
         'payload' => <<<'PHP'
 <?php

--- a/specs/class-static-prop/namespace-scope-two-level-with-single-level-use.php
+++ b/specs/class-static-prop/namespace-scope-two-level-with-single-level-use.php
@@ -22,15 +22,7 @@ return [
         'whitelist-global-functions' => true,
     ],
 
-    [
-        'spec' => <<<'SPEC'
-Constant call on a namespaced class partially imported with a use statement:
-- prefix the namespace
-- prefix the class only (not the use statement)
-- transforms the call into a FQ call to avoid autoloading issues
-SPEC
-        ,
-        'payload' => <<<'PHP'
+    'Constant call on a namespaced class partially imported with a use statement' => <<<'PHP'
 <?php
 
 namespace {
@@ -65,17 +57,9 @@ use Humbug\Foo;
 \Humbug\Foo\Bar::$mainStaticProp;
 
 PHP
-    ],
+    ,
 
-    [
-        'spec' => <<<'SPEC'
-Constant call on a namespaced class imported with a use statement:
-- prefix the namespace
-- prefix the use statement
-- transform the call into a FQ call
-SPEC
-        ,
-        'payload' => <<<'PHP'
+    'Constant call on a namespaced class imported with a use statement' => <<<'PHP'
 <?php
 
 namespace Foo {
@@ -110,17 +94,9 @@ use Humbug\Foo\Bar;
 \Humbug\Foo\Bar\X::$mainStaticProp;
 
 PHP
-    ],
+    ,
 
-    [
-        'spec' => <<<'SPEC'
-FQ constant call on a namespaced class imported with a use statement:
-- prefix the namespace
-- prefix the class only (not the use statement)
-- transforms the call into a FQ call to avoid autoloading issues
-SPEC
-        ,
-        'payload' => <<<'PHP'
+    'FQ constant call on a namespaced class imported with a use statement' => <<<'PHP'
 <?php
 
 namespace {
@@ -155,16 +131,9 @@ use Humbug\Foo;
 \Humbug\Foo\Bar::$mainStaticProp;
 
 PHP
-    ],
+    ,
 
-    [
-        'spec' => <<<'SPEC'
-FQ Constant call on a whitelisted namespaced class partially imported with a use statement:
-- prefix the namespace
-- do not prefix the class neither the use statement
-- transforms the call into a FQ call to avoid autoloading issues
-SPEC
-        ,
+    'FQ Constant call on a whitelisted namespaced class partially imported with a use statement' => [
         'whitelist' => ['Foo\Bar'],
         'payload' => <<<'PHP'
 <?php
@@ -204,14 +173,7 @@ use Humbug\Foo;
 PHP
     ],
 
-    [
-        'spec' => <<<'SPEC'
-FQ constant call on a whitelisted namespaced class imported with a use statement:
-- prefix the namespace
-- prefix the class only (not the use statement)
-- transforms the call into a FQ call to avoid autoloading issues
-SPEC
-        ,
+    'FQ constant call on a whitelisted namespaced class imported with a use statement' => [
         'whitelist' => ['Foo\Bar'],
         'payload' => <<<'PHP'
 <?php

--- a/specs/class-static-prop/namespace-scope-two-level.php
+++ b/specs/class-static-prop/namespace-scope-two-level.php
@@ -22,15 +22,7 @@ return [
         'whitelist-global-functions' => true,
     ],
 
-    [
-        'spec' => <<<'SPEC'
-Constant call on a namespaced class:
-- prefix the namespace
-- prefix the class
-- transforms the call into a FQ call to avoid autoloading issues
-SPEC
-        ,
-        'payload' => <<<'PHP'
+    'Constant call on a namespaced class' => <<<'PHP'
 <?php
 
 namespace X\PHPUnit {
@@ -53,17 +45,9 @@ namespace Humbug\X;
 \Humbug\X\PHPUnit\Command::$mainStaticProp;
 
 PHP
-    ],
+    ,
 
-    [
-        'spec' => <<<'SPEC'
-FQ constant call on a namespaced class:
-- prefix the namespace
-- prefix the class
-- transforms the call into a FQ call to avoid autoloading issues
-SPEC
-        ,
-        'payload' => <<<'PHP'
+    'FQ constant call on a namespaced class' => <<<'PHP'
 <?php
 
 namespace PHPUnit {
@@ -86,16 +70,9 @@ namespace Humbug\X;
 \Humbug\PHPUnit\Command::$mainStaticProp;
 
 PHP
-    ],
+    ,
 
-    [
-        'spec' => <<<'SPEC'
-Constant call on a whitelisted namespaced class:
-- prefix the namespace
-- do not prefix the class
-- transform the call into a FQ call
-SPEC
-        ,
+    'Constant call on a whitelisted namespaced class' => [
         'whitelist' => ['X\PHPUnit\Command'],
         'payload' => <<<'PHP'
 <?php
@@ -123,14 +100,7 @@ namespace Humbug\X;
 PHP
     ],
 
-    [
-        'spec' => <<<'SPEC'
-FQ constant call on a whitelisted namespaced class:
-- prefix the namespace
-- do not prefix the class
-- transforms the call into a FQ call to avoid autoloading issues
-SPEC
-        ,
+    'FQ constant call on a whitelisted namespaced class' => [
         'whitelist' => ['PHPUnit\Command'],
         'payload' => <<<'PHP'
 <?php

--- a/specs/class-static-prop/namespace-single-part-with-single-level-use-statement.php
+++ b/specs/class-static-prop/namespace-single-part-with-single-level-use-statement.php
@@ -22,15 +22,7 @@ return [
         'whitelist-global-functions' => true,
     ],
 
-    [
-        'spec' => <<<'SPEC'
-Constant call on a class which is imported via a use statement and which belongs to the global namespace:
-- prefix the namespace
-- do not prefix the use statement (cf. class belonging to the global scope tests)
-- transforms the call into a FQ call
-SPEC
-        ,
-        'payload' => <<<'PHP'
+    'Constant call on a class which is imported via a use statement and which belongs to the global namespace' => <<<'PHP'
 <?php
 
 namespace {
@@ -56,17 +48,9 @@ use Humbug\Foo;
 \Humbug\Foo::$mainStaticProp;
 
 PHP
-    ],
+    ,
 
-    [
-        'spec' => <<<'SPEC'
-FQ constant call on a class which is imported via a use statement and which belongs to the global namespace:
-- prefix the namespace
-- do not prefix the use statement (cf. class belonging to the global scope tests)
-- do nothing
-SPEC
-        ,
-        'payload' => <<<'PHP'
+    'FQ constant call on a class which is imported via a use statement and which belongs to the global namespace' => <<<'PHP'
 <?php
 
 namespace {
@@ -92,16 +76,9 @@ use Humbug\Command;
 \Humbug\Command::$mainStaticProp;
 
 PHP
-    ],
+    ,
 
-    [
-        'spec' => <<<'SPEC'
-Constant call on a whitelisted class which is imported via a use statement and which belongs to the global namespace:
-- prefix the namespace
-- transform the call in a FQ call (cf. class belonging to the global scope tests and `scope.inc.php` for the built-in global whitelisted classes)
-SPEC
-        ,
-        'payload' => <<<'PHP'
+    'Constant call on a whitelisted class which is imported via a use statement and which belongs to the global namespace' => <<<'PHP'
 <?php
 
 namespace X;
@@ -118,16 +95,9 @@ use Reflector;
 \Reflector::$mainStaticProp;
 
 PHP
-    ],
+    ,
 
-    [
-        'spec' => <<<'SPEC'
-FQ constant call on a whitelisted class which is imported via a use statement and which belongs to the global namespace:
-- prefix the namespace
-- prefix the class (cf. class belonging to the global scope tests and `scope.inc.php` for the built-in global whitelisted classes)
-SPEC
-        ,
-        'payload' => <<<'PHP'
+    'FQ constant call on a whitelisted class which is imported via a use statement and which belongs to the global namespace' => <<<'PHP'
 <?php
 
 namespace X;
@@ -144,5 +114,5 @@ use Reflector;
 \Reflector::$mainStaticProp;
 
 PHP
-    ],
+    ,
 ];

--- a/specs/class/abstract.php
+++ b/specs/class/abstract.php
@@ -256,7 +256,7 @@ abstract class A
 PHP
     ],
 
-    'Multiple declarations in different namespaces with whitelisted classes: prefix each namespace' => [
+    'Multiple declarations in different namespaces with whitelisted classes' => [
         'whitelist' => ['Foo\WA', 'Bar\WB', 'WC'],
         'payload' => <<<'PHP'
 <?php

--- a/specs/class/anonymous.php
+++ b/specs/class/anonymous.php
@@ -22,7 +22,7 @@ return [
         'whitelist-global-functions' => true,
     ],
 
-    'Declaration in the global namespace: prefix non-internal classes' => <<<'PHP'
+    'Declaration in the global namespace' => <<<'PHP'
 <?php
 
 interface B {}
@@ -226,7 +226,7 @@ class A
 PHP
     ],
 
-    'Declaration in a namespace: prefix the namespace' => <<<'PHP'
+    'Declaration in a namespace' => <<<'PHP'
 <?php
 
 namespace Foo;

--- a/specs/const/global-scope-global-with-global-whitelisting.php
+++ b/specs/const/global-scope-global-with-global-whitelisting.php
@@ -22,14 +22,7 @@ return [
         'whitelist-global-functions' => true,
     ],
 
-    [
-        'spec' => <<<'SPEC'
-Constant call in the global namespace:
-- prefix the constant
-- transforms the call into a FQ call
-SPEC
-        ,
-        'payload' => <<<'PHP'
+    'Constant call in the global namespace' => <<<'PHP'
 <?php
 
 DUMMY_CONST;
@@ -41,17 +34,9 @@ namespace Humbug;
 \DUMMY_CONST;
 
 PHP
-    ],
+    ,
 
-    [
-        'spec' => <<<'SPEC'
-Whitelisted constant call in the global namespace:
-- add prefixed namespace
-- transforms the call into a FQ call
-SPEC
-        ,
-        'whitelist' => ['DUMMY_CONST'],
-        'payload' => <<<'PHP'
+    'Whitelisted constant call in the global namespace' => <<<'PHP'
 <?php
 
 DUMMY_CONST;
@@ -63,9 +48,9 @@ namespace Humbug;
 \DUMMY_CONST;
 
 PHP
-    ],
+    ,
 
-    'Constant call in the global namespace which is whitelisted: add root namespace statement' => [
+    'Constant call in the global namespace which is whitelisted' => [
         'whitelist' => ['\*'],
         'payload' => <<<'PHP'
 <?php
@@ -81,14 +66,7 @@ namespace {
 PHP
     ],
 
-    [
-        'spec' => <<<'SPEC'
-Internal constant call in the global namespace:
-- do not prefix the constant
-- transforms the call into a FQ call
-SPEC
-        ,
-        'payload' => <<<'PHP'
+    'Internal constant call in the global namespace' => <<<'PHP'
 <?php
 
 DIRECTORY_SEPARATOR;
@@ -100,15 +78,9 @@ namespace Humbug;
 \DIRECTORY_SEPARATOR;
 
 PHP
-    ],
-
-    [
-        'spec' => <<<'SPEC'
-FQ constant call in the global namespace:
-- prefix the constant
-SPEC
     ,
-        'payload' => <<<'PHP'
+
+    'FQ constant call in the global namespace' => <<<'PHP'
 <?php
 
 DUMMY_CONST;
@@ -120,16 +92,9 @@ namespace Humbug;
 \DUMMY_CONST;
 
 PHP
-    ],
+    ,
 
-    [
-        'spec' => <<<'SPEC'
-Global constant call in the global scope of a constant which has a use statement for a class importing a class with the
-same name
-- do not prefix the function
-SPEC
-        ,
-        'payload' => <<<'PHP'
+    'Global constant call in the global scope of a constant which has a use statement for a class importing a class with the same name' => <<<'PHP'
 <?php
 
 use Acme\Inf;
@@ -144,5 +109,5 @@ use Humbug\Acme\Inf;
 \INF;
 
 PHP
-    ],
+    ,
 ];

--- a/specs/const/global-scope-global-with-single-level-use-statement-and-alias.php
+++ b/specs/const/global-scope-global-with-single-level-use-statement-and-alias.php
@@ -39,7 +39,9 @@ use const Humbug\DUMMY_CONST as FOO;
 PHP
     ,
 
-    'Whitelisted constant call imported with an aliased use statement' => <<<'PHP'
+    'Whitelisted constant call imported with an aliased use statement' => [
+        'whitelist' => ['DUMMY_CONST'],
+        'payload' => <<<'PHP'
 <?php
 
 use const DUMMY_CONST as FOO;
@@ -54,9 +56,9 @@ use const DUMMY_CONST as FOO;
 \DUMMY_CONST;
 
 PHP
-    ,
+    ],
 
-    'Constant call imported with an aliased use statement' => <<<'PHP'
+    'Constant FQ call imported with an aliased use statement' => <<<'PHP'
 <?php
 
 use const DUMMY_CONST as FOO;

--- a/specs/const/global-scope-global-with-single-level-use-statement-and-alias.php
+++ b/specs/const/global-scope-global-with-single-level-use-statement-and-alias.php
@@ -22,15 +22,7 @@ return [
         'whitelist-global-functions' => true,
     ],
 
-    [
-        'spec' => <<<'SPEC'
-Constant call imported with an aliased use statement:
-- prefix the use statement
-- prefix the call
-- transforms the call into a FQ call
-SPEC
-        ,
-        'payload' => <<<'PHP'
+    'Constant call imported with an aliased use statement' => <<<'PHP'
 <?php
 
 use const DUMMY_CONST as FOO;
@@ -45,17 +37,9 @@ use const Humbug\DUMMY_CONST as FOO;
 \Humbug\DUMMY_CONST;
 
 PHP
-    ],
+    ,
 
-    [
-        'spec' => <<<'SPEC'
-Whitelisted constant call imported with an aliased use statement:
-- add prefixed namespace
-- transforms the call into a FQ call
-SPEC
-        ,
-        'whitelist' => ['DUMMY_CONST'],
-        'payload' => <<<'PHP'
+    'Whitelisted constant call imported with an aliased use statement' => <<<'PHP'
 <?php
 
 use const DUMMY_CONST as FOO;
@@ -70,15 +54,9 @@ use const DUMMY_CONST as FOO;
 \DUMMY_CONST;
 
 PHP
-    ],
+    ,
 
-    [
-        'spec' => <<<'SPEC'
-Constant call imported with an aliased use statement:
-- prefix the use statement
-SPEC
-        ,
-        'payload' => <<<'PHP'
+    'Constant call imported with an aliased use statement' => <<<'PHP'
 <?php
 
 use const DUMMY_CONST as FOO;
@@ -93,5 +71,5 @@ use const Humbug\DUMMY_CONST as FOO;
 \Humbug\FOO;
 
 PHP
-    ],
+    ,
 ];

--- a/specs/const/global-scope-global-with-single-level-use-statement-with-global-whitelisting.php
+++ b/specs/const/global-scope-global-with-single-level-use-statement-with-global-whitelisting.php
@@ -22,15 +22,7 @@ return [
         'whitelist-global-functions' => true,
     ],
 
-    [
-        'spec' => <<<'SPEC'
-Constant call imported with a use statement:
-- prefix the use statement
-- prefix the call
-- transforms the call into a FQ call
-SPEC
-        ,
-        'payload' => <<<'PHP'
+    'Constant call imported with a use statement' => <<<'PHP'
 <?php
 
 use const DUMMY_CONST;
@@ -45,15 +37,9 @@ use const Humbug\DUMMY_CONST;
 \DUMMY_CONST;
 
 PHP
-    ],
+    ,
 
-    [
-        'spec' => <<<'SPEC'
-Whitelisted constant call imported with a use statement:
-- add prefixed namespace
-- transforms the call into a FQ call
-SPEC
-        ,
+    'Whitelisted constant call imported with a use statement' => [
         'whitelist' => ['DUMMY_CONST'],
         'payload' => <<<'PHP'
 <?php
@@ -72,13 +58,7 @@ use const DUMMY_CONST;
 PHP
     ],
 
-    [
-        'spec' => <<<'SPEC'
-FQ constant call imported with a use statement:
-- prefix the use statement
-SPEC
-        ,
-        'payload' => <<<'PHP'
+    'FQ constant call imported with a use statement' => <<<'PHP'
 <?php
 
 use const DUMMY_CONST;
@@ -93,5 +73,5 @@ use const Humbug\DUMMY_CONST;
 \DUMMY_CONST;
 
 PHP
-    ],
+    ,
 ];

--- a/specs/const/global-scope-global-with-single-level-use-statement.php
+++ b/specs/const/global-scope-global-with-single-level-use-statement.php
@@ -22,15 +22,7 @@ return [
         'whitelist-global-functions' => true,
     ],
 
-    [
-        'spec' => <<<'SPEC'
-Constant call imported with a use statement:
-- prefix the use statement
-- prefix the call
-- transforms the call into a FQ call
-SPEC
-        ,
-        'payload' => <<<'PHP'
+    'Constant call imported with a use statement' => <<<'PHP'
 <?php
 
 use const DUMMY_CONST;
@@ -45,15 +37,9 @@ use const Humbug\DUMMY_CONST;
 \Humbug\DUMMY_CONST;
 
 PHP
-    ],
+    ,
 
-    [
-        'spec' => <<<'SPEC'
-Whitelisted constant call imported with a use statement:
-- add prefixed namespace
-- transforms the call into a FQ call
-SPEC
-        ,
+    'Whitelisted constant call imported with a use statement' => [
         'whitelist' => ['DUMMY_CONST'],
         'payload' => <<<'PHP'
 <?php
@@ -72,13 +58,7 @@ use const DUMMY_CONST;
 PHP
     ],
 
-    [
-        'spec' => <<<'SPEC'
-FQ constant call imported with a use statement:
-- prefix the use statement
-SPEC
-        ,
-        'payload' => <<<'PHP'
+    'FQ constant call imported with a use statement' => <<<'PHP'
 <?php
 
 use const DUMMY_CONST;
@@ -93,5 +73,5 @@ use const Humbug\DUMMY_CONST;
 \Humbug\DUMMY_CONST;
 
 PHP
-    ],
+    ,
 ];

--- a/specs/const/global-scope-global.php
+++ b/specs/const/global-scope-global.php
@@ -22,14 +22,7 @@ return [
         'whitelist-global-functions' => true,
     ],
 
-    [
-        'spec' => <<<'SPEC'
-Constant call in the global namespace:
-- prefix the constant
-- transforms the call into a FQ call
-SPEC
-        ,
-        'payload' => <<<'PHP'
+    'Constant call in the global namespace' => <<<'PHP'
 <?php
 
 DUMMY_CONST;
@@ -41,17 +34,9 @@ namespace Humbug;
 \Humbug\DUMMY_CONST;
 
 PHP
-    ],
+    ,
 
-    [
-        'spec' => <<<'SPEC'
-Whitelisted constant call in the global namespace:
-- add prefixed namespace
-- transforms the call into a FQ call
-SPEC
-        ,
-        'whitelist' => ['DUMMY_CONST'],
-        'payload' => <<<'PHP'
+    'Whitelisted constant call in the global namespace' => <<<'PHP'
 <?php
 
 DUMMY_CONST;
@@ -63,9 +48,9 @@ namespace Humbug;
 \DUMMY_CONST;
 
 PHP
-    ],
+    ,
 
-    'Constant call in the global namespace which is whitelisted: add root namespace statement' => [
+    'Constant call in the global namespace which is whitelisted' => [
         'whitelist' => ['\*'],
         'payload' => <<<'PHP'
 <?php
@@ -81,14 +66,7 @@ namespace {
 PHP
     ],
 
-    [
-        'spec' => <<<'SPEC'
-Internal constant call in the global namespace:
-- do not prefix the constant
-- transforms the call into a FQ call
-SPEC
-        ,
-        'payload' => <<<'PHP'
+    'Internal constant call in the global namespace' => <<<'PHP'
 <?php
 
 DIRECTORY_SEPARATOR;
@@ -100,15 +78,9 @@ namespace Humbug;
 \DIRECTORY_SEPARATOR;
 
 PHP
-    ],
-
-    [
-        'spec' => <<<'SPEC'
-FQ constant call in the global namespace:
-- prefix the constant
-SPEC
     ,
-        'payload' => <<<'PHP'
+
+    'FQ constant call in the global namespace' => <<<'PHP'
 <?php
 
 DUMMY_CONST;
@@ -120,16 +92,9 @@ namespace Humbug;
 \Humbug\DUMMY_CONST;
 
 PHP
-    ],
+    ,
 
-    [
-        'spec' => <<<'SPEC'
-Global constant call in the global scope of a constant which has a use statement for a class importing a class with the
-same name
-- do not prefix the function
-SPEC
-        ,
-        'payload' => <<<'PHP'
+    'Global constant call in the global scope of a constant which has a use statement for a class importing a class with the same name' => <<<'PHP'
 <?php
 
 use Acme\Inf;
@@ -144,5 +109,5 @@ use Humbug\Acme\Inf;
 \INF;
 
 PHP
-    ],
+    ,
 ];

--- a/specs/const/global-scope-global.php
+++ b/specs/const/global-scope-global.php
@@ -36,7 +36,9 @@ namespace Humbug;
 PHP
     ,
 
-    'Whitelisted constant call in the global namespace' => <<<'PHP'
+    'Whitelisted constant call in the global namespace' => [
+        'whitelist' => ['DUMMY_CONST'],
+        'payload' => <<<'PHP'
 <?php
 
 DUMMY_CONST;
@@ -48,7 +50,7 @@ namespace Humbug;
 \DUMMY_CONST;
 
 PHP
-    ,
+    ],
 
     'Constant call in the global namespace which is whitelisted' => [
         'whitelist' => ['\*'],

--- a/specs/const/global-scope-single-part-namespaced-with-single-level-use-alias.php
+++ b/specs/const/global-scope-single-part-namespaced-with-single-level-use-alias.php
@@ -22,15 +22,7 @@ return [
         'whitelist-global-functions' => true,
     ],
 
-    [
-        'spec' => <<<'SPEC'
-Constant call on an imported single-level namespace
-- do not prefix the use statement (see tests related to single-level classes)
-- prefix the constant call
-- transform the call into a FQ call
-SPEC
-        ,
-        'payload' => <<<'PHP'
+    'Constant call on an imported single-level namespace' => <<<'PHP'
 <?php
 
 namespace {
@@ -63,16 +55,9 @@ use Humbug\Foo as A;
 \Humbug\Foo\DUMMY_CONST;
 
 PHP
-    ],
+    ,
 
-    [
-        'spec' => <<<'SPEC'
-FQ constant call on an imported single-level namespace
-- do not prefix the use statement (see tests related to single-level classes)
-- prefix the constant call
-SPEC
-        ,
-        'payload' => <<<'PHP'
+    'FQ constant call on an imported single-level namespace' => <<<'PHP'
 <?php
 
 namespace {
@@ -105,15 +90,9 @@ use Humbug\Foo as A;
 \Humbug\A\DUMMY_CONST;
 
 PHP
-    ],
+    ,
 
-    [
-        'spec' => <<<'SPEC'
-Whitelisted onstant call on an imported single-level namespace
-- do not prefix the use statement (see tests related to single-level classes)
-- transform the call into a FQ call
-SPEC
-        ,
+    'Whitelisted constant call on an imported single-level namespace' => [
         'whitelist' => ['Foo\DUMMY_CONST'],
         'payload' => <<<'PHP'
 <?php

--- a/specs/const/global-scope-single-part-namespaced-with-single-level-use.php
+++ b/specs/const/global-scope-single-part-namespaced-with-single-level-use.php
@@ -22,16 +22,7 @@ return [
         'whitelist-global-functions' => true,
     ],
 
-    [
-        'spec' => <<<'SPEC'
-Constant call on an imported single-level namespace:
-- add prefixed namespace
-- do not prefix the use statement (see tests related to single-level classes)
-- prefix the constant call
-- transform the call into a FQ call
-SPEC
-        ,
-        'payload' => <<<'PHP'
+    'Constant call on an imported single-level namespace' => <<<'PHP'
 <?php
 
 class Foo {}
@@ -51,16 +42,9 @@ use Humbug\Foo;
 \Humbug\Foo\DUMMY_CONST;
 
 PHP
-    ],
+    ,
 
-    [
-        'spec' => <<<'SPEC'
-FQ constant call on an imported single-level namespace
-- do not prefix the use statement (see tests related to single-level classes)
-- prefix the constant call
-SPEC
-        ,
-        'payload' => <<<'PHP'
+    'FQ constant call on an imported single-level namespace' => <<<'PHP'
 <?php
 
 namespace {
@@ -93,16 +77,9 @@ use Humbug\Foo;
 \Humbug\Foo\DUMMY_CONST;
 
 PHP
-    ],
+    ,
 
-    [
-        'spec' => <<<'SPEC'
-Whitelisted constant call on an imported single-level namespace
-- do not prefix the use statement (see tests related to single-level classes)
-- prefix the constant call: the whitelist only works on classes
-- transform the call into a FQ call
-SPEC
-        ,
+    'Whitelisted constant call on an imported single-level namespace' => [
         'whitelist' => ['Foo\DUMMY_CONST'],
         'payload' => <<<'PHP'
 <?php

--- a/specs/const/global-scope-single-part-namespaced.php
+++ b/specs/const/global-scope-single-part-namespaced.php
@@ -22,14 +22,7 @@ return [
         'whitelist-global-functions' => true,
     ],
 
-    [
-        'spec' => <<<'SPEC'
-Namespaced constant call
-- prefix the call
-- transform the call into a FQ call
-SPEC
-        ,
-        'payload' => <<<'PHP'
+    'Namespaced constant call' => <<<'PHP'
 <?php
 
 PHPUnit\DUMMY_CONST;
@@ -41,15 +34,9 @@ namespace Humbug;
 \Humbug\PHPUnit\DUMMY_CONST;
 
 PHP
-    ],
+    ,
 
-    [
-        'spec' => <<<'SPEC'
-FQ namespaced constant call
-- prefix the call
-SPEC
-        ,
-        'payload' => <<<'PHP'
+    'FQ namespaced constant call' => <<<'PHP'
 <?php
 
 \PHPUnit\DUMMY_CONST;
@@ -61,14 +48,9 @@ namespace Humbug;
 \Humbug\PHPUnit\DUMMY_CONST;
 
 PHP
-    ],
+    ,
 
-    [
-        'spec' => <<<'SPEC'
-Namespaced constant call on a whitelisted constant
-- add prefixed namespace
-SPEC
-        ,
+    'Namespaced constant call on a whitelisted constant' => [
         'whitelist' => ['PHPUnit\DUMMY_CONST'],
         'payload' => <<<'PHP'
 <?php

--- a/specs/const/global-scope-two-parts-namespaced-with-single-level-use-and-alias.php
+++ b/specs/const/global-scope-two-parts-namespaced-with-single-level-use-and-alias.php
@@ -22,15 +22,7 @@ return [
         'whitelist-global-functions' => true,
     ],
 
-    [
-        'spec' => <<<'SPEC'
-Namespaced constant call with namespace partially imported
-- do not prefix the use statement (cf. tests related to global classes)
-- prefix the call
-- transform the call in a FQ call
-SPEC
-        ,
-        'payload' => <<<'PHP'
+    'Namespaced constant call with namespace partially imported' => <<<'PHP'
 <?php
 
 class Foo {}
@@ -50,16 +42,9 @@ use Humbug\Foo as A;
 \Humbug\Foo\Bar\DUMMY_CONST;
 
 PHP
-    ],
+    ,
 
-    [
-        'spec' => <<<'SPEC'
-FQ namespaced constant call with namespace partially imported
-- do not prefix the use statement (cf. tests related to global classes)
-- prefix the call
-SPEC
-        ,
-        'payload' => <<<'PHP'
+    'FQ namespaced constant call with namespace partially imported' => <<<'PHP'
 <?php
 
 class Foo {}
@@ -79,16 +64,9 @@ use Humbug\Foo as A;
 \Humbug\A\Bar\DUMMY_CONST;
 
 PHP
-    ],
+    ,
 
-    [
-        'spec' => <<<'SPEC'
-Whitelisted namespaced constant call with namespace partially imported
-- add prefixed namespace
-- do not prefix the use statement (cf. tests related to global classes)
-- transform the call in a FQ call
-SPEC
-        ,
+    'Whitelisted namespaced constant call with namespace partially imported' => [
         'whitelist' => ['Foo\Bar\DUMMY_CONST'],
         'payload' => <<<'PHP'
 <?php

--- a/specs/const/global-scope-two-parts-namespaced-with-single-level-use.php
+++ b/specs/const/global-scope-two-parts-namespaced-with-single-level-use.php
@@ -22,15 +22,7 @@ return [
         'whitelist-global-functions' => true,
     ],
 
-    [
-        'spec' => <<<'SPEC'
-Namespaced constant call with namespace partially imported
-- do not prefix the use statement (cf. tests related to global classes)
-- prefix the call
-- transform the call in a FQ call
-SPEC
-        ,
-        'payload' => <<<'PHP'
+    'Namespaced constant call with namespace partially imported' => <<<'PHP'
 <?php
 
 class Foo {}
@@ -50,16 +42,9 @@ use Humbug\Foo;
 \Humbug\Foo\Bar\DUMMY_CONST;
 
 PHP
-    ],
+    ,
 
-    [
-        'spec' => <<<'SPEC'
-FQ namespaced constant call with namespace partially imported
-- do not prefix the use statement (cf. tests related to global classes)
-- prefix the call
-SPEC
-        ,
-        'payload' => <<<'PHP'
+    'FQ namespaced constant call with namespace partially imported' => <<<'PHP'
 <?php
 
 class Foo {}
@@ -79,16 +64,9 @@ use Humbug\Foo;
 \Humbug\Foo\Bar\DUMMY_CONST;
 
 PHP
-    ],
+    ,
 
-    [
-        'spec' => <<<'SPEC'
-Whitelisted namespaced constant call with namespace partially imported
-- add prefixed namespace
-- do not prefix the use statement (cf. tests related to global classes)
-- transform the call in a FQ call
-SPEC
-        ,
+    'Whitelisted namespaced constant call with namespace partially imported' => [
         'whitelist' => ['Foo\Bar\DUMMY_CONST'],
         'payload' => <<<'PHP'
 <?php

--- a/specs/const/global-scope-two-parts-namespaced.php
+++ b/specs/const/global-scope-two-parts-namespaced.php
@@ -22,14 +22,7 @@ return [
         'whitelist-global-functions' => true,
     ],
 
-    [
-        'spec' => <<<'SPEC'
-Namespaced constant call
-- prefix the call
-- transform the call into a FQ call
-SPEC
-        ,
-        'payload' => <<<'PHP'
+    'Namespaced constant call' => <<<'PHP'
 <?php
 
 PHPUnit\Command\DUMMY_CONST;
@@ -41,15 +34,9 @@ namespace Humbug;
 \Humbug\PHPUnit\Command\DUMMY_CONST;
 
 PHP
-    ],
+    ,
 
-    [
-        'spec' => <<<'SPEC'
-FQ namespaced constant call
-- prefix the call
-SPEC
-        ,
-        'payload' => <<<'PHP'
+    'FQ namespaced constant call' => <<<'PHP'
 <?php
 
 \PHPUnit\Command\DUMMY_CONST;
@@ -61,14 +48,9 @@ namespace Humbug;
 \Humbug\PHPUnit\Command\DUMMY_CONST;
 
 PHP
-    ],
+    ,
 
-    [
-        'spec' => <<<'SPEC'
-Namespaced constant call on a whitelisted constant
-- add prefixed namespace
-SPEC
-        ,
+    'Namespaced constant call on a whitelisted constant' => [
         'whitelist' => ['PHPUnit\Command\DUMMY_CONST'],
         'payload' => <<<'PHP'
 <?php

--- a/specs/const/namespace-global-with-global-whitelisting.php
+++ b/specs/const/namespace-global-with-global-whitelisting.php
@@ -22,14 +22,7 @@ return [
         'whitelist-global-functions' => true,
     ],
 
-    [
-        'spec' => <<<'SPEC'
-Constant call in a namespace:
-- prefix the namespace
-- do nothing: the constant can either belong to the same namespace or the global namespace
-SPEC
-        ,
-        'payload' => <<<'PHP'
+    'Constant call in a namespace' => <<<'PHP'
 <?php
 
 namespace A;
@@ -43,15 +36,9 @@ namespace Humbug\A;
 DUMMY_CONST;
 
 PHP
-    ],
+    ,
 
-    [
-        'spec' => <<<'SPEC'
-Whitelisted constant call in a namespace:
-- prefix the namespace
-- do nothing: the constant can either belong to the same namespace or the global namespace
-SPEC
-        ,
+    'Whitelisted constant call in a namespace' => [
         'whitelist' => ['DUMMY_CONST'],
         'payload' => <<<'PHP'
 <?php
@@ -69,14 +56,7 @@ DUMMY_CONST;
 PHP
     ],
 
-    [
-        'spec' => <<<'SPEC'
-FQ constant call in a namespace:
-- prefix the namespace
-- prefix the constant call
-SPEC
-    ,
-        'payload' => <<<'PHP'
+    'FQ constant call in a namespace' => <<<'PHP'
 <?php
 
 namespace A;
@@ -90,15 +70,9 @@ namespace Humbug\A;
 \DUMMY_CONST;
 
 PHP
-    ],
-
-    [
-        'spec' => <<<'SPEC'
-Whitelisted FQ constant call in a namespace:
-- prefix the namespace
-- prefix the constant call
-SPEC
     ,
+
+    'Whitelisted FQ constant call in a namespace' => [
         'whitelist' => ['DUMMY_CONST'],
         'payload' => <<<'PHP'
 <?php

--- a/specs/const/namespace-global-with-single-level-use-statement-and-alias.php
+++ b/specs/const/namespace-global-with-single-level-use-statement-and-alias.php
@@ -22,20 +22,7 @@ return [
         'whitelist-global-functions' => true,
     ],
 
-    // As it is extremely rare to use a `use const` statement for a built-in constant from the
-    // global scope, we can relatively safely assume it is a user-land declared constant which should
-    // be prefixed.
-
-    [
-        'spec' => <<<'SPEC'
-Constant call imported with an aliased use statement:
-- prefix the namespace
-- prefix the use statement
-- prefix the call
-- transforms the call into a FQ call
-SPEC
-        ,
-        'payload' => <<<'PHP'
+    'Constant call imported with an aliased use statement' => <<<'PHP'
 <?php
 
 namespace A;
@@ -52,17 +39,9 @@ use const Humbug\DUMMY_CONST as FOO;
 \Humbug\DUMMY_CONST;
 
 PHP
-    ],
+    ,
 
-    [
-        'spec' => <<<'SPEC'
-Constant call imported with an aliased use statement:
-- prefix the namespace
-- prefix the use statement
-- prefix the constant call
-SPEC
-        ,
-        'payload' => <<<'PHP'
+    'Constant FQ call imported with an aliased use statement' => <<<'PHP'
 <?php
 
 namespace A;
@@ -79,14 +58,9 @@ use const Humbug\DUMMY_CONST as FOO;
 \Humbug\FOO;
 
 PHP
-    ],
+    ,
 
-    [
-        'spec' => <<<'SPEC'
-Whitelisted constant call imported with an aliased use statement:
-- prefix the namespace
-SPEC
-        ,
+    'Whitelisted constant call imported with an aliased use statement' => [
         'whitelist' => ['DUMMY_CONST'],
         'payload' => <<<'PHP'
 <?php

--- a/specs/const/namespace-global-with-single-level-use-statement.php
+++ b/specs/const/namespace-global-with-single-level-use-statement.php
@@ -22,20 +22,7 @@ return [
         'whitelist-global-functions' => true,
     ],
 
-    // As it is extremely rare to use a `use const` statement for a built-in constant from the
-    // global scope, we can relatively safely assume it is a user-land declared constant which should
-    // be prefixed.
-
-    [
-        'spec' => <<<'SPEC'
-Constant call imported with a use statement:
-- prefix the namespace
-- prefix the use statement
-- prefix the call
-- transforms the call into a FQ call
-SPEC
-        ,
-        'payload' => <<<'PHP'
+    'Constant call imported with a use statement' => <<<'PHP'
 <?php
 
 namespace A;
@@ -52,17 +39,9 @@ use const Humbug\DUMMY_CONST;
 \Humbug\DUMMY_CONST;
 
 PHP
-    ],
+    ,
 
-    [
-        'spec' => <<<'SPEC'
-FQ constant call imported with a use statement:
-- prefix the namespace
-- prefix the use statement
-- prefix the constant call
-SPEC
-        ,
-        'payload' => <<<'PHP'
+    'FQ constant call imported with a use statement' => <<<'PHP'
 <?php
 
 namespace A;
@@ -79,14 +58,9 @@ use const Humbug\DUMMY_CONST;
 \Humbug\DUMMY_CONST;
 
 PHP
-    ],
+    ,
 
-    [
-        'spec' => <<<'SPEC'
-Whitelisted FQ constant call imported with a use statement:
-- prefix the namespace
-SPEC
-        ,
+    'Whitelisted FQ constant call imported with a use statement' => [
         'whitelist' => ['DUMMY_CONST'],
         'payload' => <<<'PHP'
 <?php

--- a/specs/const/namespace-global.php
+++ b/specs/const/namespace-global.php
@@ -22,14 +22,7 @@ return [
         'whitelist-global-functions' => true,
     ],
 
-    [
-        'spec' => <<<'SPEC'
-Constant call in a namespace:
-- prefix the namespace
-- do nothing: the constant can either belong to the same namespace or the global namespace
-SPEC
-        ,
-        'payload' => <<<'PHP'
+    'Constant call in a namespace' => <<<'PHP'
 <?php
 
 namespace A;
@@ -43,15 +36,9 @@ namespace Humbug\A;
 DUMMY_CONST;
 
 PHP
-    ],
+    ,
 
-    [
-        'spec' => <<<'SPEC'
-Whitelisted constant call in a namespace:
-- prefix the namespace
-- do nothing: the constant can either belong to the same namespace or the global namespace
-SPEC
-        ,
+    'Whitelisted constant call in a namespace' => [
         'whitelist' => ['DUMMY_CONST'],
         'payload' => <<<'PHP'
 <?php
@@ -69,14 +56,7 @@ DUMMY_CONST;
 PHP
     ],
 
-    [
-        'spec' => <<<'SPEC'
-FQ constant call in a namespace:
-- prefix the namespace
-- prefix the constant call
-SPEC
-    ,
-        'payload' => <<<'PHP'
+    'FQ constant call in a namespace' => <<<'PHP'
 <?php
 
 namespace A;
@@ -90,15 +70,9 @@ namespace Humbug\A;
 \Humbug\DUMMY_CONST;
 
 PHP
-    ],
-
-    [
-        'spec' => <<<'SPEC'
-Whitelisted FQ constant call in a namespace:
-- prefix the namespace
-- prefix the constant call
-SPEC
     ,
+
+    'Whitelisted FQ constant call in a namespace' => [
         'whitelist' => ['DUMMY_CONST'],
         'payload' => <<<'PHP'
 <?php

--- a/specs/const/namespace-single-part-namespaced.php
+++ b/specs/const/namespace-single-part-namespaced.php
@@ -22,15 +22,7 @@ return [
         'whitelist-global-functions' => true,
     ],
 
-    [
-        'spec' => <<<'SPEC'
-Namespaced constant call
-- prefix the namespace
-- prefix the call
-- transform the call into a FQ call
-SPEC
-        ,
-        'payload' => <<<'PHP'
+    'Namespaced constant call' => <<<'PHP'
 <?php
 
 namespace A;
@@ -44,16 +36,9 @@ namespace Humbug\A;
 \Humbug\A\PHPUnit\DUMMY_CONST;
 
 PHP
-    ],
+    ,
 
-    [
-        'spec' => <<<'SPEC'
-FQ namespaced constant call
-- prefix the namespace
-- prefix the call
-SPEC
-        ,
-        'payload' => <<<'PHP'
+    'FQ namespaced constant call' => <<<'PHP'
 <?php
 
 namespace A;
@@ -67,15 +52,9 @@ namespace Humbug\A;
 \Humbug\PHPUnit\DUMMY_CONST;
 
 PHP
-    ],
+    ,
 
-    [
-        'spec' => <<<'SPEC'
-Whitelisted namespaced constant call on a whitelisted constant
-- prefix the namespace
-- prefix the call: the whitelist only works for classes
-SPEC
-        ,
+    'Whitelisted namespaced constant call on a whitelisted constant' => [
         'whitelist' => ['PHPUnit\DUMMY_CONST'],
         'payload' => <<<'PHP'
 <?php
@@ -93,13 +72,7 @@ namespace Humbug\A;
 PHP
     ],
 
-    [
-        'spec' => <<<'SPEC'
-Whitelisted FQ namespaced constant call on a whitelisted constant
-- prefix the namespace
-- prefix the call: the whitelist only works for classes
-SPEC
-        ,
+    'Whitelisted FQ namespaced constant call on a whitelisted constant' => [
         'whitelist' => ['PHPUnit\DUMMY_CONST'],
         'payload' => <<<'PHP'
 <?php

--- a/specs/const/native-const-with-global-whitelisting.php
+++ b/specs/const/native-const-with-global-whitelisting.php
@@ -22,7 +22,7 @@ return [
         'whitelist-global-functions' => true,
     ],
 
-    'Internal function in a namespace: make the call into a FQ call' => <<<'PHP'
+    'Internal function in a namespace' => <<<'PHP'
 <?php
 
 namespace Acme;
@@ -39,7 +39,7 @@ $x = \DIRECTORY_SEPARATOR;
 PHP
     ,
 
-    'Namespaced function having the same name as an internal function: prefix & make the call into a FQ call' => <<<'PHP'
+    'Namespaced function having the same name as an internal function' => <<<'PHP'
 <?php
 
 namespace Acme;

--- a/specs/const/native-const.php
+++ b/specs/const/native-const.php
@@ -22,7 +22,7 @@ return [
         'whitelist-global-functions' => true,
     ],
 
-    'Internal function in a namespace: make the call into a FQ call' => <<<'PHP'
+    'Internal function in a namespace' => <<<'PHP'
 <?php
 
 namespace Acme;
@@ -39,7 +39,7 @@ $x = \DIRECTORY_SEPARATOR;
 PHP
     ,
 
-    'Namespaced function having the same name as an internal function: prefix & make the call into a FQ call' => <<<'PHP'
+    'Namespaced function having the same name as an internal function' => <<<'PHP'
 <?php
 
 namespace Acme;

--- a/specs/func-declaration/global.php
+++ b/specs/func-declaration/global.php
@@ -78,13 +78,7 @@ function foo()
 PHP
     ],
 
-    [
-        'spec' => <<<'SPEC'
-Function declaration in the global namespace:
-- prefix the namespace statements
-- prefix the appropriate classes
-SPEC
-        ,
+    'Function declaration in the global namespace' => [
         'whitelist' => ['X\Y', 'BAR_CONST'],
         'payload' => <<<'PHP'
 <?php
@@ -148,13 +142,7 @@ function foo(\Humbug\Foo $arg0, \Humbug\Foo $arg1, \Humbug\Foo\Bar $arg2, \Humbu
 PHP
     ],
 
-    [
-        'spec' => <<<'SPEC'
-Function declaration in the global namespace:
-- prefix the namespace statements
-- prefix the appropriate classes
-SPEC
-        ,
+    'Function declaration in the global namespace with globally whitelisted constants' => [
         'whitelist-global-constants' => true,
         'payload' => <<<'PHP'
 <?php
@@ -172,14 +160,7 @@ function foo(string $foo = \FOO_CONST)
 PHP
     ],
 
-    [
-        'spec' => <<<'SPEC'
-Function declaration in the global namespace with use statements:
-- prefix namespace statements
-- prefix the appropriate classes
-- append the class_alias statement to the whitelisted class
-SPEC
-        ,
+    'Function declaration in the global namespace with use statements' => [
         'whitelist' => ['X\Y'],
         'payload' => <<<'PHP'
 <?php
@@ -264,14 +245,7 @@ function foo(string $arg0, ?string $arg1, ?string $arg2 = null, \Humbug\Foo $arg
 PHP
     ],
 
-    [
-        'spec' => <<<'SPEC'
-Function declarations with return types in the global namespace with use statements:
-- prefix namespace statements
-- prefix the appropriate classes
-- append the class_alias statement to the whitelisted class
-SPEC
-        ,
+    'Function declarations with return types in the global namespace with use statements' => [
         'whitelist' => ['X\Y'],
         'payload' => <<<'PHP'
 <?php

--- a/specs/func-declaration/method.php
+++ b/specs/func-declaration/method.php
@@ -22,13 +22,7 @@ return [
         'whitelist-global-functions' => true,
     ],
 
-    [
-        'spec' => <<<'SPEC'
-Method declarations:
-- prefix the namespace statements
-- prefix the appropriate classes
-SPEC
-        ,
+    'Method declarations' => [
         'whitelist' => ['X\Y', 'BAR_CONST'],
         'payload' => <<<'PHP'
 <?php
@@ -113,14 +107,7 @@ class Main
 PHP
     ],
 
-    [
-        'spec' => <<<'SPEC'
-Method declarations with return types:
-- prefix namespace statements
-- prefix the appropriate classes
-- append the class_alias statement to the whitelisted class
-SPEC
-        ,
+    'Method declarations with return types' => [
         'whitelist' => ['X\Y'],
         'payload' => <<<'PHP'
 <?php

--- a/specs/func-declaration/namespace.php
+++ b/specs/func-declaration/namespace.php
@@ -82,13 +82,7 @@ function foo()
 PHP
     ],
 
-    [
-        'spec' => <<<'SPEC'
-Function declaration in a namespace:
-- prefix the namespace statements
-- prefix the appropriate classes
-SPEC
-        ,
+    'Function declaration in a namespace' => [
         'whitelist' => ['X\Y'],
         'payload' => <<<'PHP'
 <?php
@@ -172,13 +166,7 @@ function foo(\Humbug\Pi\Foo $arg0 = null, \Humbug\Foo $arg1, \Humbug\Pi\Foo\Bar 
 PHP
     ],
 
-    [
-        'spec' => <<<'SPEC'
-Function declaration in a namespace:
-- prefix the namespace statements
-- prefix the appropriate classes
-SPEC
-        ,
+    'Function declaration in a namespace with whitelisted classes' => [
         'whitelist' => ['X\Y'],
         'payload' => <<<'PHP'
 <?php
@@ -262,14 +250,7 @@ function foo(\Humbug\Pi\Foo $arg0 = null, \Humbug\Foo $arg1, \Humbug\Pi\Foo\Bar 
 PHP
     ],
 
-    [
-        'spec' => <<<'SPEC'
-Function declaration in a namespace with use statements:
-- prefix namespace statements
-- prefix the appropriate classes
-- append the class_alias statement to the whitelisted class
-SPEC
-        ,
+    'Function declaration in a namespace with use statements' => [
         'whitelist' => ['X\Y'],
         'payload' => <<<'PHP'
 <?php
@@ -345,13 +326,7 @@ function foo(\Humbug\Foo $arg0, \Humbug\Foo $arg1, \Humbug\Foo\Bar $arg2, \Humbu
 PHP
     ],
 
-    [
-        'spec' => <<<'SPEC'
-Function declaration in a whitelisted namespace:
-- prefix the namespace statements
-- prefix the appropriate classes
-SPEC
-        ,
+    'Function declaration in a whitelisted namespace' => [
         'whitelist' => ['Pi\*'],
         'payload' => <<<'PHP'
 <?php
@@ -434,14 +409,7 @@ function foo(\Pi\Foo $arg0 = null, \Humbug\Foo $arg1, \Pi\Foo\Bar $arg2, \Humbug
 PHP
     ],
 
-    [
-        'spec' => <<<'SPEC'
-Function declarations with return types in a namespace with use statements:
-- prefix namespace statements
-- prefix the appropriate classes
-- append the class_alias statement to the whitelisted class
-SPEC
-        ,
+    'Function declarations with return types in a namespace with use statements' => [
         'whitelist' => ['X\Y'],
         'payload' => <<<'PHP'
 <?php

--- a/specs/function/global-scope-global-func-with-single-level-use-statement-and-alias.php
+++ b/specs/function/global-scope-global-func-with-single-level-use-statement-and-alias.php
@@ -22,15 +22,7 @@ return [
         'whitelist-global-functions' => true,
     ],
 
-    [
-        'spec' => <<<'SPEC'
-Global function call imported with a use statement in the global scope
-- prefix the use statement
-- prefix the call
-- transform the call into a FQ call
-SPEC
-        ,
-        'payload' => <<<'PHP'
+    'Global function call imported with a use statement in the global scope' => <<<'PHP'
 <?php
 
 use function main as foo;
@@ -45,16 +37,9 @@ use function Humbug\main as foo;
 \Humbug\main();
 
 PHP
-    ],
+    ,
 
-    [
-        'spec' => <<<'SPEC'
-Global function call imported with a use statement in the global scope
-- prefix the use statement
-- prefix the call
-SPEC
-        ,
-        'payload' => <<<'PHP'
+    'Global function call imported with a use statement in the global scope' => <<<'PHP'
 <?php
 
 use function main as foo;
@@ -69,5 +54,5 @@ use function Humbug\main as foo;
 \Humbug\foo();
 
 PHP
-    ],
+    ,
 ];

--- a/specs/function/global-scope-global-func-with-single-level-use-statement.php
+++ b/specs/function/global-scope-global-func-with-single-level-use-statement.php
@@ -22,15 +22,7 @@ return [
         'whitelist-global-functions' => true,
     ],
 
-    [
-        'spec' => <<<'SPEC'
-Global function call imported with a use statement in the global scope
-- prefix the use statement
-- prefix the call
-- transform the call into a FQ call
-SPEC
-        ,
-        'payload' => <<<'PHP'
+    'Global function call imported with a use statement in the global scope' => <<<'PHP'
 <?php
 
 use function main;
@@ -45,16 +37,9 @@ use function Humbug\main;
 \Humbug\main();
 
 PHP
-    ],
+    ,
 
-    [
-        'spec' => <<<'SPEC'
-Global function call imported with a use statement in the global scope
-- prefix the use statement
-- prefix the call
-SPEC
-        ,
-        'payload' => <<<'PHP'
+    'Global FQ function call imported with a use statement in the global scope' => <<<'PHP'
 <?php
 
 use function main;
@@ -69,5 +54,5 @@ use function Humbug\main;
 \Humbug\main();
 
 PHP
-    ],
+    ,
 ];

--- a/specs/function/global-scope-global-func.php
+++ b/specs/function/global-scope-global-func.php
@@ -22,14 +22,7 @@ return [
         'whitelist-global-functions' => true,
     ],
 
-    [
-        'spec' => <<<'SPEC'
-Global function call in the global scope
-- prefix the function
-- transform the call into a FQ call
-SPEC
-        ,
-        'payload' => <<<'PHP'
+    'Global function call in the global scope' => <<<'PHP'
 <?php
 
 main();
@@ -41,15 +34,9 @@ namespace Humbug;
 \Humbug\main();
 
 PHP
-    ],
+    ,
 
-    [
-        'spec' => <<<'SPEC'
-FQ global function call in the global scope
-- prefix the call
-SPEC
-        ,
-        'payload' => <<<'PHP'
+    'FQ global function call in the global scope' => <<<'PHP'
 <?php
 
 \main();
@@ -61,15 +48,9 @@ namespace Humbug;
 \Humbug\main();
 
 PHP
-    ],
+    ,
 
-    [
-        'spec' => <<<'SPEC'
-Global function call in the global scope of an internal function
-- do not prefix the function
-SPEC
-        ,
-        'payload' => <<<'PHP'
+    'Global function call in the global scope of an internal function' => <<<'PHP'
 <?php
 
 is_array();
@@ -81,15 +62,9 @@ namespace Humbug;
 \is_array();
 
 PHP
-    ],
+    ,
 
-    [
-        'spec' => <<<'SPEC'
-FQ global function call in the global scope of an internal function
-- do not prefix the function
-SPEC
-        ,
-        'payload' => <<<'PHP'
+    'FQ global function call in the global scope of an internal function' => <<<'PHP'
 <?php
 
 \is_array();
@@ -101,16 +76,9 @@ namespace Humbug;
 \is_array();
 
 PHP
-    ],
+    ,
 
-    [
-        'spec' => <<<'SPEC'
-Global function call in the global scope of a function which has a use statement for a class importing a class with the
-same name
-- do not prefix the function
-SPEC
-        ,
-        'payload' => <<<'PHP'
+    'Global function call in the global scope of a function which has a use statement for a class importing a class with the same name' => <<<'PHP'
 <?php
 
 use Acme\Glob;
@@ -125,5 +93,5 @@ use Humbug\Acme\Glob;
 \glob();
 
 PHP
-    ],
+    ,
 ];

--- a/specs/function/global-scope-single-part-namespaced-func-with-single-level-use-and-alias.php
+++ b/specs/function/global-scope-single-part-namespaced-func-with-single-level-use-and-alias.php
@@ -22,15 +22,7 @@ return [
         'whitelist-global-functions' => true,
     ],
 
-    [
-        'spec' => <<<'SPEC'
-Namespaced function call imported with a partial use statement in the global scope
-- do not prefix the use statement: see tests related to classes from the global namespace
-- prefix the call
-- transform the call into a FQ call
-SPEC
-        ,
-        'payload' => <<<'PHP'
+    'Namespaced function call imported with a partial use statement in the global scope' => <<<'PHP'
 <?php
 
 namespace {
@@ -65,16 +57,9 @@ use Humbug\Foo as X;
 \Humbug\Foo\main();
 
 PHP
-    ],
+    ,
 
-    [
-        'spec' => <<<'SPEC'
-FQ namespaced function call imported with a partial use statement in the global scope
-- do not prefix the use statement: see tests related to classes from the global namespace
-- prefix the call
-SPEC
-        ,
-        'payload' => <<<'PHP'
+    'FQ namespaced function call imported with a partial use statement in the global scope' => <<<'PHP'
 <?php
 
 namespace {
@@ -109,16 +94,9 @@ use Humbug\Foo as X;
 \Humbug\X\main();
 
 PHP
-    ],
+    ,
 
-    [
-        'spec' => <<<'SPEC'
-Whitelisted namespaced function call imported with a partial use statement in the global scope
-- do not prefix the use statement: see tests related to classes from the global namespace
-- prefix the call: whitelists only works on classes
-- transform the call into a FQ call
-SPEC
-        ,
+    'Whitelisted namespaced function call imported with a partial use statement in the global scope' => [
         'whitelist' => ['Foo\main'],
         'payload' => <<<'PHP'
 <?php

--- a/specs/function/global-scope-single-part-namespaced-func-with-single-level-use.php
+++ b/specs/function/global-scope-single-part-namespaced-func-with-single-level-use.php
@@ -22,15 +22,7 @@ return [
         'whitelist-global-functions' => true,
     ],
 
-    [
-        'spec' => <<<'SPEC'
-Namespaced function call imported with a partial use statement in the global scope
-- do not prefix the use statement: see tests related to classes from the global namespace
-- prefix the call
-- transform the call into a FQ call
-SPEC
-        ,
-        'payload' => <<<'PHP'
+    'Namespaced function call imported with a partial use statement in the global scope' => <<<'PHP'
 <?php
 
 class Foo {}
@@ -50,16 +42,9 @@ use Humbug\Foo;
 \Humbug\Foo\main();
 
 PHP
-    ],
+    ,
 
-    [
-        'spec' => <<<'SPEC'
-FQ namespaced function call imported with a partial use statement in the global scope
-- do not prefix the use statement: see tests related to classes from the global namespace
-- prefix the call
-SPEC
-        ,
-        'payload' => <<<'PHP'
+    'FQ namespaced function call imported with a partial use statement in the global scope' => <<<'PHP'
 <?php
 
 class Foo {}
@@ -79,16 +64,9 @@ use Humbug\Foo;
 \Humbug\Foo\main();
 
 PHP
-    ],
+    ,
 
-    [
-        'spec' => <<<'SPEC'
-Whitelisted namespaced function call imported with a partial use statement in the global scope
-- do not prefix the use statement: see tests related to classes from the global namespace
-- prefix the call: whitelists only works on classes
-- transform the call into a FQ call
-SPEC
-        ,
+    'Whitelisted namespaced function call imported with a partial use statement in the global scope' => [
         'whitelist' => ['Foo\main'],
         'payload' => <<<'PHP'
 <?php

--- a/specs/function/global-scope-single-part-namespaced-func.php
+++ b/specs/function/global-scope-single-part-namespaced-func.php
@@ -22,14 +22,7 @@ return [
         'whitelist-global-functions' => true,
     ],
 
-    [
-        'spec' => <<<'SPEC'
-Namespaced function call
-- prefix the call
-- transform the call into a FQ call
-SPEC
-        ,
-        'payload' => <<<'PHP'
+    'Namespaced function call' => <<<'PHP'
 <?php
 
 PHPUnit\main();
@@ -41,15 +34,9 @@ namespace Humbug;
 \Humbug\PHPUnit\main();
 
 PHP
-    ],
+    ,
 
-    [
-        'spec' => <<<'SPEC'
-FQ namespaced function call
-- prefix the call
-SPEC
-        ,
-        'payload' => <<<'PHP'
+    'FQ namespaced function call' => <<<'PHP'
 <?php
 
 \PHPUnit\main();
@@ -61,15 +48,9 @@ namespace Humbug;
 \Humbug\PHPUnit\main();
 
 PHP
-    ],
+    ,
 
-    [
-        'spec' => <<<'SPEC'
-Whitelisted namespaced function call
-- prefix the call: whitelists only works on classes
-- transform the call into a FQ call
-SPEC
-        ,
+    'Whitelisted namespaced function call' => [
         'whitelist' => ['PHPUnit\main'],
         'payload' => <<<'PHP'
 <?php
@@ -85,13 +66,7 @@ namespace Humbug;
 PHP
     ],
 
-    [
-        'spec' => <<<'SPEC'
-FQ whitelisted namespaced function call
-- prefix the call: whitelists only works on classes
-- transform the call into a FQ call
-SPEC
-        ,
+    'FQ whitelisted namespaced function call' => [
         'whitelist' => ['PHPUnit\main'],
         'payload' => <<<'PHP'
 <?php

--- a/specs/function/namespace-global-func-with-single-level-use-statement-and-alias.php
+++ b/specs/function/namespace-global-func-with-single-level-use-statement-and-alias.php
@@ -22,16 +22,7 @@ return [
         'whitelist-global-functions' => true,
     ],
 
-    [
-        'spec' => <<<'SPEC'
-Global function call imported with a use statement in a namespace:
-- prefix the namespace
-- prefix the use statement
-- prefix the call
-- transform the call into a FQ call
-SPEC
-        ,
-        'payload' => <<<'PHP'
+    'Global function call imported with a use statement in a namespace' => <<<'PHP'
 <?php
 
 namespace X;
@@ -48,17 +39,9 @@ use function Humbug\main as foo;
 \Humbug\main();
 
 PHP
-    ],
+    ,
 
-    [
-        'spec' => <<<'SPEC'
-Global function call imported with a use statement in a namespace:
-- prefix the namespace
-- prefix the use statement
-- do not prefix the call: as the call is FQ, the use statement is irrelevant so the above assumption cannot apply
-SPEC
-        ,
-        'payload' => <<<'PHP'
+    'Global function call imported with a use statement in a namespace' => <<<'PHP'
 <?php
 
 namespace X;
@@ -75,5 +58,5 @@ use function Humbug\main as foo;
 \Humbug\foo();
 
 PHP
-    ],
+    ,
 ];

--- a/specs/function/namespace-global-func-with-single-level-use-statement.php
+++ b/specs/function/namespace-global-func-with-single-level-use-statement.php
@@ -22,16 +22,7 @@ return [
         'whitelist-global-functions' => true,
     ],
 
-    [
-        'spec' => <<<'SPEC'
-Global function call imported with a use statement in a namespace
-- prefix the namespace
-- prefix the use statement
-- prefix the call
-- transform the call into a FQ call
-SPEC
-        ,
-        'payload' => <<<'PHP'
+    'Global function call imported with a use statement in a namespace' => <<<'PHP'
 <?php
 
 namespace A;
@@ -48,17 +39,9 @@ use function Humbug\main;
 \Humbug\main();
 
 PHP
-    ],
+    ,
 
-    [
-        'spec' => <<<'SPEC'
-Global function call imported with a use statement in a namespace
-- prefix the namespace
-- prefix the use statement
-- prefix the call
-SPEC
-        ,
-        'payload' => <<<'PHP'
+    'Global function call imported with a use statement in a namespace' => <<<'PHP'
 <?php
 
 namespace A;
@@ -75,5 +58,5 @@ use function Humbug\main;
 \Humbug\main();
 
 PHP
-    ],
+    ,
 ];

--- a/specs/function/namespace-global-func.php
+++ b/specs/function/namespace-global-func.php
@@ -22,14 +22,7 @@ return [
         'whitelist-global-functions' => true,
     ],
 
-    [
-        'spec' => <<<'SPEC'
-Global function call in a namespace
-- do not prefix the call: ambiguous call
-- transform the call into a FQ call
-SPEC
-        ,
-        'payload' => <<<'PHP'
+    'Global function call in a namespace' => <<<'PHP'
 <?php
 
 namespace A;
@@ -43,15 +36,9 @@ namespace Humbug\A;
 main();
 
 PHP
-    ],
+    ,
 
-    [
-        'spec' => <<<'SPEC'
-Global function call in a namespace
-- prefix the call
-SPEC
-        ,
-        'payload' => <<<'PHP'
+    'Global FQ function call in a namespace' => <<<'PHP'
 <?php
 
 namespace A;
@@ -65,5 +52,5 @@ namespace Humbug\A;
 \Humbug\main();
 
 PHP
-    ],
+    ,
 ];

--- a/specs/function/namespace-single-part-namespaced-func.php
+++ b/specs/function/namespace-single-part-namespaced-func.php
@@ -22,15 +22,7 @@ return [
         'whitelist-global-functions' => true,
     ],
 
-    [
-        'spec' => <<<'SPEC'
-Namespaced function call:
-- prefix the namespace
-- prefix the call
-- transform the call into a FQ call
-SPEC
-        ,
-        'payload' => <<<'PHP'
+    'Namespaced function call' => <<<'PHP'
 <?php
 
 namespace X;
@@ -44,16 +36,9 @@ namespace Humbug\X;
 \Humbug\X\PHPUnit\main();
 
 PHP
-    ],
+    ,
 
-    [
-        'spec' => <<<'SPEC'
-FQ namespaced function call:
-- prefix the namespace
-- prefix the call
-SPEC
-        ,
-        'payload' => <<<'PHP'
+    'FQ namespaced function call' => <<<'PHP'
 <?php
 
 namespace X;
@@ -67,16 +52,9 @@ namespace Humbug\X;
 \Humbug\PHPUnit\main();
 
 PHP
-    ],
+    ,
 
-    [
-        'spec' => <<<'SPEC'
-Whitelisted namespaced function call:
-- prefix the namespace
-- prefix the call: whitelists only works on classes
-- transform the call into a FQ call
-SPEC
-        ,
+    'Whitelisted namespaced function call' => [
         'whitelist' => ['PHPUnit\X\main'],
         'payload' => <<<'PHP'
 <?php
@@ -94,14 +72,7 @@ namespace Humbug\X;
 PHP
     ],
 
-    [
-        'spec' => <<<'SPEC'
-FQ whitelisted namespaced function call:
-- prefix the namespace
-- prefix the call: whitelists only works on classes
-- transform the call into a FQ call
-SPEC
-        ,
+    'FQ whitelisted namespaced function call' => [
         'whitelist' => ['PHPUnit\main'],
         'payload' => <<<'PHP'
 <?php

--- a/specs/function/native-func.php
+++ b/specs/function/native-func.php
@@ -22,7 +22,7 @@ return [
         'whitelist-global-functions' => true,
     ],
 
-    'Internal function in a namespace: make the call into a FQ call' => <<<'PHP'
+    'Internal function in a namespace' => <<<'PHP'
 <?php
 
 namespace Acme;
@@ -39,7 +39,7 @@ $x = \is_array([]);
 PHP
     ,
 
-    'Namespaced function having the same name as an internal function: prefix & make the call into a FQ call' => <<<'PHP'
+    'Namespaced function having the same name as an internal function' => <<<'PHP'
 <?php
 
 namespace Acme;

--- a/specs/misc.php
+++ b/specs/misc.php
@@ -22,7 +22,7 @@ return [
         'whitelist-global-functions' => true,
     ],
 
-    'Empty file: do nothing' => <<<'PHP'
+    'Empty file' => <<<'PHP'
 <?php
 
 ----
@@ -33,7 +33,7 @@ return [
 PHP
     ,
 
-    'Empty php file with a declare statement: do nothing' => <<<'PHP'
+    'Empty php file with a declare statement' => <<<'PHP'
 <?php declare(strict_types=1);
 
 ----

--- a/specs/misc.php
+++ b/specs/misc.php
@@ -44,12 +44,7 @@ declare (strict_types=1);
 PHP
     ,
 
-    [
-        'spec' => <<<'SPEC'
-Account for PHP case insentitiveness when resolving FQCNs.
-SPEC
-        ,
-        'payload' => <<<'PHP'
+    'Account for PHP case insentitiveness when resolving FQCNs' => <<<'PHP'
 <?php
 
 namespace Foo {
@@ -83,5 +78,5 @@ use Humbug\Foo\stdClass;
 \var_dump(new \Humbug\Foo\stdClass());
 
 PHP
-    ],
+    ,
 ];

--- a/specs/namespace/braces.php
+++ b/specs/namespace/braces.php
@@ -22,7 +22,7 @@ return [
         'whitelist-global-functions' => true,
     ],
 
-    'One level namespace: prefix it' => <<<'PHP'
+    'One level namespace' => <<<'PHP'
 <?php
 
 namespace Foo;
@@ -36,7 +36,7 @@ namespace Humbug\Foo;
 PHP
     ,
 
-    'Two levels namespace: prefix it' => <<<'PHP'
+    'Two levels namespace' => <<<'PHP'
 <?php
 
 namespace Foo\Bar;

--- a/specs/namespace/no-braces.php
+++ b/specs/namespace/no-braces.php
@@ -22,7 +22,7 @@ return [
         'whitelist-global-functions' => true,
     ],
 
-    'Root namespace: prefix the namespace' => <<<'PHP'
+    'Root namespace' => <<<'PHP'
 <?php
 
 namespace {
@@ -39,7 +39,7 @@ $x = 'root';
 PHP
     ,
 
-    'One level: prefix the namespace' => <<<'PHP'
+    'One level' => <<<'PHP'
 <?php
 
 namespace Foo {
@@ -54,7 +54,7 @@ namespace Humbug\Foo;
 PHP
     ,
 
-    'One level whitelisted namespace: prefix the namespace (whitelist works only on classes)' => [
+    'One level whitelisted namespace' => [
         'whitelist' => ['Foo'],
         'payload' => <<<'PHP'
 <?php
@@ -71,7 +71,7 @@ namespace Humbug\Foo;
 PHP
     ],
 
-    'Already prefixed one-level namespace: do nothing' => <<<'PHP'
+    'Already prefixed one-level namespace' => <<<'PHP'
 <?php
 
 namespace Humbug\Foo {
@@ -86,7 +86,7 @@ namespace Humbug\Foo;
 PHP
     ,
 
-    'Two levels namespace: prefix it' => <<<'PHP'
+    'Two levels namespace' => <<<'PHP'
 <?php
 
 namespace Foo\Bar {
@@ -101,7 +101,7 @@ namespace Humbug\Foo\Bar;
 PHP
     ,
 
-    'Two levels whitelisted namespace: prefix it (whitelist only works on classes)' => [
+    'Two levels whitelisted namespace' => [
         'whitelist' => ['Foo'],
         'payload' => <<<'PHP'
 <?php
@@ -118,7 +118,7 @@ namespace Humbug\Foo\Bar;
 PHP
     ],
 
-    'Already prefixed two levels namespace: do nothing' => <<<'PHP'
+    'Already prefixed two levels namespace' => <<<'PHP'
 <?php
 
 namespace Humbug\Foo\Bar;

--- a/specs/special-keywords/self-static-parent-const.php
+++ b/specs/special-keywords/self-static-parent-const.php
@@ -22,12 +22,7 @@ return [
         'whitelist-global-functions' => true,
     ],
 
-    [
-        'spec' => <<<'SPEC'
-Usage for classes in the global scope.
-SPEC
-        ,
-        'payload' => <<<'PHP'
+    'Usage for classes in the global scope' => <<<'PHP'
 <?php
 
 class A {
@@ -99,14 +94,9 @@ class B extends \Humbug\A
 echo (new \Humbug\B('yo'))->getName() . \PHP_EOL;
 
 PHP
-    ],
+    ,
 
-    [
-        'spec' => <<<'SPEC'
-Usage for classes in a namespaced.
-SPEC
-        ,
-        'payload' => <<<'PHP'
+    'Usage for classes in a namespaced' => <<<'PHP'
 <?php
 
 namespace Foo {
@@ -187,5 +177,5 @@ use Humbug\Foo\B;
 echo (new \Humbug\Foo\B('yo'))->getName() . \PHP_EOL;
 
 PHP
-    ],
+    ,
 ];

--- a/specs/special-keywords/self-static-parent-method.php
+++ b/specs/special-keywords/self-static-parent-method.php
@@ -22,12 +22,7 @@ return [
         'whitelist-global-functions' => true,
     ],
 
-    [
-        'spec' => <<<'SPEC'
-Usage for classes in the global scope.
-SPEC
-        ,
-        'payload' => <<<'PHP'
+    'Usage for classes in the global scope' => <<<'PHP'
 <?php
 
 class A {
@@ -125,14 +120,9 @@ class B extends \Humbug\A
 echo (new \Humbug\B('yo'))->getName() . \PHP_EOL;
 
 PHP
-    ],
+    ,
 
-    [
-        'spec' => <<<'SPEC'
-Usage for classes in a namespaced.
-SPEC
-        ,
-        'payload' => <<<'PHP'
+    'Usage for classes in a namespaced' => <<<'PHP'
 <?php
 
 namespace Foo {
@@ -239,5 +229,5 @@ use Humbug\Foo\B;
 echo (new \Humbug\Foo\B('yo'))->getName() . \PHP_EOL;
 
 PHP
-    ],
+    ,
 ];

--- a/specs/special-keywords/self-static-parent-static-var.php
+++ b/specs/special-keywords/self-static-parent-static-var.php
@@ -22,12 +22,7 @@ return [
         'whitelist-global-functions' => true,
     ],
 
-    [
-        'spec' => <<<'SPEC'
-Usage for classes in the global scope.
-SPEC
-        ,
-        'payload' => <<<'PHP'
+    'Usage for classes in the global scope' => <<<'PHP'
 <?php
 
 class A {
@@ -99,14 +94,9 @@ class B extends \Humbug\A
 echo (new \Humbug\B('yo'))->getName() . \PHP_EOL;
 
 PHP
-    ],
+    ,
 
-    [
-        'spec' => <<<'SPEC'
-Usage for classes in a namespaced.
-SPEC
-        ,
-        'payload' => <<<'PHP'
+    'Usage for classes in a namespaced' => <<<'PHP'
 <?php
 
 namespace Foo {
@@ -187,5 +177,5 @@ use Humbug\Foo\B;
 echo (new \Humbug\Foo\B('yo'))->getName() . \PHP_EOL;
 
 PHP
-    ],
+    ,
 ];

--- a/specs/static-method/global-scope-single-part-with-single-level-use-statement-and-alias.php
+++ b/specs/static-method/global-scope-single-part-with-single-level-use-statement-and-alias.php
@@ -22,14 +22,7 @@ return [
         'whitelist-global-functions' => true,
     ],
 
-    [
-        'spec' => <<<'SPEC'
-Static method call statement of a class belonging to the global namespace imported via an aliased use statement:
-- do not touch the use statement (see tests related to the use statements of a class belonging to the global scope)
-- transform the call into a FQ call
-SPEC
-        ,
-        'payload' => <<<'PHP'
+    'Static method call statement of a class belonging to the global namespace imported via an aliased use statement' => <<<'PHP'
 <?php
 
 class Foo {}
@@ -49,16 +42,9 @@ use Humbug\Foo as X;
 \Humbug\Foo::main();
 
 PHP
-    ],
+    ,
 
-    [
-        'spec' => <<<'SPEC'
-FQ static method call statement of a class belonging to the global namespace imported via an aliased use statement:
-- do not touch the use statement (see tests related to the use statements of a class belonging to the global scope)
-- do not touch the call
-SPEC
-        ,
-        'payload' => <<<'PHP'
+    'FQ static method call statement of a class belonging to the global namespace imported via an aliased use statement' => <<<'PHP'
 <?php
 
 class Foo {}
@@ -82,18 +68,9 @@ use Humbug\Foo as X;
 \Humbug\X::main();
 
 PHP
-    ],
+    ,
 
-    [
-        'spec' => <<<'SPEC'
-Static method call statement of a class belonging to the global namespace which has been whitelisted:
-- prefix the use statement
-- prefix the call
-- transform the call into a FQ call
-- See `scope.inc.php` for the built-in global whitelisted classes
-SPEC
-        ,
-        'payload' => <<<'PHP'
+    'Static method call statement of a class belonging to the global namespace which has been whitelisted' => <<<'PHP'
 <?php
 
 use Closure as X;
@@ -108,17 +85,9 @@ use Closure as X;
 \Closure::bind();
 
 PHP
-    ],
+    ,
 
-    [
-        'spec' => <<<'SPEC'
-FQ static method call statement of a class belonging to the global namespace which has been whitelisted:
-- prefix the statement
-- prefix the call
-- See `scope.inc.php` for the built-in global whitelisted classes
-SPEC
-        ,
-        'payload' => <<<'PHP'
+    'FQ static method call statement of a class belonging to the global namespace which has been whitelisted' => <<<'PHP'
 <?php
 
 class X {}
@@ -138,5 +107,5 @@ use Closure as X;
 \Humbug\X::bind();
 
 PHP
-    ],
+    ,
 ];

--- a/specs/static-method/global-scope-single-part-with-single-level-use-statement.php
+++ b/specs/static-method/global-scope-single-part-with-single-level-use-statement.php
@@ -22,14 +22,7 @@ return [
         'whitelist-global-functions' => true,
     ],
 
-    [
-        'spec' => <<<'SPEC'
-Static method call statement of a class belonging to the global namespace imported via a use statement:
-- do not touch the use statement (see tests related to the use statements of a class belonging to the global scope)
-- transform the call into a FQ call
-SPEC
-        ,
-        'payload' => <<<'PHP'
+    'Static method call statement of a class belonging to the global namespace imported via a use statement' => <<<'PHP'
 <?php
 
 class Foo {}
@@ -49,15 +42,9 @@ use Humbug\Foo;
 \Humbug\Foo::main();
 
 PHP
-    ],
+    ,
 
-    [
-        'spec' => <<<'SPEC'
-FQ static method call statement of a class belonging to the global namespace imported via a use statement:
-- do not touch the use statement (see tests related to the use statements of a class belonging to the global scope)
-SPEC
-        ,
-        'payload' => <<<'PHP'
+    'FQ static method call statement of a class belonging to the global namespace imported via a use statement' => <<<'PHP'
 <?php
 
 class Foo {}
@@ -77,18 +64,9 @@ use Humbug\Foo;
 \Humbug\Foo::main();
 
 PHP
-    ],
+    ,
 
-    [
-        'spec' => <<<'SPEC'
-Static method call statement of a class belonging to the global namespace which has been whitelisted:
-- prefix the use statement
-- prefix the call
-- transform the call into a FQ call
-- See `scope.inc.php` for the built-in global whitelisted classes
-SPEC
-        ,
-        'payload' => <<<'PHP'
+    'Static method call statement of a class belonging to the global namespace which has been whitelisted' => <<<'PHP'
 <?php
 
 use Closure;
@@ -103,17 +81,9 @@ use Closure;
 \Closure::bind();
 
 PHP
-    ],
+    ,
 
-    [
-        'spec' => <<<'SPEC'
-FQ static method call statement of a class belonging to the global namespace which has been whitelisted:
-- prefix the statement
-- prefix the call
-- See `scope.inc.php` for the built-in global whitelisted classes
-SPEC
-        ,
-        'payload' => <<<'PHP'
+    'FQ static method call statement of a class belonging to the global namespace which has been whitelisted' => <<<'PHP'
 <?php
 
 use Closure;
@@ -128,5 +98,5 @@ use Closure;
 \Closure::bind();
 
 PHP
-    ],
+    ,
 ];

--- a/specs/static-method/global-scope-single-part.php
+++ b/specs/static-method/global-scope-single-part.php
@@ -22,13 +22,7 @@ return [
         'whitelist-global-functions' => true,
     ],
 
-    [
-        'spec' => <<<'SPEC'
-Static method call statement of a class belonging to the global namespace:
-- transform the call into a FQ call
-SPEC
-        ,
-        'payload' => <<<'PHP'
+    'Static method call statement of a class belonging to the global namespace' => <<<'PHP'
 <?php
 
 class Command {}
@@ -45,15 +39,9 @@ class Command
 \Humbug\Command::main();
 
 PHP
-    ],
+    ,
 
-    [
-        'spec' => <<<'SPEC'
-FQ static method call statement of a class belonging to the global namespace:
-- do not prefix the call as can be part of the global namespace
-SPEC
-        ,
-        'payload' => <<<'PHP'
+    'FQ static method call statement of a class belonging to the global namespace' => <<<'PHP'
 <?php
 
 class Command {}
@@ -70,16 +58,9 @@ class Command
 \Humbug\Command::main();
 
 PHP
-    ],
+    ,
 
-    [
-        'spec' => <<<'SPEC'
-Static method call statement of an internal class :
-- do not prefix the call
-- transform the call into a FQ call
-SPEC
-        ,
-        'payload' => <<<'PHP'
+    'Static method call statement of an internal class' => <<<'PHP'
 <?php
 
 Closure::bind();
@@ -91,16 +72,9 @@ namespace Humbug;
 \Closure::bind();
 
 PHP
-    ],
+    ,
 
-    [
-        'spec' => <<<'SPEC'
-FQ static method call statement of an internal class :
-- do not prefix the call
-- transform the call into a FQ call
-SPEC
-        ,
-        'payload' => <<<'PHP'
+    'FQ static method call statement of an internal class' => <<<'PHP'
 <?php
 
 \Closure::bind();
@@ -112,5 +86,5 @@ namespace Humbug;
 \Closure::bind();
 
 PHP
-    ],
+    ,
 ];

--- a/specs/static-method/global-scope-two-parts-with-single-level-use-and-alias.php
+++ b/specs/static-method/global-scope-two-parts-with-single-level-use-and-alias.php
@@ -22,15 +22,7 @@ return [
         'whitelist-global-functions' => true,
     ],
 
-    [
-        'spec' => <<<'SPEC'
-Static method call statement of a namespaced class partially imported with an aliased use statement:
-- do not touch the use statement: see tests for the use statements as to why
-- prefix the call
-- transform the call into a FQ call
-SPEC
-        ,
-        'payload' => <<<'PHP'
+    'Static method call statement of a namespaced class partially imported with an aliased use statement' => <<<'PHP'
 <?php
 
 namespace {
@@ -65,17 +57,9 @@ use Humbug\Foo as A;
 \Humbug\Foo\Bar::main();
 
 PHP
-    ],
+    ,
 
-    [
-        'spec' => <<<'SPEC'
-Static method call statement of a namespaced class imported with an aliased use statement:
-- prefix the use statement
-- prefix the call
-- transform the call into a FQ call
-SPEC
-        ,
-        'payload' => <<<'PHP'
+    'Static method call statement of a namespaced class imported with an aliased use statement' => <<<'PHP'
 <?php
 
 namespace Foo {
@@ -101,16 +85,9 @@ use Humbug\Foo\Bar as A;
 \Humbug\Foo\Bar::main();
 
 PHP
-    ],
+    ,
 
-    [
-        'spec' => <<<'SPEC'
-FQ static method call statement of a namespaced class partially imported with an aliased use statement:
-- do not touch the use statement: see tests for the use statements and classes of the global namespace as to why
-- prefix the call
-SPEC
-        ,
-        'payload' => <<<'PHP'
+    'FQ static method call statement of a namespaced class partially imported with an aliased use statement' => <<<'PHP'
 <?php
 
 namespace {
@@ -145,16 +122,9 @@ use Humbug\Foo as A;
 \Humbug\A\Bar::main();
 
 PHP
-    ],
+    ,
 
-    [
-        'spec' => <<<'SPEC'
-FQ static method call statement of a namespaced class imported with an aliased use statement:
-- prefix the use statement
-- do not touch the call: see tests for the use statements and classes of the global namespace as to why
-SPEC
-        ,
-        'payload' => <<<'PHP'
+    'FQ static method call statement of a namespaced class imported with an aliased use statement' => <<<'PHP'
 <?php
 
 namespace Foo {
@@ -185,16 +155,9 @@ use Humbug\Foo\Bar as A;
 \Humbug\A::main();
 
 PHP
-    ],
+    ,
 
-    [
-        'spec' => <<<'SPEC'
-Static method call statement of a whitelisted namespaced class partially imported with an aliased use statement:
-- do not touch the use statement: see tests for the use statements as to why
-- do not prefix the call
-- transform the call into a FQ call
-SPEC
-        ,
+    'Static method call statement of a whitelisted namespaced class partially imported with an aliased use statement' => [
         'whitelist' => ['Foo\Bar'],
         'payload' => <<<'PHP'
 <?php
@@ -234,14 +197,7 @@ use Humbug\Foo as A;
 PHP
     ],
 
-    [
-        'spec' => <<<'SPEC'
-Static method call statement of a whitelisted namespaced class imported with an aliased use statement:
-- prefix the use statement
-- do not prefix the call
-- transform the call into a FQ call
-SPEC
-        ,
+    'Static method call statement of a whitelisted namespaced class imported with an aliased use statement' => [
         'whitelist' => ['Foo\Bar'],
         'payload' => <<<'PHP'
 <?php
@@ -272,13 +228,7 @@ use Humbug\Foo\Bar as A;
 PHP
     ],
 
-    [
-        'spec' => <<<'SPEC'
-FQ static method call statement of a whitelisted namespaced class partially imported with an aliased use statement:
-- do not touch the use statement: see tests for the use statements as to why
-- prefix the call: as the call is FQ the use statement is ignored
-SPEC
-        ,
+    'FQ static method call statement of a whitelisted namespaced class partially imported with an aliased use statement' => [
         'whitelist' => ['Foo\Bar'],
         'payload' => <<<'PHP'
 <?php
@@ -317,14 +267,7 @@ use Humbug\Foo as A;
 PHP
     ],
 
-    [
-        'spec' => <<<'SPEC'
-FQ static method call statement of a whitelisted namespaced class imported with an aliased use statement:
-- prefix the use statement
-- do not prefix the call
-- transform the call into a FQ call
-SPEC
-        ,
+    'FQ static method call statement of a whitelisted namespaced class imported with an aliased use statement' => [
         'whitelist' => ['Foo\Bar'],
         'payload' => <<<'PHP'
 <?php

--- a/specs/static-method/global-scope-two-parts-with-single-level-use.php
+++ b/specs/static-method/global-scope-two-parts-with-single-level-use.php
@@ -22,15 +22,7 @@ return [
         'whitelist-global-functions' => true,
     ],
 
-    [
-        'spec' => <<<'SPEC'
-Static method call statement of a namespaced class partially imported with a use statement:
-- do not touch the use statement: see tests for the use statements as to why
-- prefix the call
-- transform the call into a FQ call
-SPEC
-        ,
-        'payload' => <<<'PHP'
+    'Static method call statement of a namespaced class partially imported with a use statement' => <<<'PHP'
 <?php
 
 namespace {
@@ -65,17 +57,9 @@ use Humbug\Foo;
 \Humbug\Foo\Bar::main();
 
 PHP
-    ],
+    ,
 
-    [
-        'spec' => <<<'SPEC'
-Static method call statement of a namespaced class imported with a use statement:
-- prefix the use statement
-- prefix the call
-- transform the call into a FQ call
-SPEC
-        ,
-        'payload' => <<<'PHP'
+    'Static method call statement of a namespaced class imported with a use statement' => <<<'PHP'
 <?php
 
 namespace Foo {
@@ -101,16 +85,9 @@ use Humbug\Foo\Bar;
 \Humbug\Foo\Bar::main();
 
 PHP
-    ],
+    ,
 
-    [
-        'spec' => <<<'SPEC'
-FQ static method call statement of a namespaced class partially imported with a use statement:
-- do not touch the use statement: see tests for the use statements and classes of the global namespace as to why
-- prefix the call
-SPEC
-        ,
-        'payload' => <<<'PHP'
+    'FQ static method call statement of a namespaced class partially imported with a use statement' => <<<'PHP'
 <?php
 
 namespace {
@@ -145,16 +122,9 @@ use Humbug\Foo;
 \Humbug\Foo\Bar::main();
 
 PHP
-    ],
+    ,
 
-    [
-        'spec' => <<<'SPEC'
-FQ static method call statement of a namespaced class imported with a use statement:
-- prefix the use statement
-- do not touch the call: see tests for the use statements and classes of the global namespace as to why
-SPEC
-        ,
-        'payload' => <<<'PHP'
+    'FQ static method call statement of a namespaced class imported with a use statement' => <<<'PHP'
 <?php
 
 namespace Foo {
@@ -185,16 +155,9 @@ use Humbug\Foo\Bar;
 \Humbug\Bar::main();
 
 PHP
-    ],
+    ,
 
-    [
-        'spec' => <<<'SPEC'
-Static method call statement of a whitelisted namespaced class partially imported with a use statement:
-- do not touch the use statement: see tests for the use statements as to why
-- do not prefix the call
-- transform the call into a FQ call
-SPEC
-        ,
+    'Static method call statement of a whitelisted namespaced class partially imported with a use statement' => [
         'whitelist' => ['Foo\Bar'],
         'payload' => <<<'PHP'
 <?php
@@ -234,14 +197,7 @@ use Humbug\Foo;
 PHP
     ],
 
-    [
-        'spec' => <<<'SPEC'
-Static method call statement of a whitelisted namespaced class imported with a use statement:
-- prefix the use statement
-- do not prefix the call
-- transform the call into a FQ call
-SPEC
-        ,
+    'Static method call statement of a whitelisted namespaced class imported with a use statement' => [
         'whitelist' => ['Foo\Bar'],
         'payload' => <<<'PHP'
 <?php
@@ -272,13 +228,7 @@ use Humbug\Foo\Bar;
 PHP
     ],
 
-    [
-        'spec' => <<<'SPEC'
-FQ static method call statement of a whitelisted namespaced class partially imported with a use statement:
-- do not touch the use statement: see tests for the use statements as to why
-- do not prefix the call
-SPEC
-        ,
+    'FQ static method call statement of a whitelisted namespaced class partially imported with a use statement' => [
         'whitelist' => ['Foo\Bar'],
         'payload' => <<<'PHP'
 <?php
@@ -318,14 +268,7 @@ use Humbug\Foo;
 PHP
     ],
 
-    [
-        'spec' => <<<'SPEC'
-FQ static method call statement of a whitelisted namespaced class imported with a use statement:
-- prefix the use statement
-- do not prefix the call
-- transform the call into a FQ call
-SPEC
-        ,
+    'FQ static method call statement of a whitelisted namespaced class imported with a use statement' => [
         'whitelist' => ['Foo\Bar'],
         'payload' => <<<'PHP'
 <?php

--- a/specs/static-method/global-scope-two-parts.php
+++ b/specs/static-method/global-scope-two-parts.php
@@ -22,14 +22,7 @@ return [
         'whitelist-global-functions' => true,
     ],
 
-    [
-        'spec' => <<<'SPEC'
-Static method call statement of a namespaced class:
-- prefix the call
-- transform the call into a FQ call
-SPEC
-        ,
-        'payload' => <<<'PHP'
+    'Static method call statement of a namespaced class' => <<<'PHP'
 <?php
 
 namespace Foo {
@@ -52,15 +45,9 @@ namespace Humbug;
 \Humbug\Foo\Bar::main();
 
 PHP
-    ],
+    ,
 
-    [
-        'spec' => <<<'SPEC'
-FQ static method call statement of a namespaced class:
-- prefix the call
-SPEC
-        ,
-        'payload' => <<<'PHP'
+    'FQ static method call statement of a namespaced class' => <<<'PHP'
 namespace Foo {
     class Bar {}
 }
@@ -78,15 +65,9 @@ namespace {
 }
 
 PHP
-    ],
+    ,
 
-    [
-        'spec' => <<<'SPEC'
-Static method call statement of a namespaced class which has been whitelisted:
-- do not prefix the call
-- transform the call into a FQ call
-SPEC
-        ,
+    'Static method call statement of a namespaced class which has been whitelisted' => [
         'whitelist' => ['Foo\Bar'],
         'payload' => <<<'PHP'
 <?php
@@ -114,12 +95,7 @@ namespace Humbug;
 PHP
     ],
 
-    [
-        'spec' => <<<'SPEC'
-FQ static method call statement of a namespaced class which has been whitelisted:
-- do not prefix the call
-SPEC
-        ,
+    'FQ static method call statement of a namespaced class which has been whitelisted' => [
         'whitelist' => ['Foo\Bar'],
         'payload' => <<<'PHP'
 <?php

--- a/specs/static-method/namespace-single-part-with-single-level-use-statement.php
+++ b/specs/static-method/namespace-single-part-with-single-level-use-statement.php
@@ -23,15 +23,7 @@ return [
         'whitelist-global-functions' => true,
     ],
 
-    [
-        'spec' => <<<'SPEC'
-Static method call statement of a class:
-- prefix the namespace
-- do not prefix the call: see tests related to the classes belonging to the global namespace
-- transform the call into a FQ call
-SPEC
-        ,
-        'payload' => <<<'PHP'
+    'Static method call statement of a class' => <<<'PHP'
 <?php
 
 namespace {
@@ -57,16 +49,9 @@ use Humbug\Foo;
 \Humbug\Foo::main();
 
 PHP
-    ],
+    ,
 
-    [
-        'spec' => <<<'SPEC'
-FQ static method call statement of a class:
-- prefix the namespace
-- do not prefix the call: see tests related to the classes belonging to the global namespace
-SPEC
-        ,
-        'payload' => <<<'PHP'
+    'FQ static method call statement of a class' => <<<'PHP'
 <?php
 
 namespace {
@@ -92,17 +77,9 @@ use Humbug\Foo;
 \Humbug\Foo::main();
 
 PHP
-    ],
+    ,
 
-    [
-        'spec' => <<<'SPEC'
-Static method call statement of a class which has been whitelisted and belongs to the global namespace:
-- prefix the namespace
-- prefix the call: see `scope.inc.php` for the built-in global whitelisted classes
-- transform the call into a FQ call
-SPEC
-        ,
-        'payload' => <<<'PHP'
+    'Static method call statement of a class which has been whitelisted and belongs to the global namespace' => <<<'PHP'
 <?php
 
 namespace A;
@@ -119,17 +96,9 @@ use Closure;
 \Closure::bind();
 
 PHP
-    ],
+    ,
 
-    [
-        'spec' => <<<'SPEC'
-FQ static method call statement of a class which has been whitelisted and belongs to the global namespace:
-- prefix the namespace
-- prefix the call: see `scope.inc.php` for the built-in global whitelisted classes
-- transform the call into a FQ call
-SPEC
-        ,
-        'payload' => <<<'PHP'
+    'FQ static method call statement of a class which has been whitelisted and belongs to the global namespace' => <<<'PHP'
 <?php
 
 namespace A;
@@ -146,5 +115,5 @@ use Closure;
 \Closure::bind();
 
 PHP
-    ],
+    ,
 ];

--- a/specs/static-method/namespace-single-part.php
+++ b/specs/static-method/namespace-single-part.php
@@ -22,15 +22,7 @@ return [
         'whitelist-global-functions' => true,
     ],
 
-    [
-        'spec' => <<<'SPEC'
-Static method call statement of a class:
-- prefix the namespace
-- prefix the call
-- transform the call into a FQ call
-SPEC
-        ,
-        'payload' => <<<'PHP'
+    'Static method call statement of a class' => <<<'PHP'
 <?php
 
 namespace A;
@@ -49,16 +41,9 @@ class Foo
 \Humbug\A\Foo::main();
 
 PHP
-    ],
+    ,
 
-    [
-        'spec' => <<<'SPEC'
-FQ static method call statement of a class belonging to the global namespace:
-- prefix the namespace
-- do not prefix the call
-SPEC
-        ,
-        'payload' => <<<'PHP'
+    'FQ static method call statement of a class belonging to the global namespace' => <<<'PHP'
 <?php
 
 namespace {
@@ -81,17 +66,9 @@ namespace Humbug\A;
 \Humbug\Foo::main();
 
 PHP
-    ],
+    ,
 
-    [
-        'spec' => <<<'SPEC'
-FQ static method call statement of a class belonging to the global namespace which has been whitelisted:
-- prefix the namespace
-- prefix the call
-- See `scope.inc.php` for the built-in global whitelisted classes
-SPEC
-        ,
-        'payload' => <<<'PHP'
+    'FQ static method call statement of a class belonging to the global namespace which has been whitelisted' => <<<'PHP'
 <?php
 
 namespace A;
@@ -105,5 +82,5 @@ namespace Humbug\A;
 \Closure::bind();
 
 PHP
-    ],
+    ,
 ];

--- a/specs/static-method/namespace-two-parts-with-single-level-use.php
+++ b/specs/static-method/namespace-two-parts-with-single-level-use.php
@@ -22,14 +22,7 @@ return [
         'whitelist-global-functions' => true,
     ],
 
-    [
-        'spec' => <<<'SPEC'
-Static method call statement of a class belonging to the global namespace imported via a use statement:
-- do not touch the use statement (see tests related to the use statements of a class belonging to the global scope)
-- transform the call into a FQ call
-SPEC
-        ,
-        'payload' => <<<'PHP'
+    'Static method call statement of a class belonging to the global namespace imported via a use statement' => <<<'PHP'
 <?php
 
 namespace {
@@ -55,15 +48,9 @@ use Humbug\Foo;
 \Humbug\Foo::main();
 
 PHP
-    ],
+    ,
 
-    [
-        'spec' => <<<'SPEC'
-FQ static method call statement of a class belonging to the global namespace imported via a use statement:
-- do not touch the use statement (see tests related to the use statements of a class belonging to the global scope)
-SPEC
-        ,
-        'payload' => <<<'PHP'
+    'FQ static method call statement of a class belonging to the global namespace imported via a use statement' => <<<'PHP'
 <?php
 
 namespace {
@@ -89,18 +76,9 @@ use Humbug\Foo;
 \Humbug\Foo::main();
 
 PHP
-    ],
+    ,
 
-    [
-        'spec' => <<<'SPEC'
-Static method call statement of a class belonging to the global namespace which has been whitelisted:
-- prefix the use statement
-- prefix the call
-- transform the call into a FQ call
-- See `scope.inc.php` for the built-in global whitelisted classes
-SPEC
-        ,
-        'payload' => <<<'PHP'
+    'Static method call statement of a class belonging to the global namespace which has been whitelisted' => <<<'PHP'
 <?php
 
 namespace A;
@@ -117,17 +95,9 @@ use Closure;
 \Closure::bind();
 
 PHP
-    ],
+    ,
 
-    [
-        'spec' => <<<'SPEC'
-FQ static method call statement of a class belonging to the global namespace which has been whitelisted:
-- prefix the statement
-- prefix the call
-- See `scope.inc.php` for the built-in global whitelisted classes
-SPEC
-        ,
-        'payload' => <<<'PHP'
+    'FQ static method call statement of a class belonging to the global namespace which has been whitelisted' => <<<'PHP'
 <?php
 
 namespace A;
@@ -144,5 +114,5 @@ use Closure;
 \Closure::bind();
 
 PHP
-    ],
+    ,
 ];

--- a/specs/static-method/namespace-two-parts-with-two-level-use.php
+++ b/specs/static-method/namespace-two-parts-with-two-level-use.php
@@ -22,16 +22,7 @@ return [
         'whitelist-global-functions' => true,
     ],
 
-    [
-        'spec' => <<<'SPEC'
-Static method call statement of a class via a use statement:
-- prefix the namespace
-- prefix the use statement
-- prefix the call
-- transform the call into a FQ call
-SPEC
-        ,
-        'payload' => <<<'PHP'
+    'Static method call statement of a class via a use statement' => <<<'PHP'
 <?php
 
 namespace X {
@@ -66,18 +57,9 @@ use Humbug\X\Foo;
 \Humbug\X\Foo\Bar::main();
 
 PHP
-    ],
+    ,
 
-    [
-        'spec' => <<<'SPEC'
-FQ static method call statement of a class via a use statement:
-- prefix the namespace
-- prefix the use statement
-- prefix the call
-- transform the call into a FQ call
-SPEC
-        ,
-        'payload' => <<<'PHP'
+    'FQ static method call statement of a class via a use statement' => <<<'PHP'
 <?php
 
 namespace X {
@@ -112,17 +94,9 @@ use Humbug\X\Foo;
 \Humbug\Foo\Bar::main();
 
 PHP
-    ],
+    ,
 
-    [
-        'spec' => <<<'SPEC'
-Static method call statement of a whitelisted class via a use statement:
-- prefix the namespace
-- prefix the use statement
-- do not prefix the call
-- transform the call into a FQ call
-SPEC
-        ,
+    'Static method call statement of a whitelisted class via a use statement' => [
         'whitelist' => ['X\Foo\Bar'],
         'payload' => <<<'PHP'
 <?php
@@ -162,15 +136,7 @@ use Humbug\X\Foo;
 PHP
     ],
 
-    [
-        'spec' => <<<'SPEC'
-FQ static method call statement of a non-whitelisted class via a use statement:
-- prefix the namespace
-- prefix the use statement
-- prefix the call
-- transform the call into a FQ call
-SPEC
-        ,
+    'FQ static method call statement of a non-whitelisted class via a use statement' => [
         'whitelist' => ['X\Foo\Bar'],
         'payload' => <<<'PHP'
 <?php

--- a/specs/static-method/namespace-two-parts.php
+++ b/specs/static-method/namespace-two-parts.php
@@ -22,15 +22,7 @@ return [
         'whitelist-global-functions' => true,
     ],
 
-    [
-        'spec' => <<<'SPEC'
-Static method call statement of a class:
-- prefix the namespace
-- prefix the call
-- transform the call into a FQ call
-SPEC
-        ,
-        'payload' => <<<'PHP'
+    'Static method call statement of a class' => <<<'PHP'
 <?php
 
 namespace X\Foo {
@@ -53,17 +45,9 @@ namespace Humbug\X;
 \Humbug\X\Foo\Bar::main();
 
 PHP
-    ],
+    ,
 
-    [
-        'spec' => <<<'SPEC'
-FQ static method call statement of a class:
-- prefix the namespace
-- prefix the call
-- transform the call into a FQ call
-SPEC
-        ,
-        'payload' => <<<'PHP'
+    'FQ static method call statement of a class' => <<<'PHP'
 <?php
 
 namespace Foo {
@@ -86,16 +70,9 @@ namespace Humbug\X;
 \Humbug\Foo\Bar::main();
 
 PHP
-    ],
+    ,
 
-    [
-        'spec' => <<<'SPEC'
-Static method call statement of a whitelisted class:
-- prefix the namespace
-- do not prefix the call
-- transform the call into a FQ call
-SPEC
-        ,
+    'Static method call statement of a whitelisted class' => [
         'whitelist' => ['X\Foo\Bar'],
         'payload' => <<<'PHP'
 <?php
@@ -123,13 +100,7 @@ namespace Humbug\X;
 PHP
     ],
 
-    [
-        'spec' => <<<'SPEC'
-FQ static method call statement of a non-whitelisted class:
-- prefix the namespace
-- prefix the call
-SPEC
-        ,
+    'FQ static method call statement of a non-whitelisted class' => [
         'whitelist' => ['X\Foo\Bar'],
         'payload' => <<<'PHP'
 <?php

--- a/specs/string-literal/array-var.php
+++ b/specs/string-literal/array-var.php
@@ -22,7 +22,7 @@ return [
         'whitelist-global-functions' => true,
     ],
 
-    'String argument: transform into a FQCN and prefix it' => <<<'PHP'
+    'String argument' => <<<'PHP'
 <?php
 
 $x = [

--- a/specs/string-literal/class-const-array.php
+++ b/specs/string-literal/class-const-array.php
@@ -22,7 +22,7 @@ return [
         'whitelist-global-functions' => true,
     ],
 
-    'FQCN string argument: transform into a FQCN and prefix it' => <<<'PHP'
+    'FQCN string argument' => <<<'PHP'
 <?php
 
 class Foo {

--- a/specs/string-literal/class-const.php
+++ b/specs/string-literal/class-const.php
@@ -22,7 +22,7 @@ return [
         'whitelist-global-functions' => true,
     ],
 
-    'FQCN string argument: transform into a FQCN and prefix it' => <<<'PHP'
+    'FQCN string argument' => <<<'PHP'
 <?php
 
 class Foo {

--- a/specs/string-literal/class-prop.php
+++ b/specs/string-literal/class-prop.php
@@ -22,7 +22,7 @@ return [
         'whitelist-global-functions' => true,
     ],
 
-    'FQCN string argument: transform into a FQCN and prefix it' => <<<'PHP'
+    'FQCN string argument' => <<<'PHP'
 <?php
 
 class Foo {

--- a/specs/string-literal/class-var.php
+++ b/specs/string-literal/class-var.php
@@ -22,7 +22,7 @@ return [
         'whitelist-global-functions' => true,
     ],
 
-    'FQCN string argument: transform into a FQCN and prefix it' => <<<'PHP'
+    'FQCN string argument' => <<<'PHP'
 <?php
 
 class Foo {

--- a/specs/use/use-class-alias.php
+++ b/specs/use/use-class-alias.php
@@ -22,14 +22,7 @@ return [
         'whitelist-global-functions' => true,
     ],
 
-    [
-        'spec' => <<<'SPEC'
-Use statement of a class belonging to the global scope:
-- wrap everything in a prefixed namespace
-- prefix the use statement
-SPEC
-        ,
-        'payload' => <<<'PHP'
+    'Use statement of a class belonging to the global scope' => <<<'PHP'
 <?php
 
 class Foo {}
@@ -47,16 +40,9 @@ class Foo
 use Humbug\Foo as A;
 
 PHP
-    ],
+    ,
 
-    [
-        'spec' => <<<'SPEC'
-FQ use statement of a class belonging to the global scope:
-- wrap everything in a prefixed namespace
-- prefix the use statement
-SPEC
-        ,
-        'payload' => <<<'PHP'
+    'FQ use statement of a class belonging to the global scope' => <<<'PHP'
 <?php
 
 class Foo {}
@@ -74,16 +60,9 @@ class Foo
 use Humbug\Foo as A;
 
 PHP
-    ],
+    ,
 
-    [
-        'spec' => <<<'SPEC'
-Use statement of an internal class belonging to the global scope:
-- wrap everything in a prefixed namespace
-- do not prefix the use statement
-SPEC
-        ,
-        'payload' => <<<'PHP'
+    'Use statement of an internal class belonging to the global scope' => <<<'PHP'
 <?php
 
 use ArrayIterator as A;
@@ -96,16 +75,9 @@ namespace Humbug;
 use ArrayIterator as A;
 
 PHP
-    ],
+    ,
 
-    [
-        'spec' => <<<'SPEC'
-FQ use statement of an internal class belonging to the global scope:
-- wrap everything in a prefixed namespace
-- do not prefix the use statement
-SPEC
-        ,
-        'payload' => <<<'PHP'
+    'FQ use statement of an internal class belonging to the global scope' => <<<'PHP'
 <?php
 
 use \ArrayIterator as A;
@@ -118,15 +90,9 @@ namespace Humbug;
 use ArrayIterator as A;
 
 PHP
-    ],
+    ,
 
-    [
-        'spec' => <<<'SPEC'
-Use statement of two-level class:
-- prefix the use statement
-SPEC
-        ,
-        'payload' => <<<'PHP'
+    'Use statement of two-level class' => <<<'PHP'
 <?php
 
 use Foo\Bar as A;
@@ -139,15 +105,9 @@ namespace Humbug;
 use Humbug\Foo\Bar as A;
 
 PHP
-    ],
+    ,
 
-    [
-        'spec' => <<<'SPEC'
-Use statement of two-level class which has been already prefixed:
-- do nothing
-SPEC
-        ,
-        'payload' => <<<'PHP'
+    'Use statement of two-level class which has been already prefixed' => <<<'PHP'
 <?php
 
 use Humbug\Foo\Bar as A;
@@ -160,14 +120,9 @@ namespace Humbug;
 use Humbug\Foo\Bar as A;
 
 PHP
-    ],
+    ,
 
-    [
-        'spec' => <<<'SPEC'
-Use statement of two-level class which has been whitelisted:
-- prefix the use statement
-SPEC
-        ,
+    'Use statement of two-level class which has been whitelisted' => [
         'whitelist' => ['Foo\Bar'],
         'payload' => <<<'PHP'
 <?php

--- a/specs/use/use-class-group.php
+++ b/specs/use/use-class-group.php
@@ -22,14 +22,7 @@ return [
         'whitelist-global-functions' => true,
     ],
 
-    [
-        'spec' => <<<'SPEC'
-Multiple group use statement:
-- transform grouped statements into simple statements
-- prefix each of them
-SPEC
-        ,
-        'payload' => <<<'PHP'
+    'Multiple group use statement' => <<<'PHP'
 <?php
 
 use A\{B};
@@ -48,15 +41,9 @@ use Humbug\A\B\C\D as ABCD;
 use Humbug\A\B\E;
 
 PHP
-    ],
+    ,
 
-    [
-        'spec' => <<<'SPEC'
-Multiple group use statement which are already prefixed:
-- transform grouped statements into simple statements
-SPEC
-        ,
-        'payload' => <<<'PHP'
+    'Multiple group use statement which are already prefixed' => <<<'PHP'
 <?php
 
 use Humbug\A\{B};
@@ -75,15 +62,9 @@ use Humbug\A\B\C\D;
 use Humbug\A\B\E;
 
 PHP
-    ],
+    ,
 
-    [
-        'spec' => <<<'SPEC'
-Multiple group use statement with whitelisted classes:
-- transform grouped statements into simple statements
-- prefix each of them: only actual usages will be whitelisted, not the use statements
-SPEC
-        ,
+    'Multiple group use statement with whitelisted classes' => [
         'whitelist' => [
             'A\B',
             'A\B\C',

--- a/specs/use/use-class.php
+++ b/specs/use/use-class.php
@@ -22,14 +22,7 @@ return [
         'whitelist-global-functions' => true,
     ],
 
-    [
-        'spec' => <<<'SPEC'
-Use statement of a class belonging to the global scope:
-- wrap the statement in a prefixed namespace
-- prefix the use statement
-SPEC
-        ,
-        'payload' => <<<'PHP'
+    'Use statement of a class belonging to the global scope' => <<<'PHP'
 <?php
 
 class Foo {}
@@ -47,16 +40,9 @@ class Foo
 use Humbug\Foo;
 
 PHP
-    ],
+    ,
 
-    [
-        'spec' => <<<'SPEC'
-FQ use statement of a class belonging to the global scope:
-- wrap the statement in a prefixed namespace
-- prefix the use statement
-SPEC
-        ,
-        'payload' => <<<'PHP'
+    'FQ use statement of a class belonging to the global scope' => <<<'PHP'
 <?php
 
 class Foo {}
@@ -74,16 +60,9 @@ class Foo
 use Humbug\Foo;
 
 PHP
-    ],
+    ,
 
-    [
-        'spec' => <<<'SPEC'
-Use statement of an internal class belonging to the global scope:
-- wrap the statement in a prefixed namespace
-- do not prefix the use statement
-SPEC
-        ,
-        'payload' => <<<'PHP'
+    'Use statement of an internal class belonging to the global scope' => <<<'PHP'
 <?php
 
 use ArrayIterator;
@@ -96,16 +75,9 @@ namespace Humbug;
 use ArrayIterator;
 
 PHP
-    ],
+    ,
 
-    [
-        'spec' => <<<'SPEC'
-Use statement of an internal class belonging to the global scope:
-- wrap the statement in a prefixed namespace
-- do not prefix the use statement
-SPEC
-        ,
-        'payload' => <<<'PHP'
+    'Use statement of an internal class belonging to the global scope' => <<<'PHP'
 <?php
 
 use \ArrayIterator;
@@ -118,16 +90,9 @@ namespace Humbug;
 use ArrayIterator;
 
 PHP
-    ],
+    ,
 
-    [
-        'spec' => <<<'SPEC'
-Use statement of a non existent class belonging to the global scope:
-- wrap the statement in a prefixed namespace
-- do not prefix the use statement
-SPEC
-        ,
-        'payload' => <<<'PHP'
+    'Use statement of a non existent class belonging to the global scope' => <<<'PHP'
 <?php
 
 use Unknown;
@@ -140,16 +105,9 @@ namespace Humbug;
 use Humbug\Unknown;
 
 PHP
-    ],
+    ,
 
-    [
-        'spec' => <<<'SPEC'
-Use statement of a whitelisted class belonging to the global scope:
-- wrap the statement in a prefixed namespace
-- prefix the use statement
-- append a class alias statement after the class declaration
-SPEC
-        ,
+    'Use statement of a whitelisted class belonging to the global scope' => [
         'whitelist' => ['Foo'],
         'payload' => <<<'PHP'
 <?php
@@ -172,14 +130,7 @@ use Humbug\Foo;
 PHP
     ],
 
-    [
-        'spec' => <<<'SPEC'
-Use statement of a class belonging to the global scope which has been whitelisted:
-- wrap the statement in a prefixed namespace
-- prefix the use statement
-- append a class alias statement after the class declaration
-SPEC
-        ,
+    'Use statement of a class belonging to the global scope which has been whitelisted' => [
         'whitelist' => ['\*'],
         'payload' => <<<'PHP'
 <?php
@@ -201,14 +152,7 @@ namespace {
 PHP
     ],
 
-    [
-        'spec' => <<<'SPEC'
-Use statement of a whitelisted class belonging to the global scope which has been whitelisted:
-- wrap the statement in a prefixed namespace
-- prefix the use statement
-- append a class alias statement after the class declaration
-SPEC
-        ,
+    'Use statement of a whitelisted class belonging to the global scope which has been whitelisted' => [
         'whitelist' => ['Foo', '\*'],
         'payload' => <<<'PHP'
 <?php
@@ -230,14 +174,7 @@ namespace {
 PHP
     ],
 
-    [
-        'spec' => <<<'SPEC'
-Use statement of two-level class:
-- prefix the namespaces
-- prefix the use statement
-SPEC
-        ,
-        'payload' => <<<'PHP'
+    'Use statement of two-level class' => <<<'PHP'
 <?php
 
 namespace Foo {
@@ -261,16 +198,9 @@ namespace Humbug;
 use Humbug\Foo\Bar;
 
 PHP
-    ],
+    ,
 
-    [
-        'spec' => <<<'SPEC'
-Already prefixed use statement of two-level class:
-- prefix the namespaces
-- prefix the use statement
-SPEC
-        ,
-        'payload' => <<<'PHP'
+    'Already prefixed use statement of two-level class' => <<<'PHP'
 <?php
 
 namespace Foo {
@@ -294,16 +224,9 @@ namespace Humbug;
 use Humbug\Foo\Bar;
 
 PHP
-    ],
+    ,
 
-    [
-        'spec' => <<<'SPEC'
-Use statement of two-level class which has been whitelisted:
-- prefix the namespaces
-- append the class_alias statement to the whitelisted class
-- do not prefix the use statement
-SPEC
-        ,
+    'Use statement of two-level class which has been whitelisted' => [
         'whitelist' => ['Foo\Bar'],
         'payload' => <<<'PHP'
 <?php
@@ -332,13 +255,7 @@ use Humbug\Foo\Bar;
 PHP
     ],
 
-    [
-        'spec' => <<<'SPEC'
-Use statement of two-level class belonging to a whitelisted namespace:
-- prefix the namespaces
-- prefix the use statement
-SPEC
-        ,
+    'Use statement of two-level class belonging to a whitelisted namespace' => [
         'whitelist' => ['Foo\*'],
         'payload' => <<<'PHP'
 <?php
@@ -366,13 +283,7 @@ use Foo\Bar;
 PHP
     ],
 
-    [
-        'spec' => <<<'SPEC'
-Use statement of whitelisted two-level class belonging to a whitelisted namespace:
-- prefix the namespaces
-- prefix the use statement
-SPEC
-        ,
+    'Use statement of whitelisted two-level class belonging to a whitelisted namespace' => [
         'whitelist' => ['Foo', 'Foo\*'],
         'payload' => <<<'PHP'
 <?php

--- a/specs/use/use-const-alias.php
+++ b/specs/use/use-const-alias.php
@@ -22,14 +22,7 @@ return [
         'whitelist-global-functions' => true,
     ],
 
-    [
-        'spec' => <<<'SPEC'
-Constant use statement for a constant belonging to the global namespace:
-- prefix the use statement: as it is extremely rare to use a `use const` statement for a built-in const from the
-global scope, we can relatively safely assume it is a user-land declare static-method which should be prefixed.
-SPEC
-        ,
-        'payload' => <<<'PHP'
+    'Constant use statement for a constant belonging to the global namespace' => <<<'PHP'
 <?php
 
 use const FOO as A;
@@ -42,15 +35,9 @@ namespace Humbug;
 use const Humbug\FOO as A;
 
 PHP
-    ],
+    ,
 
-    [
-        'spec' => <<<'SPEC'
-Constant use statement for a constant belonging to the global namespace and which has already been prefixed:
-- do nothing
-SPEC
-        ,
-        'payload' => <<<'PHP'
+    'Constant use statement for a constant belonging to the global namespace and which has already been prefixed' => <<<'PHP'
 <?php
 
 use const Humbug\FOO as A;
@@ -63,15 +50,9 @@ namespace Humbug;
 use const Humbug\FOO as A;
 
 PHP
-    ],
+    ,
 
-    [
-        'spec' => <<<'SPEC'
-Constant use statement for a namespaced constant:
-- prefix the use statement
-SPEC
-        ,
-        'payload' => <<<'PHP'
+    'Constant use statement for a namespaced constant' => <<<'PHP'
 <?php
 
 use const Foo\BAR as A;
@@ -84,15 +65,9 @@ namespace Humbug;
 use const Humbug\Foo\BAR as A;
 
 PHP
-    ],
+    ,
 
-    [
-        'spec' => <<<'SPEC'
-Constant use statement for a namespaced constant which has already been prefixed:
-- do nothing
-SPEC
-        ,
-        'payload' => <<<'PHP'
+    'Constant use statement for a namespaced constant which has already been prefixed' => <<<'PHP'
 <?php
 
 use const Humbug\Foo\BAR as A;
@@ -105,7 +80,7 @@ namespace Humbug;
 use const Humbug\Foo\BAR as A;
 
 PHP
-    ],
+    ,
 
     'Constant use statement for a namespaced constant which has been whitelisted' => [
         'whitelist' => ['Foo\BAR'],

--- a/specs/use/use-const-alias.php
+++ b/specs/use/use-const-alias.php
@@ -107,7 +107,7 @@ use const Humbug\Foo\BAR as A;
 PHP
     ],
 
-    'Constant use statement for a namespaced constant which has been whitelisted: do nothing' => [
+    'Constant use statement for a namespaced constant which has been whitelisted' => [
         'whitelist' => ['Foo\BAR'],
         'payload' => <<<'PHP'
 <?php

--- a/specs/use/use-const.php
+++ b/specs/use/use-const.php
@@ -22,13 +22,7 @@ return [
         'whitelist-global-functions' => true,
     ],
 
-    [
-        'spec' => <<<'SPEC'
-Constant use statement for a constant belonging to the global namespace:
-- prefix the use statement
-SPEC
-        ,
-        'payload' => <<<'PHP'
+    'Constant use statement for a constant belonging to the global namespace' => <<<'PHP'
 <?php
 
 use const FOO;
@@ -41,15 +35,9 @@ namespace Humbug;
 use const Humbug\FOO;
 
 PHP
-    ],
+    ,
 
-    [
-        'spec' => <<<'SPEC'
-Constant use statement for an internal constant belonging to the global namespace:
-- do not prefix the use statement
-SPEC
-        ,
-        'payload' => <<<'PHP'
+    'Constant use statement for an internal constant belonging to the global namespace' => <<<'PHP'
 <?php
 
 use const DIRECTORY_SEPARATOR;
@@ -62,15 +50,9 @@ namespace Humbug;
 use const DIRECTORY_SEPARATOR;
 
 PHP
-    ],
+    ,
 
-    [
-        'spec' => <<<'SPEC'
-Constant use statement for a constant belonging to the global namespace and which has already been prefixed:
-- do nothing
-SPEC
-        ,
-        'payload' => <<<'PHP'
+    'Constant use statement for a constant belonging to the global namespace and which has already been prefixed' => <<<'PHP'
 <?php
 
 use const Humbug\FOO;
@@ -83,15 +65,9 @@ namespace Humbug;
 use const Humbug\FOO;
 
 PHP
-    ],
+    ,
 
-    [
-        'spec' => <<<'SPEC'
-Constant use statement for a namespaced constant:
-- prefix the use statement
-SPEC
-        ,
-        'payload' => <<<'PHP'
+    'Constant use statement for a namespaced constant' => <<<'PHP'
 <?php
 
 use const Foo\BAR;
@@ -104,15 +80,9 @@ namespace Humbug;
 use const Humbug\Foo\BAR;
 
 PHP
-    ],
+    ,
 
-    [
-        'spec' => <<<'SPEC'
-Constant use statement for a namespaced constant which has already been prefixed:
-- do nothing
-SPEC
-        ,
-        'payload' => <<<'PHP'
+    'Constant use statement for a namespaced constant which has already been prefixed' => <<<'PHP'
 <?php
 
 use const Humbug\Foo\BAR;
@@ -125,7 +95,7 @@ namespace Humbug;
 use const Humbug\Foo\BAR;
 
 PHP
-    ],
+    ,
 
     'Constant use statement for a namespaced constant which has been whitelisted' => [
         'whitelist' => ['Foo\BAR'],

--- a/specs/use/use-const.php
+++ b/specs/use/use-const.php
@@ -127,7 +127,7 @@ use const Humbug\Foo\BAR;
 PHP
     ],
 
-    'Constant use statement for a namespaced constant which has been whitelisted: do nothing' => [
+    'Constant use statement for a namespaced constant which has been whitelisted' => [
         'whitelist' => ['Foo\BAR'],
         'payload' => <<<'PHP'
 <?php

--- a/specs/use/use-func-alias.php
+++ b/specs/use/use-func-alias.php
@@ -22,15 +22,7 @@ return [
         'whitelist-global-functions' => true,
     ],
 
-    [
-        'spec' => <<<'SPEC'
-Use statement for a function belonging to the global namespace:
-- prefix the use statement: as it is extremely rare to use a `use function` statement for a built-in
-function from the global scope, we can relatively safely assume it is a user-land declare static-method
-which should be prefixed.
-SPEC
-        ,
-        'payload' => <<<'PHP'
+    'Use statement for a function belonging to the global namespace' => <<<'PHP'
 <?php
 
 use function foo as greet;
@@ -43,15 +35,9 @@ namespace Humbug;
 use function Humbug\foo as greet;
 
 PHP
-    ],
+    ,
 
-    [
-        'spec' => <<<'SPEC'
-Use statement for a function belonging to the global namespace which has already been prefixed:
-- do nothing
-SPEC
-        ,
-        'payload' => <<<'PHP'
+    'Use statement for a function belonging to the global namespace which has already been prefixed' => <<<'PHP'
 <?php
 
 use function Humbug\foo as greet;
@@ -64,15 +50,9 @@ namespace Humbug;
 use function Humbug\foo as greet;
 
 PHP
-    ],
+    ,
 
-    [
-        'spec' => <<<'SPEC'
-Use statement for a namespaced function:
-- prefix the use statement
-SPEC
-        ,
-        'payload' => <<<'PHP'
+    'Use statement for a namespaced function' => <<<'PHP'
 <?php
 
 use function Foo\bar as greet;
@@ -85,15 +65,9 @@ namespace Humbug;
 use function Humbug\Foo\bar as greet;
 
 PHP
-    ],
+    ,
 
-    [
-        'spec' => <<<'SPEC'
-Use statement for a namespaced function which has already been prefixed:
-- do nothing
-SPEC
-        ,
-        'payload' => <<<'PHP'
+    'Use statement for a namespaced function which has already been prefixed' => <<<'PHP'
 <?php
 
 use function Humbug\Foo\bar as greet;
@@ -106,14 +80,9 @@ namespace Humbug;
 use function Humbug\Foo\bar as greet;
 
 PHP
-    ],
+    ,
 
-    [
-        'spec' => <<<'SPEC'
-Use statement for a namespaced function which has been whitelisted:
-- prefix the use statement: the whitelist only works for classes
-SPEC
-        ,
+    'Use statement for a namespaced function which has been whitelisted' => [
         'whitelist' => ['Foo\bar'],
         'payload' => <<<'PHP'
 <?php

--- a/specs/use/use-func.php
+++ b/specs/use/use-func.php
@@ -22,14 +22,7 @@ return [
         'whitelist-global-functions' => true,
     ],
 
-    [
-        'spec' => <<<'SPEC'
-Use statement for a function belonging to the global namespace:
-- wrap the code in a prefixed namespace
-- prefix the use statement
-SPEC
-        ,
-        'payload' => <<<'PHP'
+    'Use statement for a function belonging to the global namespace' => <<<'PHP'
 <?php
 
 use function foo;
@@ -42,16 +35,9 @@ namespace Humbug;
 use function Humbug\foo;
 
 PHP
-    ],
+    ,
 
-    [
-        'spec' => <<<'SPEC'
-Use statement for an internal function belonging to the global namespace:
-- wrap the code in a prefixed namespace
-- do not prefix the use statement
-SPEC
-        ,
-        'payload' => <<<'PHP'
+    'Use statement for an internal function belonging to the global namespace' => <<<'PHP'
 <?php
 
 use function is_array;
@@ -64,15 +50,9 @@ namespace Humbug;
 use function is_array;
 
 PHP
-    ],
+    ,
 
-    [
-        'spec' => <<<'SPEC'
-Use statement for a function belonging to the global namespace which has already been prefixed:
-- do nothing
-SPEC
-        ,
-        'payload' => <<<'PHP'
+    'Use statement for a function belonging to the global namespace which has already been prefixed' => <<<'PHP'
 <?php
 
 use function Humbug\foo;
@@ -85,15 +65,9 @@ namespace Humbug;
 use function Humbug\foo;
 
 PHP
-    ],
+    ,
 
-    [
-        'spec' => <<<'SPEC'
-Use statement for a namespaced function:
-- prefix the use statement
-SPEC
-        ,
-        'payload' => <<<'PHP'
+    'Use statement for a namespaced function' => <<<'PHP'
 <?php
 
 use function Foo\bar;
@@ -106,15 +80,9 @@ namespace Humbug;
 use function Humbug\Foo\bar;
 
 PHP
-    ],
+    ,
 
-    [
-        'spec' => <<<'SPEC'
-Use statement for a namespaced function which has already been prefixed:
-- do nothing
-SPEC
-        ,
-        'payload' => <<<'PHP'
+    'Use statement for a namespaced function which has already been prefixed' => <<<'PHP'
 <?php
 
 use function Humbug\Foo\bar;
@@ -127,13 +95,9 @@ namespace Humbug;
 use function Humbug\Foo\bar;
 
 PHP
-    ],
+    ,
 
-    [
-        'spec' => <<<'SPEC'
-Use statement for a namespaced function which has been whitelisted
-SPEC
-        ,
+    'Use statement for a namespaced function which has been whitelisted' => [
         'whitelist' => ['Foo\bar'],
         'payload' => <<<'PHP'
 <?php


### PR DESCRIPTION
The original intent was to give a detail spec explanation: describe what the test is about and the expected result. It however turns out to be 1. very hard to do correctly and 2. impossible to maintain. So I think keeping the spec description without the expected result is good enough