### PR TITLE
Automatically check the COMPOSER_ROOT_VERSION

### DIFF
--- a/.composer-root-version
+++ b/.composer-root-version
@@ -1,0 +1,1 @@
+export COMPOSER_ROOT_VERSION='0.11.99'

--- a/.composer-root-version
+++ b/.composer-root-version
@@ -1,1 +1,3 @@
+#!/usr/bin/env bash
+
 export COMPOSER_ROOT_VERSION='0.11.99'

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 /bin/
 !/bin/php-scoper
+!/bin/check-composer-root-version.php
+!/bin/dump-composer-root-version.php
 /.box_dump/
 /box.json
 /build/

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,8 @@
 /bin/
 !/bin/php-scoper
 !/bin/check-composer-root-version.php
-!/bin/dump-composer-root-version.php
+!/bin/check-composer-root-version.php
+!/bin/root-version.php
 /.box_dump/
 /box.json
 /build/

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,7 @@ matrix:
 before_install:
   - echo "memory_limit=-1" >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
   - phpenv config-rm xdebug.ini || true
+  - set -Eeuo pipefail
   - source .composer-root-version
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,7 @@ install:
   - composer install --no-interaction --no-progress --no-suggest --prefer-dist $COMPOSER_FLAGS
 
 script:
+  - make check-root-version
   - |
     if [ "$COVERAGE" == "true" ]; then
       make tc

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ install:
   - composer install --no-interaction --no-progress --no-suggest --prefer-dist $COMPOSER_FLAGS
 
 script:
-  - make check-root-version
+  - make check-composer-root-version
   - |
     if [ "$COVERAGE" == "true" ]; then
       make tc

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ matrix:
 before_install:
   - echo "memory_limit=-1" >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
   - phpenv config-rm xdebug.ini || true
-  - export COMPOSER_ROOT_VERSION=0.11.99
+  - source .composer-root-version
 
 install:
   - composer install --no-interaction --no-progress --no-suggest --prefer-dist $COMPOSER_FLAGS

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,6 @@ matrix:
 before_install:
   - echo "memory_limit=-1" >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
   - phpenv config-rm xdebug.ini || true
-  - set -Eeuo pipefail
   - source .composer-root-version
 
 install:

--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,12 @@ clean:	 ## Clean all created artifacts
 clean:
 	git clean --exclude=.idea/ -ffdx
 
+update-root-version: ## Check the lastest GitHub release and update COMPOSER_ROOT_VERSION accordingly
+update-root-version:
+	rm .composer-root-version
+	$(MAKE) .composer-root-version
+
+
 .PHONY: cs
 CODE_SNIFFER=vendor-bin/code-sniffer/vendor/bin/phpcs
 CODE_SNIFFER_FIX=vendor-bin/code-sniffer/vendor/bin/phpcbf
@@ -363,19 +369,16 @@ tb: bin/php-scoper.phar  vendor
 # Rules from files
 #---------------------------------------------------------------------------
 
-vendor: composer.lock
-	export COMPOSER_ROOT_VERSION='0.11.99'; composer install
-	unset "COMPOSER_ROOT_VERSION"
+vendor: composer.lock .composer-root-version
+	source .composer-root-version; composer install
 	touch $@
 
-vendor/bamarni: composer.lock
-	export COMPOSER_ROOT_VERSION='0.11.99'; composer install
-	unset "COMPOSER_ROOT_VERSION"
+vendor/bamarni: composer.lock .composer-root-version
+	source .composer-root-version; composer install
 	touch $@
 
-bin/phpunit: composer.lock
-	export COMPOSER_ROOT_VERSION='0.11.99'; composer install
-	unset "COMPOSER_ROOT_VERSION"
+bin/phpunit: composer.lock .composer-root-version
+	source .composer-root-version; composer install
 	touch $@
 
 vendor-bin/covers-validator/vendor: vendor-bin/covers-validator/composer.lock vendor/bamarni
@@ -540,4 +543,8 @@ $(CODE_SNIFFER_FIX): vendor-bin/code-sniffer/vendor
 
 $(PHPSTAN): vendor-bin/phpstan/vendor
 	composer bin phpstan install
+	touch $@
+
+.composer-root-version:
+	php bin/dump-root-version.php
 	touch $@

--- a/Makefile
+++ b/Makefile
@@ -49,12 +49,12 @@ build: bin/php-scoper.phar
 
 .PHONY: test
 test:	 ## Run all the tests
-test: check-root-version tc e2e
+test: check-composer-root-version tc e2e
 
-.PHONY: check-root-version
-check-root-version:	## Checks that the COMPOSER_ROOT_VERSION is up to date
-check-root-version: .composer-root-version
-	php bin/check-root-version.php
+.PHONY: check-composer-root-version
+check-composer-root-version:	## Checks that the COMPOSER_ROOT_VERSION is up to date
+check-composer-root-version: .composer-root-version
+	php bin/check-composer-root-version.php
 
 .PHONY: tu
 PHPUNIT=bin/phpunit
