### PR TITLE
Whitelist functions as soon as they are used

### DIFF
--- a/specs/const/const-declaration-with-global-whitelisting.php
+++ b/specs/const/const-declaration-with-global-whitelisting.php
@@ -20,7 +20,7 @@ return [
         'whitelist' => [],
         'whitelist-global-constants' => true,
         'whitelist-global-classes' => false,
-        'whitelist-global-functions' => true,
+        'whitelist-global-functions' => false,
         'registered-classes' => [],
         'registered-functions' => [],
     ],

--- a/specs/const/const-declaration.php
+++ b/specs/const/const-declaration.php
@@ -20,7 +20,7 @@ return [
         'whitelist' => [],
         'whitelist-global-constants' => false,
         'whitelist-global-classes' => false,
-        'whitelist-global-functions' => true,
+        'whitelist-global-functions' => false,
         'registered-classes' => [],
         'registered-functions' => [],
     ],

--- a/specs/function/global-scope-global-func-with-single-level-use-statement-and-alias.php
+++ b/specs/function/global-scope-global-func-with-single-level-use-statement-and-alias.php
@@ -20,7 +20,7 @@ return [
         'whitelist' => [],
         'whitelist-global-constants' => true,
         'whitelist-global-classes' => false,
-        'whitelist-global-functions' => true,
+        'whitelist-global-functions' => false,
         'registered-classes' => [],
         'registered-functions' => [],
     ],
@@ -42,6 +42,28 @@ use function Humbug\main as foo;
 PHP
     ,
 
+    'Global function call imported with a use statement in the global scope with global functions whitelisted' => [
+        'whitelist-global-functions' => true,
+        'registered-functions' => [
+            ['main', 'Humbug\main'],
+        ],
+        'payload' => <<<'PHP'
+<?php
+
+use function main as foo;
+
+foo();
+----
+<?php
+
+namespace Humbug;
+
+use function Humbug\main as foo;
+\Humbug\main();
+
+PHP
+    ],
+
     'Global FQ function call imported with a use statement in the global scope' => <<<'PHP'
 <?php
 
@@ -58,4 +80,26 @@ use function Humbug\main as foo;
 
 PHP
     ,
+
+    'Global FQ function call imported with a use statement in the global scope with global functions whitelisted' => [
+        'whitelist-global-functions' => true,
+        'registered-functions' => [
+            ['foo', 'Humbug\foo'],
+        ],
+        'payload' => <<<'PHP'
+<?php
+
+use function main as foo;
+
+\foo();
+----
+<?php
+
+namespace Humbug;
+
+use function Humbug\main as foo;
+\Humbug\foo();
+
+PHP
+    ],
 ];

--- a/specs/function/global-scope-global-func.php
+++ b/specs/function/global-scope-global-func.php
@@ -20,7 +20,7 @@ return [
         'whitelist' => [],
         'whitelist-global-constants' => true,
         'whitelist-global-classes' => false,
-        'whitelist-global-functions' => true,
+        'whitelist-global-functions' => false,
         'registered-classes' => [],
         'registered-functions' => [],
     ],

--- a/specs/function/global-scope-single-part-namespaced-func.php
+++ b/specs/function/global-scope-single-part-namespaced-func.php
@@ -20,7 +20,7 @@ return [
         'whitelist' => [],
         'whitelist-global-constants' => true,
         'whitelist-global-classes' => false,
-        'whitelist-global-functions' => true,
+        'whitelist-global-functions' => false,
         'registered-classes' => [],
         'registered-functions' => [],
     ],
