### PR TITLE
Introduce a container

### DIFF
--- a/bin/php-scoper
+++ b/bin/php-scoper
@@ -23,7 +23,7 @@ if (PHP_SAPI !== 'cli' && PHP_SAPI !== 'phpdbg') {
     exit(1);
 }
 
-$findAutoload = function () {
+$findAutoload = static function () {
     if (file_exists($autoload = __DIR__.'/../../../autoload.php')) {
         // Is installed via composer
         return $autoload;
@@ -46,5 +46,4 @@ if (false === class_exists(IsolatedFinder::class)) {
     class_alias(Finder::class, IsolatedFinder::class);
 }
 
-$app = create_application();
-$app->run();
+create_application()->run();

--- a/box.json.dist
+++ b/box.json.dist
@@ -13,7 +13,6 @@
     "files": [
         "src/scoper.inc.php.tpl"
     ],
-    "git": "git_version_placeholder",
     "datetime": "release-date",
 
     "compression": "GZ",

--- a/src/Console/Application.php
+++ b/src/Console/Application.php
@@ -15,6 +15,7 @@ declare(strict_types=1);
 namespace Humbug\PhpScoper\Console;
 
 use Humbug\PhpScoper\Container;
+use function Humbug\PhpScoper\get_php_scoper_version;
 use PackageVersions\Versions;
 use Symfony\Component\Console\Application as SymfonyApplication;
 use function trim;
@@ -42,21 +43,13 @@ ASCII;
     public function __construct(
         Container $container,
         string $name = 'Box',
-        string $version = null,
+        ?string $version = null,
         string $releaseDate = '@release-date@'
     ) {
-        if (null === $version) {
-            $rawVersion = Versions::getVersion('humbug/php-scoper');
-
-            [$prettyVersion, $commitHash] = explode('@', $rawVersion);
-
-            $version = $prettyVersion.'@'.substr($commitHash, 0, 7);
-        }
-
         $this->container = $container;
         $this->releaseDate = false === strpos($releaseDate, '@') ? $releaseDate : '';
 
-        parent::__construct($name, $version);
+        parent::__construct($name, $version ?? get_php_scoper_version());
     }
 
     public function getContainer(): Container

--- a/src/Console/Application.php
+++ b/src/Console/Application.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 
 namespace Humbug\PhpScoper\Console;
 
+use Humbug\PhpScoper\Container;
 use PackageVersions\Versions;
 use Symfony\Component\Console\Application as SymfonyApplication;
 use function trim;
@@ -32,13 +33,18 @@ final class Application extends SymfonyApplication
 
 ASCII;
 
+    private $container;
     private $releaseDate;
 
     /**
      * {@inheritdoc}
      */
-    public function __construct(string $name = 'Box', string $version = null, string $releaseDate = '@release-date@')
-    {
+    public function __construct(
+        Container $container,
+        string $name = 'Box',
+        string $version = null,
+        string $releaseDate = '@release-date@'
+    ) {
         if (null === $version) {
             $rawVersion = Versions::getVersion('humbug/php-scoper');
 
@@ -47,9 +53,15 @@ ASCII;
             $version = $prettyVersion.'@'.substr($commitHash, 0, 7);
         }
 
+        $this->container = $container;
         $this->releaseDate = false === strpos($releaseDate, '@') ? $releaseDate : '';
 
         parent::__construct($name, $version);
+    }
+
+    public function getContainer(): Container
+    {
+        return $this->container;
     }
 
     /**

--- a/src/Console/Application.php
+++ b/src/Console/Application.php
@@ -15,9 +15,8 @@ declare(strict_types=1);
 namespace Humbug\PhpScoper\Console;
 
 use Humbug\PhpScoper\Container;
-use function Humbug\PhpScoper\get_php_scoper_version;
-use PackageVersions\Versions;
 use Symfony\Component\Console\Application as SymfonyApplication;
+use function Humbug\PhpScoper\get_php_scoper_version;
 use function trim;
 
 final class Application extends SymfonyApplication

--- a/src/Console/ApplicationFactory.php
+++ b/src/Console/ApplicationFactory.php
@@ -41,66 +41,17 @@ class ApplicationFactory
     {
         $app = new Application(
             new Container(),
-            'PHP Scoper',
-            static::getVersion()
+            'PHP Scoper'
         );
 
         $app->addCommands([
             new AddPrefixCommand(
                 new Filesystem(),
-                static::createScoper()
+                $app->getContainer()->getScoper()
             ),
             new InitCommand(),
         ]);
 
         return $app;
-    }
-
-    protected static function getVersion(): string
-    {
-        if (0 === strpos(__FILE__, 'phar:')) {
-            return '@git_version_placeholder@';
-        }
-
-        $rawVersion = Versions::getVersion('humbug/php-scoper');
-
-        [$prettyVersion, $commitHash] = explode('@', $rawVersion);
-
-        return (1 === preg_match('/9{7}/', $prettyVersion)) ? $commitHash : $prettyVersion;
-    }
-
-    protected static function createScoper(): Scoper
-    {
-        return new PatchScoper(
-            new PhpScoper(
-                static::createParser(),
-                new JsonFileScoper(
-                    new InstalledPackagesScoper(
-                        new SymfonyScoper(
-                            new NullScoper()
-                        )
-                    )
-                ),
-                new TraverserFactory(static::createReflector())
-            )
-        );
-    }
-
-    protected static function createParser(): Parser
-    {
-        return (new ParserFactory())->create(ParserFactory::ONLY_PHP7);
-    }
-
-    protected static function createReflector(): Reflector
-    {
-        $phpParser = static::createParser();
-        $astLocator = new Locator($phpParser);
-
-        $sourceLocator = new MemoizingSourceLocator(
-            new PhpInternalSourceLocator($astLocator)
-        );
-        $classReflector = new ClassReflector($sourceLocator);
-
-        return new Reflector($classReflector);
     }
 }

--- a/src/Console/ApplicationFactory.php
+++ b/src/Console/ApplicationFactory.php
@@ -17,22 +17,7 @@ namespace Humbug\PhpScoper\Console;
 use Humbug\PhpScoper\Console\Command\AddPrefixCommand;
 use Humbug\PhpScoper\Console\Command\InitCommand;
 use Humbug\PhpScoper\Container;
-use Humbug\PhpScoper\PhpParser\TraverserFactory;
-use Humbug\PhpScoper\Reflector;
 use Humbug\PhpScoper\Scoper;
-use Humbug\PhpScoper\Scoper\Composer\InstalledPackagesScoper;
-use Humbug\PhpScoper\Scoper\Composer\JsonFileScoper;
-use Humbug\PhpScoper\Scoper\NullScoper;
-use Humbug\PhpScoper\Scoper\PatchScoper;
-use Humbug\PhpScoper\Scoper\PhpScoper;
-use Humbug\PhpScoper\Scoper\SymfonyScoper;
-use PackageVersions\Versions;
-use PhpParser\Parser;
-use PhpParser\ParserFactory;
-use Roave\BetterReflection\Reflector\ClassReflector;
-use Roave\BetterReflection\SourceLocator\Ast\Locator;
-use Roave\BetterReflection\SourceLocator\Type\MemoizingSourceLocator;
-use Roave\BetterReflection\SourceLocator\Type\PhpInternalSourceLocator;
 use Symfony\Component\Filesystem\Filesystem;
 
 final class ApplicationFactory

--- a/src/Console/ApplicationFactory.php
+++ b/src/Console/ApplicationFactory.php
@@ -20,7 +20,11 @@ use Humbug\PhpScoper\Container;
 use Humbug\PhpScoper\Scoper;
 use Symfony\Component\Filesystem\Filesystem;
 
-final class ApplicationFactory
+/**
+ * @final
+ * TODO: mark this class as final in the next release
+ */
+class ApplicationFactory
 {
     public function create(): Application
     {
@@ -38,5 +42,13 @@ final class ApplicationFactory
         ]);
 
         return $app;
+    }
+
+    /**
+     * @deprecated This function will be removed in the next release
+     */
+    protected static function createScoper(): Scoper
+    {
+        return (new Container())->getScoper();
     }
 }

--- a/src/Console/ApplicationFactory.php
+++ b/src/Console/ApplicationFactory.php
@@ -35,7 +35,7 @@ use Roave\BetterReflection\SourceLocator\Type\MemoizingSourceLocator;
 use Roave\BetterReflection\SourceLocator\Type\PhpInternalSourceLocator;
 use Symfony\Component\Filesystem\Filesystem;
 
-class ApplicationFactory
+final class ApplicationFactory
 {
     public function create(): Application
     {

--- a/src/Console/ApplicationFactory.php
+++ b/src/Console/ApplicationFactory.php
@@ -16,6 +16,7 @@ namespace Humbug\PhpScoper\Console;
 
 use Humbug\PhpScoper\Console\Command\AddPrefixCommand;
 use Humbug\PhpScoper\Console\Command\InitCommand;
+use Humbug\PhpScoper\Container;
 use Humbug\PhpScoper\PhpParser\TraverserFactory;
 use Humbug\PhpScoper\Reflector;
 use Humbug\PhpScoper\Scoper;
@@ -38,7 +39,11 @@ class ApplicationFactory
 {
     public function create(): Application
     {
-        $app = new Application('PHP Scoper', static::getVersion());
+        $app = new Application(
+            new Container(),
+            'PHP Scoper',
+            static::getVersion()
+        );
 
         $app->addCommands([
             new AddPrefixCommand(

--- a/src/Container.php
+++ b/src/Container.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Humbug\PhpScoper;
+
+
+final class Container
+{
+
+}

--- a/src/Container.php
+++ b/src/Container.php
@@ -5,7 +5,70 @@ declare(strict_types=1);
 namespace Humbug\PhpScoper;
 
 
+use Humbug\PhpScoper\PhpParser\TraverserFactory;
+use Humbug\PhpScoper\Scoper\Composer\InstalledPackagesScoper;
+use Humbug\PhpScoper\Scoper\Composer\JsonFileScoper;
+use Humbug\PhpScoper\Scoper\NullScoper;
+use Humbug\PhpScoper\Scoper\PatchScoper;
+use Humbug\PhpScoper\Scoper\PhpScoper;
+use Humbug\PhpScoper\Scoper\SymfonyScoper;
+use PhpParser\Parser;
+use PhpParser\ParserFactory;
+use Roave\BetterReflection\Reflector\ClassReflector;
+use Roave\BetterReflection\SourceLocator\Ast\Locator;
+use Roave\BetterReflection\SourceLocator\Type\MemoizingSourceLocator;
+use Roave\BetterReflection\SourceLocator\Type\PhpInternalSourceLocator;
+
 final class Container
 {
+    private $parser;
+    private $reflector;
+    private $scoper;
 
+    public function getScoper(): Scoper
+    {
+        if (null === $this->scoper) {
+            $this->scoper = new PatchScoper(
+                new PhpScoper(
+                    $this->getParser(),
+                    new JsonFileScoper(
+                        new InstalledPackagesScoper(
+                            new SymfonyScoper(
+                                new NullScoper()
+                            )
+                        )
+                    ),
+                    new TraverserFactory($this->getReflector())
+                )
+            );
+        }
+
+        return $this->scoper;
+    }
+
+    public function getParser(): Parser
+    {
+        if (null === $this->parser) {
+            $this->parser = (new ParserFactory())->create(ParserFactory::ONLY_PHP7);
+        }
+
+        return $this->parser;
+    }
+
+    public function getReflector(): Reflector
+    {
+        if (null === $this->reflector) {
+            $phpParser = $this->getParser();
+            $astLocator = new Locator($phpParser);
+
+            $sourceLocator = new MemoizingSourceLocator(
+                new PhpInternalSourceLocator($astLocator)
+            );
+            $classReflector = new ClassReflector($sourceLocator);
+
+            $this->reflector = new Reflector($classReflector);
+        }
+
+        return $this->reflector;
+    }
 }

--- a/src/Container.php
+++ b/src/Container.php
@@ -2,8 +2,17 @@
 
 declare(strict_types=1);
 
-namespace Humbug\PhpScoper;
+/*
+ * This file is part of the humbug/php-scoper package.
+ *
+ * Copyright (c) 2017 Théo FIDRY <theo.fidry@gmail.com>,
+ *                    Pádraic Brady <padraic.brady@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
 
+namespace Humbug\PhpScoper;
 
 use Humbug\PhpScoper\PhpParser\TraverserFactory;
 use Humbug\PhpScoper\Scoper\Composer\InstalledPackagesScoper;

--- a/src/functions.php
+++ b/src/functions.php
@@ -17,6 +17,7 @@ namespace Humbug\PhpScoper;
 use Humbug\PhpScoper\Console\Application;
 use Humbug\PhpScoper\Console\ApplicationFactory;
 use Iterator;
+use PackageVersions\Versions;
 use PhpParser\Node;
 use PhpParser\Node\Identifier;
 use PhpParser\Node\Name;
@@ -37,6 +38,15 @@ use function unserialize;
 function create_application(): Application
 {
     return (new ApplicationFactory())->create();
+}
+
+function get_php_scoper_version(): string
+{
+    $rawVersion = Versions::getVersion('humbug/php-scoper');
+
+    [$prettyVersion, $commitHash] = explode('@', $rawVersion);
+
+    return $prettyVersion.'@'.substr($commitHash, 0, 7);
 }
 
 /**

--- a/src/functions.php
+++ b/src/functions.php
@@ -40,21 +40,6 @@ function create_application(): Application
 }
 
 /**
- * @private
- *
- * @deprecated Will be removed in future releases.
- */
-function create_scoper(): Scoper
-{
-    return (new class() extends ApplicationFactory {
-        public static function createScoper(): Scoper
-        {
-            return parent::createScoper();
-        }
-    })::createScoper();
-}
-
-/**
  * @param string[] $paths Absolute paths
  *
  * @return string

--- a/tests/Console/Command/AddPrefixCommandTest.php
+++ b/tests/Console/Command/AddPrefixCommandTest.php
@@ -15,6 +15,7 @@ declare(strict_types=1);
 namespace Humbug\PhpScoper\Console\Command;
 
 use Humbug\PhpScoper\Console\Application;
+use Humbug\PhpScoper\Container;
 use Humbug\PhpScoper\FileSystemTestCase;
 use Humbug\PhpScoper\Patcher\SymfonyPatcher;
 use Humbug\PhpScoper\Scoper;
@@ -902,7 +903,7 @@ EOF;
         /** @var Scoper $handle */
         $handle = $this->scoperProphecy->reveal();
 
-        $application = new Application('php-scoper-test');
+        $application = new Application(new Container(), 'php-scoper-test');
         $application->addCommands([
             new AddPrefixCommand($fileSystem, $handle),
         ]);

--- a/tests/ContainerTest.php
+++ b/tests/ContainerTest.php
@@ -4,9 +4,48 @@ declare(strict_types=1);
 
 namespace Humbug\PhpScoper;
 
+use Generator;
 use PHPUnit\Framework\TestCase;
+use ReflectionClass;
 
+/**
+ * @covers \Humbug\PhpScoper\Container
+ */
 class ContainerTest extends TestCase
 {
+    /**
+     * @dataProvider provideServiceGetter
+     */
+    public function test_it_can_instantiate_its_services(string $getterName): void
+    {
+        $result = (new Container())->$getterName();
 
+        $this->assertNotNull($result);
+    }
+
+    /**
+     * @dataProvider provideServiceGetter
+     */
+    public function test_it_always_returns_the_same_instance_on_a_container_basis(string $getterName): void
+    {
+        $container = new Container();
+        $anotherContainer = new Container();
+
+        $this->assertSame(
+            $container->$getterName(),
+            $container->$getterName()
+        );
+
+        $this->assertNotSame(
+            $container->$getterName(),
+            $anotherContainer->$getterName()
+        );
+    }
+
+    public function provideServiceGetter(): Generator
+    {
+        foreach ((new ReflectionClass(Container::class))->getMethods() as $methodReflection) {
+            yield [$methodReflection->getName()];
+        }
+    }
 }

--- a/tests/ContainerTest.php
+++ b/tests/ContainerTest.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Humbug\PhpScoper;
+
+use PHPUnit\Framework\TestCase;
+
+class ContainerTest extends TestCase
+{
+
+}

--- a/tests/ContainerTest.php
+++ b/tests/ContainerTest.php
@@ -2,6 +2,16 @@
 
 declare(strict_types=1);
 
+/*
+ * This file is part of the humbug/php-scoper package.
+ *
+ * Copyright (c) 2017 Théo FIDRY <theo.fidry@gmail.com>,
+ *                    Pádraic Brady <padraic.brady@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace Humbug\PhpScoper;
 
 use Generator;

--- a/tests/functions.php
+++ b/tests/functions.php
@@ -80,10 +80,5 @@ function create_fake_patcher(): Closure
  */
 function create_parser(): Parser
 {
-    return (new class() extends ApplicationFactory {
-        public static function createParser(): Parser
-        {
-            return parent::createParser();
-        }
-    })::createParser();
+    return (new Container())->getParser();
 }

--- a/tests/functions.php
+++ b/tests/functions.php
@@ -15,7 +15,6 @@ declare(strict_types=1);
 namespace Humbug\PhpScoper;
 
 use Closure;
-use Humbug\PhpScoper\Console\ApplicationFactory;
 use LogicException;
 use PhpParser\Parser;
 use Symfony\Component\Filesystem\Filesystem;


### PR DESCRIPTION
- Introduce a `Container` class instead of relying on the `ApplicationFactory`
- Simplify the Application version retrieval
    - Move the code in a `get_php_scoper_version(): string` similar to `get_box_version(): string`
    - Retrieve the version from it if no version is passed
    - No longer rely on a version set within the PHAR
- Remove the deprecated `create_scoper()` function