### PR TITLE
Fixed duplicate key found in scoper.inc.php.tpl

### DIFF
--- a/src/scoper.inc.php.tpl
+++ b/src/scoper.inc.php.tpl
@@ -77,7 +77,7 @@ return [
     // If `true` then the user defined classes belonging to the global namespace will not be prefixed.
     //
     // For more see https://github.com/humbug/php-scoper#constants--constants--functions-from-the-global-namespace
-    'whitelist-global-constants' => true,
+    'whitelist-global-classes' => true,
 
     // If `true` then the user defined functions belonging to the global namespace will not be prefixed.
     //


### PR DESCRIPTION
The key `whitelist-global-constants` was found twice. I replaced one of them to be `whitelist-global-classes`.