### PR TITLE
Add support for the eval function

### DIFF
--- a/specs/eval.php
+++ b/specs/eval.php
@@ -1,0 +1,209 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the humbug/php-scoper package.
+ *
+ * Copyright (c) 2017 Théo FIDRY <theo.fidry@gmail.com>,
+ *                    Pádraic Brady <padraic.brady@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+return [
+    'meta' => [
+        'title' => 'Eval',
+        // Default values. If not specified will be the one used
+        'prefix' => 'Humbug',
+        'whitelist' => [],
+        'whitelist-global-constants' => false,
+        'whitelist-global-classes' => false,
+        'whitelist-global-functions' => false,
+        'registered-classes' => [],
+        'registered-functions' => [],
+    ],
+
+    'string' => <<<'PHP'
+<?php
+
+eval('
+<?php
+
+use Acme\Foo;
+
+');
+
+----
+<?php
+
+namespace Humbug;
+
+eval('
+<?php 
+namespace Humbug;
+
+use Humbug\\Acme\\Foo;
+');
+
+PHP
+    ,
+
+    'string with invalid PHP' => <<<'PHP'
+<?php
+
+eval('invalid PHP');
+
+----
+<?php
+
+namespace Humbug;
+
+eval('invalid PHP');
+
+PHP
+    ,
+
+    'concatenated string' => <<<'PHP'
+<?php
+
+eval('<?php'.' echo "Hello!";');
+
+----
+<?php
+
+namespace Humbug;
+
+eval('<?php' . ' echo "Hello!";');
+
+PHP
+    ,
+
+    'Nowdoc' => <<<'PHP'
+<?php
+
+eval(<<<'PHP_NOWDOC'
+<?php
+
+use Acme\Foo;
+
+PHP_NOWDOC
+);
+
+eval(<<<'PHP_NOWDOC'
+<?php
+
+use Acme\Foo;
+PHP_NOWDOC
+);
+
+----
+<?php
+
+namespace Humbug;
+
+eval(<<<'PHP_NOWDOC'
+<?php
+
+namespace Humbug;
+
+use Humbug\Acme\Foo;
+
+PHP_NOWDOC
+);
+eval(<<<'PHP_NOWDOC'
+<?php
+
+namespace Humbug;
+
+use Humbug\Acme\Foo;
+PHP_NOWDOC
+);
+
+PHP
+    ,
+
+    'Nowdoc with invalid PHP' => <<<'PHP'
+<?php
+
+eval(<<<'PHP_NOWDOC'
+Not.php
+PHP_NOWDOC
+);
+
+----
+<?php
+
+namespace Humbug;
+
+eval(<<<'PHP_NOWDOC'
+Not.php
+PHP_NOWDOC
+);
+
+PHP
+    ,
+
+    'Heredoc' => <<<'PHP'
+<?php
+
+eval(<<<PHP_HEREDOC
+<?php
+
+use Acme\Foo;
+
+PHP_HEREDOC
+);
+
+----
+<?php
+
+namespace Humbug;
+
+eval(<<<PHP_HEREDOC
+<?php
+
+namespace Humbug;
+
+use Humbug\\Acme\\Foo;
+
+PHP_HEREDOC
+);
+
+PHP
+    ,
+
+     'string with whitelisted function' => [
+         'whitelist' => ['Acme\foo'],
+         'registered-functions' => [
+             ['Acme\foo', 'Humbug\Acme\foo'],
+         ],
+         'payload' => <<<'PHP'
+<?php
+
+eval('<?php
+
+namespace Acme;
+
+function foo() {}
+
+');
+
+----
+<?php
+
+namespace Humbug;
+
+eval('<?php
+
+namespace Humbug\\Acme;
+
+function foo()
+{
+}
+');
+
+PHP
+    ],
+];

--- a/src/PhpParser/NodeVisitor/EvalPrefixer.php
+++ b/src/PhpParser/NodeVisitor/EvalPrefixer.php
@@ -15,16 +15,10 @@ declare(strict_types=1);
 namespace Humbug\PhpScoper\PhpParser\NodeVisitor;
 
 use Humbug\PhpScoper\PhpParser\StringScoperPrefixer;
-use Humbug\PhpScoper\Scoper\PhpScoper;
-use Humbug\PhpScoper\Whitelist;
-use PhpParser\Error as PhpParserError;
 use PhpParser\Node;
 use PhpParser\Node\Expr\Eval_;
 use PhpParser\Node\Scalar\String_;
 use PhpParser\NodeVisitorAbstract;
-use function ltrim;
-use function strpos;
-use function substr;
 
 final class EvalPrefixer extends NodeVisitorAbstract
 {

--- a/src/PhpParser/NodeVisitor/EvalPrefixer.php
+++ b/src/PhpParser/NodeVisitor/EvalPrefixer.php
@@ -19,13 +19,14 @@ use Humbug\PhpScoper\Scoper\PhpScoper;
 use Humbug\PhpScoper\Whitelist;
 use PhpParser\Error as PhpParserError;
 use PhpParser\Node;
+use PhpParser\Node\Expr\Eval_;
 use PhpParser\Node\Scalar\String_;
 use PhpParser\NodeVisitorAbstract;
 use function ltrim;
 use function strpos;
 use function substr;
 
-final class NewdocPrefixer extends NodeVisitorAbstract
+final class EvalPrefixer extends NodeVisitorAbstract
 {
     use StringScoperPrefixer;
 
@@ -34,22 +35,10 @@ final class NewdocPrefixer extends NodeVisitorAbstract
      */
     public function enterNode(Node $node): Node
     {
-        if ($node instanceof String_ && $this->isPhpNowdoc($node)) {
+        if ($node instanceof String_ && ParentNodeAppender::findParent($node) instanceof Eval_) {
             $this->scopeStringValue($node);
         }
 
         return $node;
-    }
-
-    private function isPhpNowdoc(String_ $node): bool
-    {
-        if (String_::KIND_NOWDOC !== $node->getAttribute('kind')) {
-            return false;
-        }
-
-        return 0 === strpos(
-            substr(ltrim($node->value), 0, 5),
-            '<?php'
-        );
     }
 }

--- a/src/PhpParser/NodeVisitor/NewdocPrefixer.php
+++ b/src/PhpParser/NodeVisitor/NewdocPrefixer.php
@@ -15,9 +15,6 @@ declare(strict_types=1);
 namespace Humbug\PhpScoper\PhpParser\NodeVisitor;
 
 use Humbug\PhpScoper\PhpParser\StringScoperPrefixer;
-use Humbug\PhpScoper\Scoper\PhpScoper;
-use Humbug\PhpScoper\Whitelist;
-use PhpParser\Error as PhpParserError;
 use PhpParser\Node;
 use PhpParser\Node\Scalar\String_;
 use PhpParser\NodeVisitorAbstract;

--- a/src/PhpParser/StringScoperPrefixer.php
+++ b/src/PhpParser/StringScoperPrefixer.php
@@ -17,12 +17,7 @@ namespace Humbug\PhpScoper\PhpParser;
 use Humbug\PhpScoper\Scoper\PhpScoper;
 use Humbug\PhpScoper\Whitelist;
 use PhpParser\Error as PhpParserError;
-use PhpParser\Node;
-use PhpParser\Node\Expr\Eval_;
 use PhpParser\Node\Scalar\String_;
-use PhpParser\NodeVisitorAbstract;
-use function ltrim;
-use function strpos;
 use function substr;
 
 trait StringScoperPrefixer

--- a/src/PhpParser/StringScoperPrefixer.php
+++ b/src/PhpParser/StringScoperPrefixer.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the humbug/php-scoper package.
+ *
+ * Copyright (c) 2017 Théo FIDRY <theo.fidry@gmail.com>,
+ *                    Pádraic Brady <padraic.brady@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Humbug\PhpScoper\PhpParser;
+
+use Humbug\PhpScoper\Scoper\PhpScoper;
+use Humbug\PhpScoper\Whitelist;
+use PhpParser\Error as PhpParserError;
+use PhpParser\Node;
+use PhpParser\Node\Expr\Eval_;
+use PhpParser\Node\Scalar\String_;
+use PhpParser\NodeVisitorAbstract;
+use function ltrim;
+use function strpos;
+use function substr;
+
+trait StringScoperPrefixer
+{
+    private $scoper;
+    private $prefix;
+    private $whitelist;
+
+    public function __construct(PhpScoper $scoper, string $prefix, Whitelist $whitelist)
+    {
+        $this->scoper = $scoper;
+        $this->prefix = $prefix;
+        $this->whitelist = $whitelist;
+    }
+
+    private function scopeStringValue(String_ $node): void
+    {
+        try {
+            $lastChar = substr($node->value, -1);
+
+            $newValue = $this->scoper->scopePhp($node->value, $this->prefix, $this->whitelist);
+
+            if ("\n" !== $lastChar) {
+                $newValue = substr($newValue, 0, -1);
+            }
+
+            $node->value = $newValue;
+        } catch (PhpParserError $error) {
+            // Continue without scoping the heredoc which for some reasons contains invalid PHP code
+        }
+    }
+}

--- a/src/PhpParser/TraverserFactory.php
+++ b/src/PhpParser/TraverserFactory.php
@@ -55,6 +55,7 @@ class TraverserFactory
         $traverser->addVisitor(new NodeVisitor\NameStmtPrefixer($prefix, $whitelist, $nameResolver, $this->reflector));
         $traverser->addVisitor(new NodeVisitor\StringScalarPrefixer($prefix, $whitelist, $this->reflector));
         $traverser->addVisitor(new NodeVisitor\NewdocPrefixer($scoper, $prefix, $whitelist));
+        $traverser->addVisitor(new NodeVisitor\EvalPrefixer($scoper, $prefix, $whitelist));
 
         $traverser->addVisitor(new NodeVisitor\ClassAliasStmtAppender($prefix, $whitelist, $nameResolver));
         $traverser->addVisitor(new NodeVisitor\ConstStmtReplacer($whitelist, $nameResolver));


### PR DESCRIPTION
Attempt to scope the content of the eval function whenever possible. Leave the expression unchanged
otherwise.