@@ -551,5 +551,5 @@ $(PHPSTAN): vendor-bin/phpstan/vendor
 	touch $@
 
 .composer-root-version:
-	php bin/dump-root-version.php
+	php bin/dump-composer-root-version.php
 	touch $@

--- a/Makefile
+++ b/Makefile
@@ -375,15 +375,15 @@ tb: bin/php-scoper.phar  vendor
 #---------------------------------------------------------------------------
 
 vendor: composer.lock .composer-root-version
-	/bin/bash -c 'source .composer-root-version'; composer install
+	/bin/bash -c 'source .composer-root-version' && composer install
 	touch $@
 
 vendor/bamarni: composer.lock .composer-root-version
-	/bin/bash -c 'source .composer-root-version'; composer install
+	/bin/bash -c 'source .composer-root-version' && composer install
 	touch $@
 
 bin/phpunit: composer.lock .composer-root-version
-	/bin/bash -c 'source .composer-root-version'; composer install
+	/bin/bash -c 'source .composer-root-version' && composer install
 	touch $@
 
 vendor-bin/covers-validator/vendor: vendor-bin/covers-validator/composer.lock vendor/bamarni

--- a/Makefile
+++ b/Makefile
@@ -375,15 +375,15 @@ tb: bin/php-scoper.phar  vendor
 #---------------------------------------------------------------------------
 
 vendor: composer.lock .composer-root-version
-	source .composer-root-version; composer install
+	/bin/bash -c source .composer-root-version; composer install
 	touch $@
 
 vendor/bamarni: composer.lock .composer-root-version
-	source .composer-root-version; composer install
+	/bin/bash -c source .composer-root-version; composer install
 	touch $@
 
 bin/phpunit: composer.lock .composer-root-version
-	source .composer-root-version; composer install
+	/bin/bash -c source .composer-root-version; composer install
 	touch $@
 
 vendor-bin/covers-validator/vendor: vendor-bin/covers-validator/composer.lock vendor/bamarni

--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,12 @@ build: bin/php-scoper.phar
 
 .PHONY: test
 test:	 ## Run all the tests
-test: tc e2e
+test: check-root-version tc e2e
+
+.PHONY: check-root-version
+check-root-version:	## Checks that the COMPOSER_ROOT_VERSION is up to date
+check-root-version: .composer-root-version
+	php bin/check-root-version.php
 
 .PHONY: tu
 PHPUNIT=bin/phpunit

--- a/Makefile
+++ b/Makefile
@@ -375,15 +375,15 @@ tb: bin/php-scoper.phar  vendor
 #---------------------------------------------------------------------------
 
 vendor: composer.lock .composer-root-version
-	/bin/bash -c source .composer-root-version; composer install
+	/bin/bash -c 'source .composer-root-version'; composer install
 	touch $@
 
 vendor/bamarni: composer.lock .composer-root-version
-	/bin/bash -c source .composer-root-version; composer install
+	/bin/bash -c 'source .composer-root-version'; composer install
 	touch $@
 
 bin/phpunit: composer.lock .composer-root-version
-	/bin/bash -c source .composer-root-version; composer install
+	/bin/bash -c 'source .composer-root-version'; composer install
 	touch $@
 
 vendor-bin/covers-validator/vendor: vendor-bin/covers-validator/composer.lock vendor/bamarni

--- a/bin/check-composer-root-version.php
+++ b/bin/check-composer-root-version.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+require_once 'root-version.php';
+
+$composerRootVersion = get_composer_root_version(get_last_tag_name());
+
+preg_match(
+    '/COMPOSER_ROOT_VERSION=\'(?<version>.*?)\'/',
+    file_get_contents('.composer-root-version'),
+    $matches
+);
+
+$currentRootVersion = $matches['version'];
+
+if ($composerRootVersion !== $currentRootVersion) {
+    file_put_contents(
+        'php://stderr',
+        sprintf(
+            'Expected the COMPOSER_ROOT_VERSION to be "%s" but got "%s" instead.'.PHP_EOL,
+            $composerRootVersion,
+            $currentRootVersion
+        )
+    );
+
+    exit(1);
+}

--- a/bin/check-composer-root-version.php
+++ b/bin/check-composer-root-version.php
@@ -2,6 +2,16 @@
 
 declare(strict_types=1);
 
