### PR TITLE
Fix running the tests with phpdbg

### DIFF
--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -6,7 +6,7 @@ build:
     tests:
         override:
             -
-                command: 'phpdbg -qrr -d zend.enable_gc=0 bin/phpunit --coverage-clover=coverage.clover --exclude-group=integration'
+                command: 'phpdbg -qrr bin/phpunit --coverage-clover=coverage.clover --exclude-group=integration'
                 coverage:
                     file: 'coverage.clover'
                     format: 'clover'

--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -6,7 +6,7 @@ build:
     tests:
         override:
             -
-                command: 'phpdbg -qrr -d zend.enable_gc=0 bin/phpunit --coverage-clover=coverage.clover'
+                command: 'phpdbg -qrr -d zend.enable_gc=0 bin/phpunit --coverage-clover=coverage.clover --exclude-group=integration'
                 coverage:
                     file: 'coverage.clover'
                     format: 'clover'

--- a/tests/Console/Command/AddPrefixCommandTest.php
+++ b/tests/Console/Command/AddPrefixCommandTest.php
@@ -31,7 +31,6 @@ use function preg_replace;
 
 /**
  * @covers \Humbug\PhpScoper\Console\Command\AddPrefixCommand
- * @runTestsInSeparateProcesses
  */
 class AddPrefixCommandTest extends FileSystemTestCase
 {


### PR DESCRIPTION
Remove the unnecessary run in separate process PHPUnit annotation for the `AddPrefixCommand` unit test and ignore `integration` (the PHPUnit group) tests.