### PR TITLE
Fix unit tests for Windows

### DIFF
--- a/fixtures/set016-symfony-finder/main.php
+++ b/fixtures/set016-symfony-finder/main.php
@@ -7,7 +7,7 @@ use Symfony\Component\Finder\SplFileInfo;
 
 require_once __DIR__ . '/vendor/autoload.php';
 
-$finder = Finder::create()->files()->in(__DIR__)->depth(0);
+$finder = Finder::create()->files()->in(__DIR__)->depth(0)->sortByName();
 
 foreach ($finder as $fileInfo) {
     /** @var SplFileInfo $fileInfo */

--- a/fixtures/set023/expected-output
+++ b/fixtures/set023/expected-output
@@ -2,5 +2,5 @@ composer.json
 composer.lock
 expected-output
 main.php
-scoper.inc.php
 output
+scoper.inc.php

--- a/fixtures/set023/main.php
+++ b/fixtures/set023/main.php
@@ -7,7 +7,7 @@ use Symfony\Component\Finder\SplFileInfo;
 
 require_once __DIR__ . '/vendor/autoload.php';
 
-$finder = Finder::create()->files()->in(__DIR__)->depth(0);
+$finder = Finder::create()->files()->in(__DIR__)->depth(0)->sortByName();
 
 foreach ($finder as $fileInfo) {
     /** @var SplFileInfo $fileInfo */

--- a/src/Autoload/ScoperAutoloadGenerator.php
+++ b/src/Autoload/ScoperAutoloadGenerator.php
@@ -16,10 +16,10 @@ namespace Humbug\PhpScoper\Autoload;
 
 use Humbug\PhpScoper\Whitelist;
 use PhpParser\Node\Name\FullyQualified;
-use const PHP_EOL;
 use function array_column;
 use function array_map;
 use function array_unshift;
+use function chr;
 use function sprintf;
 use function str_repeat;
 use function str_replace;
@@ -28,10 +28,12 @@ use function strpos;
 final class ScoperAutoloadGenerator
 {
     private $whitelist;
+    private $eol;
 
     public function __construct(Whitelist $whitelist)
     {
         $this->whitelist = $whitelist;
+        $this->eol = chr(10);
     }
 
     public function dump(string $prefix): string
@@ -41,16 +43,16 @@ final class ScoperAutoloadGenerator
         $hasNamespacedFunctions = $this->hasNamespacedFunctions($whitelistedFunctions);
 
         $statements = implode(
-            PHP_EOL,
+            $this->eol,
             $this->createClassAliasStatements(
                 $this->whitelist->getRecordedWhitelistedClasses(),
                 $hasNamespacedFunctions)
             )
-            .PHP_EOL
-            .PHP_EOL
+            .$this->eol
+            .$this->eol
         ;
         $statements .= implode(
-            PHP_EOL,
+            $this->eol,
             $this->createFunctionAliasStatements(
                 $whitelistedFunctions,
                 $hasNamespacedFunctions
@@ -125,7 +127,7 @@ PHP;
             );
 
             array_unshift($statements, 'namespace {');
-            $statements[] = '}'.PHP_EOL;
+            $statements[] = '}'.$this->eol;
         }
 
         array_unshift(

--- a/src/Scoper/Composer/InstalledPackagesScoper.php
+++ b/src/Scoper/Composer/InstalledPackagesScoper.php
@@ -21,7 +21,7 @@ use function Humbug\PhpScoper\json_encode;
 
 final class InstalledPackagesScoper implements Scoper
 {
-    private static $filePattern = '/composer\/installed\.json/';
+    private static $filePattern = '/composer(\/|\\\\)installed\.json/';
 
     private $decoratedScoper;
 

--- a/src/functions.php
+++ b/src/functions.php
@@ -86,7 +86,6 @@ function get_common_path(array $paths): string
             }
         }
     }
-    $lastSeparatorPos = false;
     foreach (['/', '\\'] as $separator) {
         $lastSeparatorPos = strrpos($commonPath, $separator);
         if ($lastSeparatorPos !== false) {

--- a/src/functions.php
+++ b/src/functions.php
@@ -72,19 +72,12 @@ function get_common_path(array $paths): string
     } else {
         $commonPath = '';
         foreach (str_split($pathRef) as $pos => $char) {
-            $isCommonChar = true;
             foreach ($paths as $path) {
                 if (!isset($path[$pos]) || $path[$pos] !== $char) {
-                    $isCommonChar = false;
-
-                    break;
+                    break 2;
                 }
             }
-            if ($isCommonChar) {
-                $commonPath .= $char;
-            } else {
-                break;
-            }
+            $commonPath .= $char;
         }
     }
     foreach (['/', '\\'] as $separator) {

--- a/src/functions.php
+++ b/src/functions.php
@@ -63,11 +63,11 @@ function create_scoper(): Scoper
 function get_common_path(array $paths): string
 {
     $nbPaths = count($paths);
-    if ($nbPaths === 0) {
+    if (0 === $nbPaths) {
         return '';
     }
     $pathRef = array_pop($paths);
-    if ($nbPaths === 1) {
+    if (1 === $nbPaths) {
         $commonPath = $pathRef;
     } else {
         $commonPath = '';
@@ -76,6 +76,7 @@ function get_common_path(array $paths): string
             foreach ($paths as $path) {
                 if (!isset($path[$pos]) || $path[$pos] !== $char) {
                     $isCommonChar = false;
+
                     break;
                 }
             }
@@ -88,11 +89,13 @@ function get_common_path(array $paths): string
     }
     foreach (['/', '\\'] as $separator) {
         $lastSeparatorPos = strrpos($commonPath, $separator);
-        if ($lastSeparatorPos !== false) {
+        if (false !== $lastSeparatorPos) {
             $commonPath = rtrim(substr($commonPath, 0, $lastSeparatorPos), $separator);
+
             break;
         }
     }
+
     return $commonPath;
 }
 

--- a/tests/ConfigurationTest.php
+++ b/tests/ConfigurationTest.php
@@ -82,14 +82,14 @@ PHP
         );
         touch('file1');
 
-        $configuration = Configuration::load($this->tmp.'/scoper.inc.php');
+        $configuration = Configuration::load($this->tmp.DIRECTORY_SEPARATOR.'scoper.inc.php');
 
-        $this->assertSame([$this->tmp.'/file1'], $configuration->getWhitelistedFiles());
+        $this->assertSame([$this->tmp.DIRECTORY_SEPARATOR.'file1'], $configuration->getWhitelistedFiles());
         $this->assertEquals(
             Whitelist::create(false, false, false, 'Foo', 'Bar\*'),
             $configuration->getWhitelist()
         );
-        $this->assertSame($this->tmp.'/scoper.inc.php', $configuration->getPath());
+        $this->assertSame($this->tmp.DIRECTORY_SEPARATOR.'scoper.inc.php', $configuration->getPath());
         $this->assertSame('MyPrefix', $configuration->getPrefix());
         $this->assertSame([], $configuration->getFilesWithContents());
         $this->assertEquals([new SymfonyPatcher()], $configuration->getPatchers());

--- a/tests/Console/Command/AddPrefixCommandIntegrationTest.php
+++ b/tests/Console/Command/AddPrefixCommandIntegrationTest.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 
 namespace Humbug\PhpScoper\Console\Command;
 
+use Humbug\PhpScoper\Console\DisplayNormalizer;
 use Humbug\PhpScoper\FileSystemTestCase;
 use Symfony\Component\Console\Tester\ApplicationTester;
 use Symfony\Component\Finder\Finder;
@@ -262,10 +263,8 @@ EOF;
     {
         $display = str_replace(realpath(self::FIXTURE_PATH), '/path/to', $display);
         $display = str_replace($this->tmp, '/path/to', $display);
-        if ('\\' === DIRECTORY_SEPARATOR) {
-            $display = $this->getNormalizeSeparators($display);
-            $display = $this->getNormalizeProgressBar($display);
-        }
+        $display = DisplayNormalizer::normalizeSeparators($display);
+        $display = DisplayNormalizer::normalizeProgressBar($display);
         $display = preg_replace(
             '/PHP Scoper version (?:dev\-)?.+/',
             'PHP Scoper version 12ccf1ac8c7ae8eaf502bd30f95630a112dc713f',

--- a/tests/Console/Command/AddPrefixCommandIntegrationTest.php
+++ b/tests/Console/Command/AddPrefixCommandIntegrationTest.php
@@ -272,6 +272,9 @@ EOF;
             '// Memory usage: 5.00MB (peak: 10.00MB), time: 0.00s',
             $display
         );
+        if ('\\' === \DIRECTORY_SEPARATOR && 'Hyper' !== getenv('TERM_PROGRAM')) {
+            $display = str_replace(['>', '-', '='], ['░', '░', '▓'], $display);
+        }
 
         $lines = explode("\n", $display);
 

--- a/tests/Console/Command/AddPrefixCommandIntegrationTest.php
+++ b/tests/Console/Command/AddPrefixCommandIntegrationTest.php
@@ -286,35 +286,6 @@ EOF;
         return implode("\n", $lines);
     }
 
-    private function getNormalizeSeparators(string $display): string
-    {
-        if (preg_match_all('/\/path\/to(.*\\\\)+/', $display, $match)) {
-            $paths = $match[0];
-            usort($paths, static function ($a, $b) {
-                return strlen($b) - strlen($a);
-            });
-            foreach ($paths as $path) {
-                $fixedPath = str_replace('\\', '/', $path);
-                $display = str_replace($path, $fixedPath, $display);
-            }
-        }
-
-        return $display;
-    }
-
-    private function getNormalizeProgressBar(string $display): string
-    {
-        if (preg_match_all('/\\[=*>?\\-*\\]/', $display, $match)) {
-            $bars = $match[0];
-            foreach ($bars as $bar) {
-                $fixedBar = str_replace(['>', '-', '='], ['░', '░', '▓'], $bar);
-                $display = str_replace($bar, $fixedBar, $display);
-            }
-        }
-
-        return $display;
-    }
-
     private function assertFilesAreSame(string $expectedDir, string $actualDir): void
     {
         $expected = $this->collectFiles($expectedDir);

--- a/tests/Console/DisplayNormalizer.php
+++ b/tests/Console/DisplayNormalizer.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the humbug/php-scoper package.
+ *
+ * Copyright (c) 2017 Théo FIDRY <theo.fidry@gmail.com>,
+ *                    Pádraic Brady <padraic.brady@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Humbug\PhpScoper\Console;
+
+use function preg_match_all;
+use function str_replace;
+use function strlen;
+use function usort;
+
+final class DisplayNormalizer
+{
+    public static function normalizeSeparators(string $display): string
+    {
+        if ('\\' === DIRECTORY_SEPARATOR && preg_match_all('/\/path\/to(.*\\\\)+/', $display, $match)) {
+            $paths = $match[0];
+            usort($paths, static function ($a, $b) {
+                return strlen($b) - strlen($a);
+            });
+            foreach ($paths as $path) {
+                $fixedPath = str_replace('\\', '/', $path);
+                $display = str_replace($path, $fixedPath, $display);
+            }
+        }
+
+        return $display;
+    }
+
+    public static function normalizeProgressBar(string $display): string
+    {
+        if ('\\' === DIRECTORY_SEPARATOR && preg_match_all('/\\[=*>?\\-*\\]/', $display, $match)) {
+            $bars = $match[0];
+            foreach ($bars as $bar) {
+                $fixedBar = str_replace(['>', '-', '='], ['░', '░', '▓'], $bar);
+                $display = str_replace($bar, $fixedBar, $display);
+            }
+        }
+
+        return $display;
+    }
+
+    private function __construct()
+    {
+    }
+}

--- a/tests/FunctionsTest.php
+++ b/tests/FunctionsTest.php
@@ -74,5 +74,37 @@ class FunctionsTest extends TestCase
             ],
             '',
         ];
+
+        yield [
+            [
+                'C:\\path\\to\\file',
+            ],
+            'C:\\path\\to',
+        ];
+
+        yield [
+            [
+                'C:\\path\\to\\file',
+                'C:\\path\\to\\another-file',
+            ],
+            'C:\\path\\to',
+        ];
+
+        yield [
+            [
+                'C:\\path\\to\\file',
+                'C:\\path\\to\\another-file',
+                'C:\\path\\another-to\\another-file',
+            ],
+            'C:\\path',
+        ];
+
+        yield [
+            [
+                'C:\\path\\to\\file',
+                'D:\\another\\path\\to\\another-file',
+            ],
+            '',
+        ];
     }
 }


### PR DESCRIPTION
Fix #122 .

I still have 3 errors but I don't know if it's related to Windows.

The details of the errors:
```
1) Humbug\PhpScoper\Console\Command\AddPrefixCommandIntegrationTest::test_scope_in_normal_mode
PHPUnit\Framework\Exception: PHP Fatal error:  Uncaught Exception: Serialization of 'Closure' is not allowed in C:\Users\villfa\AppData\Local\Temp\PHP3EBD.tmp:254
Stack trace:
#0 C:\Users\villfa\AppData\Local\Temp\PHP3EBD.tmp(254): serialize(Array)
#1 C:\Users\villfa\AppData\Local\Temp\PHP3EBD.tmp(730): __phpunit_run_isolated_test()
#2 {main}
  thrown in C:\Users\villfa\AppData\Local\Temp\PHP3EBD.tmp on line 254
Fatal error: Uncaught Exception: Serialization of 'Closure' is not allowed in C:\Users\villfa\AppData\Local\Temp\PHP3EBD.tmp:254
Stack trace:
#0 C:\Users\villfa\AppData\Local\Temp\PHP3EBD.tmp(254): serialize(Array)
#1 C:\Users\villfa\AppData\Local\Temp\PHP3EBD.tmp(730): __phpunit_run_isolated_test()
#2 {main}
  thrown in C:\Users\villfa\AppData\Local\Temp\PHP3EBD.tmp on line 254

2) Humbug\PhpScoper\Console\Command\AddPrefixCommandIntegrationTest::test_scope_in_verbose_mode
PHPUnit\Framework\Exception: PHP Fatal error:  Uncaught Exception: Serialization of 'Closure' is not allowed in C:\Users\villfa\AppData\Local\Temp\PHP4006.tmp:254
Stack trace:
#0 C:\Users\villfa\AppData\Local\Temp\PHP4006.tmp(254): serialize(Array)
#1 C:\Users\villfa\AppData\Local\Temp\PHP4006.tmp(730): __phpunit_run_isolated_test()
#2 {main}
  thrown in C:\Users\villfa\AppData\Local\Temp\PHP4006.tmp on line 254
Fatal error: Uncaught Exception: Serialization of 'Closure' is not allowed in C:\Users\villfa\AppData\Local\Temp\PHP4006.tmp:254
Stack trace:
#0 C:\Users\villfa\AppData\Local\Temp\PHP4006.tmp(254): serialize(Array)
#1 C:\Users\villfa\AppData\Local\Temp\PHP4006.tmp(730): __phpunit_run_isolated_test()
#2 {main}
  thrown in C:\Users\villfa\AppData\Local\Temp\PHP4006.tmp on line 254

3) Humbug\PhpScoper\Console\Command\AddPrefixCommandIntegrationTest::test_scope_in_very_verbose_mode
PHPUnit\Framework\Exception: PHP Fatal error:  Uncaught Exception: Serialization of 'Closure' is not allowed in C:\Users\villfa\AppData\Local\Temp\PHP4121.tmp:254
Stack trace:
#0 C:\Users\villfa\AppData\Local\Temp\PHP4121.tmp(254): serialize(Array)
#1 C:\Users\villfa\AppData\Local\Temp\PHP4121.tmp(730): __phpunit_run_isolated_test()
#2 {main}
  thrown in C:\Users\villfa\AppData\Local\Temp\PHP4121.tmp on line 254
Fatal error: Uncaught Exception: Serialization of 'Closure' is not allowed in C:\Users\villfa\AppData\Local\Temp\PHP4121.tmp:254
Stack trace:
#0 C:\Users\villfa\AppData\Local\Temp\PHP4121.tmp(254): serialize(Array)
#1 C:\Users\villfa\AppData\Local\Temp\PHP4121.tmp(730): __phpunit_run_isolated_test()
#2 {main}
  thrown in C:\Users\villfa\AppData\Local\Temp\PHP4121.tmp on line 254
```