+/*
+ * This file is part of the humbug/php-scoper package.
+ *
+ * Copyright (c) 2017 Théo FIDRY <theo.fidry@gmail.com>,
+ *                    Pádraic Brady <padraic.brady@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 require_once __DIR__.'/root-version.php';
 
 $composerRootVersion = get_composer_root_version(get_last_tag_name());

--- a/bin/check-composer-root-version.php
+++ b/bin/check-composer-root-version.php
@@ -2,13 +2,13 @@
 
 declare(strict_types=1);
 
-require_once 'root-version.php';
+require_once __DIR__.'/root-version.php';
 
 $composerRootVersion = get_composer_root_version(get_last_tag_name());
 
 preg_match(
     '/COMPOSER_ROOT_VERSION=\'(?<version>.*?)\'/',
-    file_get_contents('.composer-root-version'),
+    file_get_contents(__DIR__.'/../.composer-root-version'),
     $matches
 );
 

--- a/bin/dump-composer-root-version.php
+++ b/bin/dump-composer-root-version.php
@@ -2,12 +2,12 @@
 
 declare(strict_types=1);
 
-require_once 'root-version.php';
+require_once __DIR__.'/root-version.php';
 
 $composerRootVersion = get_composer_root_version(get_last_tag_name());
 
 file_put_contents(
-    '.composer-root-version',
+    __DIR__.'/../.composer-root-version',
     sprintf(
         <<<'BASH'
 #!/usr/bin/env bash
@@ -21,13 +21,13 @@ BASH
 );
 
 file_put_contents(
-    '.scrutinizer.yml',
+    $scrutinizerPath = __DIR__.'/../.scrutinizer.yml',
     preg_replace(
         '/COMPOSER_ROOT_VERSION: \'.*?\'/',
         sprintf(
             'COMPOSER_ROOT_VERSION: \'%s\'',
             $composerRootVersion
         ),
-        file_get_contents('.scrutinizer.yml')
+        file_get_contents($scrutinizerPath)
     )
 );

--- a/bin/dump-composer-root-version.php
+++ b/bin/dump-composer-root-version.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+require_once 'root-version.php';
+
+$composerRootVersion = get_composer_root_version(get_last_tag_name());
+
+file_put_contents(
+    '.composer-root-version',
+    sprintf(
+        <<<'BASH'
+#!/usr/bin/env bash
+
+export COMPOSER_ROOT_VERSION='%s'
+
+BASH
+        ,
+        $composerRootVersion
+    )
+);
+
+file_put_contents(
+    '.scrutinizer.yml',
+    preg_replace(
+        '/COMPOSER_ROOT_VERSION: \'.*?\'/',
+        sprintf(
+            'COMPOSER_ROOT_VERSION: \'%s\'',
+            $composerRootVersion
+        ),
+        file_get_contents('.scrutinizer.yml')
+    )
+);

--- a/bin/dump-composer-root-version.php
+++ b/bin/dump-composer-root-version.php
@@ -2,6 +2,16 @@
 
 declare(strict_types=1);
 
+/*
+ * This file is part of the humbug/php-scoper package.
+ *
+ * Copyright (c) 2017 Théo FIDRY <theo.fidry@gmail.com>,
+ *                    Pádraic Brady <padraic.brady@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 require_once __DIR__.'/root-version.php';
 
 $composerRootVersion = get_composer_root_version(get_last_tag_name());

--- a/bin/root-version.php
+++ b/bin/root-version.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+function get_last_tag_name(): string
+{
+    $tags = json_decode(
+        file_get_contents(
+            'https://api.github.com/repos/humbug/php-scoper/tags',
+            false,
+            stream_context_create([
+                'http' => [
+                    'method' => 'GET',
+                    'header' => <<<'EOF'
+    User-Agent: Mozilla/5.0 (Windows NT 10.0; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/50.0.2661.102 Safari/537.36;
+    Content-Type: text/json;
+EOF
+                ],
+            ])
+        )
+    );
+
+    return $tags[0]->name;
+}
+
+function get_composer_root_version(string $lastTagName): string
+{
+    $tagParts = explode('.', $lastTagName);
+
+    array_pop($tagParts);
+
+    $tagParts[] = '99';
+
+    return implode('.', $tagParts);
+}

--- a/bin/root-version.php
+++ b/bin/root-version.php
@@ -2,6 +2,16 @@
 
 declare(strict_types=1);
 
+/*
+ * This file is part of the humbug/php-scoper package.
+ *
+ * Copyright (c) 2017 Théo FIDRY <theo.fidry@gmail.com>,
+ *                    Pádraic Brady <padraic.brady@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 function get_last_tag_name(): string
 {
     $tags = json_decode(


### PR DESCRIPTION
Since PHP-Scoper depends (as a dev dep) on Box which itself depends on PHP-Scoper, the
`COMPOSER_ROOT_VERSION` environment variable must be set accordingly for Composer.

Until now, the value was hardcoded in a few places and manually updated. It's however causing a number of issues since:

- It requires to manually check that the value set is the correct one by checking the last tag release
- It requires to manually update the values (find/replace in an IDE or other)

Since I'm a bit forgetful, this is messing up things occasionally.

In order to tackle this issue, this PR introduces a:

- `.composer-root-version` file committed which exports the right `COMPOSER_ROOT_VERSION` value
- Replaces the hardedcoded occurrences of `COMPOSER_ROOT_VERSION` by loading the newly introduced `.composer-root-version` file instead
- Add a `update-composer-root-version` command which updates the `.composer-root-version` file and the remaining occurrences left (e.g. scrutinizer for which sourcing the file is not an option)
- Add a `check-composer-root-version` command which is run as part of the tests and in Travis to ensure the version does not get out of sync