@@ -55,6 +55,9 @@ PHP
 
     'Whitelisted namespaced function call' => [
         'whitelist' => ['PHPUnit\main'],
+        'registered-functions' => [
+            ['PHPUnit\main', 'Humbug\PHPUnit\main'],
+        ],
         'payload' => <<<'PHP'
 <?php
 
@@ -71,6 +74,9 @@ PHP
 
     'FQ whitelisted namespaced function call' => [
         'whitelist' => ['PHPUnit\main'],
+        'registered-functions' => [
+            ['PHPUnit\main', 'Humbug\PHPUnit\main'],
+        ],
         'payload' => <<<'PHP'
 <?php
 

--- a/specs/function/namespace-global-func-with-single-level-use-statement-and-alias.php
+++ b/specs/function/namespace-global-func-with-single-level-use-statement-and-alias.php
@@ -20,7 +20,7 @@ return [
         'whitelist' => [],
         'whitelist-global-constants' => true,
         'whitelist-global-classes' => false,
-        'whitelist-global-functions' => true,
+        'whitelist-global-functions' => false,
         'registered-classes' => [],
         'registered-functions' => [],
     ],

--- a/specs/function/namespace-global-func-with-single-level-use-statement.php
+++ b/specs/function/namespace-global-func-with-single-level-use-statement.php
@@ -20,7 +20,7 @@ return [
         'whitelist' => [],
         'whitelist-global-constants' => true,
         'whitelist-global-classes' => false,
-        'whitelist-global-functions' => true,
+        'whitelist-global-functions' => false,
         'registered-classes' => [],
         'registered-functions' => [],
     ],

--- a/specs/function/namespace-global-func.php
+++ b/specs/function/namespace-global-func.php
@@ -20,7 +20,7 @@ return [
         'whitelist' => [],
         'whitelist-global-constants' => true,
         'whitelist-global-classes' => false,
-        'whitelist-global-functions' => true,
+        'whitelist-global-functions' => false,
         'registered-classes' => [],
         'registered-functions' => [],
     ],

--- a/specs/function/namespace-global-scope-func.php
+++ b/specs/function/namespace-global-scope-func.php
@@ -20,7 +20,7 @@ return [
         'whitelist' => [],
         'whitelist-global-constants' => true,
         'whitelist-global-classes' => false,
-        'whitelist-global-functions' => true,
+        'whitelist-global-functions' => false,
         'registered-classes' => [],
         'registered-functions' => [],
     ],

--- a/specs/function/namespace-single-part-namespaced-func.php
+++ b/specs/function/namespace-single-part-namespaced-func.php
@@ -20,7 +20,7 @@ return [
         'whitelist' => [],
         'whitelist-global-constants' => true,
         'whitelist-global-classes' => false,
-        'whitelist-global-functions' => true,
+        'whitelist-global-functions' => false,
         'registered-classes' => [],
         'registered-functions' => [],
     ],
@@ -59,6 +59,7 @@ PHP
 
     'Whitelisted namespaced function call' => [
         'whitelist' => ['PHPUnit\X\main'],
+        // No function registered to the whitelist here since no FQ could be resolved
         'payload' => <<<'PHP'
 <?php
 
@@ -77,6 +78,9 @@ PHP
 
     'FQ whitelisted namespaced function call' => [
         'whitelist' => ['PHPUnit\main'],
+        'registered-functions' => [
+            ['PHPUnit\main', 'Humbug\PHPUnit\main'],
+        ],
         'payload' => <<<'PHP'
 <?php
 

--- a/specs/function/whitelist-func-existence-checked.php
+++ b/specs/function/whitelist-func-existence-checked.php
@@ -1,0 +1,114 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the humbug/php-scoper package.
+ *
+ * Copyright (c) 2017 Théo FIDRY <theo.fidry@gmail.com>,
+ *                    Pádraic Brady <padraic.brady@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+return [
+    'meta' => [
+        'title' => 'Whitelisting functions which are never declared but for which the existence is checked',
+        // Default values. If not specified will be the one used
+        'prefix' => 'Humbug',
+        'whitelist' => [],
+        'whitelist-global-constants' => false,
+        'whitelist-global-classes' => false,
+        'whitelist-global-functions' => false,
+        'registered-classes' => [],
+        'registered-functions' => [],
+    ],
+
+    'Non whitelisted global function call' => <<<'PHP'
+<?php
+
+function_exists('main');
+----
+<?php
+
+namespace Humbug;
+
+\function_exists('Humbug\\main');
+
+PHP
+    ,
+
+    'Whitelisted global function call' => [
+        'whitelist' => ['main'],
+        'registered-functions' => [
+            ['main', 'Humbug\main'],
+        ],
+        'payload' => <<<'PHP'
+<?php
+
+function_exists('main');
+----
+<?php
+
+namespace Humbug;
+
+\function_exists('Humbug\\main');
+
+PHP
+    ],
+
+    'Global function call with whitelisted global functions' => [
+        'whitelist-global-functions' => true,
+        'registered-functions' => [
+            ['main', 'Humbug\main'],
+        ],
+        'payload' => <<<'PHP'
+<?php
+
+function_exists('main');
+----
+<?php
+
+namespace Humbug;
+
+\function_exists('Humbug\\main');
+
+PHP
+    ],
+
+    'Global function call with non-whitelisted global functions' => <<<'PHP'
+<?php
+
+function_exists('main');
+----
+<?php
+
+namespace Humbug;
+
+\function_exists('Humbug\\main');
+
+PHP
+    ,
+
+    'Whitelisted namespaced function call' => [
+        'whitelist' => ['Acme\main'],
+        'registered-functions' => [
+            ['Acme\main', 'Humbug\Acme\main'],
+        ],
+        'payload' => <<<'PHP'
+<?php
+
+namespace Acme;
+
+function_exists('Acme\main');
+----
+<?php
+
+namespace Humbug\Acme;
+
+\function_exists('Humbug\\Acme\\main');
+
+PHP
+    ],
+];

--- a/specs/function/whitelist-func-used.php
+++ b/specs/function/whitelist-func-used.php
@@ -14,21 +14,19 @@ declare(strict_types=1);
 
 return [
     'meta' => [
-        'title' => 'Global function call imported with a use statement in the global scope',
+        'title' => 'Whitelisting functions which are never declared',
         // Default values. If not specified will be the one used
         'prefix' => 'Humbug',
         'whitelist' => [],
-        'whitelist-global-constants' => true,
+        'whitelist-global-constants' => false,
         'whitelist-global-classes' => false,
         'whitelist-global-functions' => false,
         'registered-classes' => [],
         'registered-functions' => [],
     ],
 
-    'Global function call imported with a use statement in the global scope' => <<<'PHP'
+    'Non whitelisted global function call' => <<<'PHP'
 <?php
-
-use function main;
 
 main();
 ----
@@ -36,52 +34,31 @@ main();
 
 namespace Humbug;
 
-use function Humbug\main;
 \Humbug\main();
 
 PHP
     ,
 
-    'Global function call imported with a use statement in the global scope with global functions whitelisted' => [
-        'whitelist-global-functions' => true,
+    'Whitelisted global function call' => [
+        'whitelist' => ['main'],
         'registered-functions' => [
             ['main', 'Humbug\main'],
         ],
         'payload' => <<<'PHP'
 <?php
 
-use function main;
-
 main();
 ----
 <?php
 
 namespace Humbug;
 
-use function Humbug\main;
 \Humbug\main();
 
 PHP
     ],
 
-    'Global FQ function call imported with a use statement in the global scope' => <<<'PHP'
-<?php
-
-use function main;
-
-\main();
-----
-<?php
-
-namespace Humbug;
-
-use function Humbug\main;
-\Humbug\main();
-
-PHP
-    ,
-
-    'Global FQ function call imported with a use statement in the global scope with global functions whitelisted' => [
+    'Global function call with whitelisted global functions' => [
         'whitelist-global-functions' => true,
         'registered-functions' => [
             ['main', 'Humbug\main'],
@@ -89,16 +66,46 @@ PHP
         'payload' => <<<'PHP'
 <?php
 
-use function main;
-
-\main();
+main();
 ----
 <?php
 
 namespace Humbug;
 
-use function Humbug\main;
 \Humbug\main();
+
+PHP
+    ],
+
+    'Global function call with non-whitelisted global functions' => <<<'PHP'
+<?php
+
+main();
+----
+<?php
+
+namespace Humbug;
+
+\Humbug\main();
+
+PHP
+    ,
+
+    'Whitelisted namespaced function call' => [
+        'whitelist' => ['Acme\main'],
+        'registered-functions' => [],   // Nothing registered here since the FQ could not be resolved
+        'payload' => <<<'PHP'
+<?php
+
+namespace Acme;
+
+main();
+----
+<?php
+
+namespace Humbug\Acme;
+
+main();
 
 PHP
     ],

--- a/specs/string-literal/func-arg.php
+++ b/specs/string-literal/func-arg.php
@@ -18,9 +18,9 @@ return [
         // Default values. If not specified will be the one used
         'prefix' => 'Humbug',
         'whitelist' => [],
-        'whitelist-global-constants' => true,
+        'whitelist-global-constants' => false,
         'whitelist-global-classes' => false,
-        'whitelist-global-functions' => true,
+        'whitelist-global-functions' => false,
         'registered-classes' => [],
         'registered-functions' => [],
     ],

--- a/src/PhpParser/NodeVisitor/Collection/NamespaceStmtCollection.php
+++ b/src/PhpParser/NodeVisitor/Collection/NamespaceStmtCollection.php
@@ -67,6 +67,17 @@ final class NamespaceStmtCollection implements IteratorAggregate, Countable
         return $this->getNodeNamespace($node);
     }
 
+    public function findNamespaceByName(string $name): ?Name
+    {
+        foreach ($this->nodes as $node) {
+            if ((string) $node->name === $name) {
+                return $node->name;
+            }
+        }
+
+        return null;
+    }
+
     public function getCurrentNamespaceName(): ?Name
     {
         if (0 === count($this->nodes)) {

--- a/src/PhpParser/NodeVisitor/Resolver/FullyQualifiedNameResolver.php
+++ b/src/PhpParser/NodeVisitor/Resolver/FullyQualifiedNameResolver.php
@@ -19,15 +19,15 @@ use Humbug\PhpScoper\PhpParser\NodeVisitor\Collection\NamespaceStmtCollection;
 use Humbug\PhpScoper\PhpParser\NodeVisitor\Collection\UseStmtCollection;
 use Humbug\PhpScoper\PhpParser\NodeVisitor\NameStmtPrefixer;
 use Humbug\PhpScoper\PhpParser\NodeVisitor\ParentNodeAppender;
-use function ltrim;
 use PhpParser\Node;
 use PhpParser\Node\Expr\ConstFetch;
 use PhpParser\Node\Expr\FuncCall;
 use PhpParser\Node\Identifier;
 use PhpParser\Node\Name;
 use PhpParser\Node\Name\FullyQualified;
-use function in_array;
 use PhpParser\Node\Scalar\String_;
+use function in_array;
+use function ltrim;
 
 /**
  * Attempts to resolve the node name into a fully qualified node. Returns a valid (non fully-qualified) name node on

--- a/src/PhpParser/TraverserFactory.php
+++ b/src/PhpParser/TraverserFactory.php
@@ -49,7 +49,7 @@ class TraverserFactory
         $traverser->addVisitor(new NodeVisitor\UseStmt\UseStmtCollector($namespaceStatements, $useStatements));
         $traverser->addVisitor(new NodeVisitor\UseStmt\UseStmtPrefixer($prefix, $whitelist, $this->reflector));
 
-        $traverser->addVisitor(new NodeVisitor\FunctionIdentifierRecorder($prefix, $nameResolver, $whitelist));
+        $traverser->addVisitor(new NodeVisitor\FunctionIdentifierRecorder($prefix, $nameResolver, $whitelist, $this->reflector));
         $traverser->addVisitor(new NodeVisitor\ClassIdentifierRecorder($prefix, $nameResolver, $whitelist));
         $traverser->addVisitor(new NodeVisitor\NameStmtPrefixer($prefix, $whitelist, $nameResolver, $this->reflector));
         $traverser->addVisitor(new NodeVisitor\StringScalarPrefixer($prefix, $whitelist, $this->reflector));

--- a/tests/Scoper/PhpScoperSpecTest.php
+++ b/tests/Scoper/PhpScoperSpecTest.php
@@ -14,11 +14,13 @@ declare(strict_types=1);
 
 namespace Humbug\PhpScoper\Scoper;
 
+use Error;
 use Generator;
 use Humbug\PhpScoper\PhpParser\TraverserFactory;
 use Humbug\PhpScoper\Reflector;
 use Humbug\PhpScoper\Scoper;
 use Humbug\PhpScoper\Whitelist;
+use PHPUnit\Framework\AssertionFailedError;
 use PHPUnit\Framework\TestCase;
 use Roave\BetterReflection\BetterReflection;
 use Roave\BetterReflection\Reflector\ClassReflector;
@@ -113,7 +115,15 @@ class PhpScoperSpecTest extends TestCase
 
             return;
         } catch (Throwable $throwable) {
-            $this->fail('Could not parse the spec: '.$spec);
+            throw new Error(
+                sprintf(
+                    'Could not parse the spec %s: %s',
+                    $spec,
+                    $throwable->getMessage()
+                ),
+                0,
+                $throwable
+            );
         }
 
         $specMessage = $this->createSpecMessage(

--- a/tests/Scoper/PhpScoperSpecTest.php
+++ b/tests/Scoper/PhpScoperSpecTest.php
@@ -20,7 +20,6 @@ use Humbug\PhpScoper\PhpParser\TraverserFactory;
 use Humbug\PhpScoper\Reflector;
 use Humbug\PhpScoper\Scoper;
 use Humbug\PhpScoper\Whitelist;
-use PHPUnit\Framework\AssertionFailedError;
 use PHPUnit\Framework\TestCase;
 use Roave\BetterReflection\BetterReflection;
 use Roave\BetterReflection\Reflector\ClassReflector;


### PR DESCRIPTION
Previously, if you had the following code:

```php
namespace Acme;

if (function_exists('foo')) {
    \foo();
}
```

with `foo` being in the whitelist, the function would have not been whitelisted. The reasoning was that the recording of whitelisted elements was the same for functions and classes. For classes, it makes sense since the whitelisting will not work if the whitelisted class declaration is not found, however this is not the case for functions since the declaration dumped in the `scoper-autoload.php` is sufficient.

With this PR, the function `foo` above is now prefixed, which should allow cases like [this one](https://github.com/humbug/box/issues/193#issuecomment-431915508) to work out of the box, either by whitelisting the global functions or by manually whitelisting it.