### PR TITLE
Add compatibility with Composer 2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,8 @@ cache:
 
 env:
   global:
-    secure: "1sVenz4DUy14AWE08s8V7Vz1D313t08R7axjBWI5R53BGNScm0lHlF/mONYEkdais5Mo9jkXwfzXIhqwqT6i9xltuIAIb1wUIwnQJCiACUGFWE4IP48ayD4KcjlExxoYHf2l98N0x/fc6ihwTa9pEHSH0cltr9wFJVbQD+lMC82V5gSVVzuteXjd7Dp/UFEgx3PcjRyvsrhySOE+qNInvOu3+ChPbFGE5Z18fncULJrEfVKpvOPBSYDDyI3A7KoHx/MrY9h3ow89S0jQw1AP1B5SVWKhIrFQT/d2oGeVPE382PSdnD5YiUNgcW85EHyFjt70oQyu1gxyIhRKygR+o02pDeanOJXp9wVsTo2yp6Nf/WWjniQenxxueM5MHfimMt1Khpx4ebiIuCOzIn6lhgQ1Aw6z3vVZelqk07zrIEycKJNWsto6a0X7H8McnJDyOlJ/PnbwXwsmcg29jDmNnKc6rGiQ08gK8BaZZfqhdtH8WxKxyUCuowprHslq614/W/4sLNophAOFSyOEFQl1Zqz3Ibe5EVPHbw5paxt9eY8W3gGajY8Bh1BYZOkXmkIgm4UFJHqslal/91Z4CIbLtCjGac0LWrvZaE5QFM8VRLmjgBWij5ajzFP5PI7S9JKJCETj8yrSRE51nAOPq1s1HmxdNQHmBa/xXQP8UahaRsM="
+    - COMPOSER_VERSION='1'
+    - secure: "1sVenz4DUy14AWE08s8V7Vz1D313t08R7axjBWI5R53BGNScm0lHlF/mONYEkdais5Mo9jkXwfzXIhqwqT6i9xltuIAIb1wUIwnQJCiACUGFWE4IP48ayD4KcjlExxoYHf2l98N0x/fc6ihwTa9pEHSH0cltr9wFJVbQD+lMC82V5gSVVzuteXjd7Dp/UFEgx3PcjRyvsrhySOE+qNInvOu3+ChPbFGE5Z18fncULJrEfVKpvOPBSYDDyI3A7KoHx/MrY9h3ow89S0jQw1AP1B5SVWKhIrFQT/d2oGeVPE382PSdnD5YiUNgcW85EHyFjt70oQyu1gxyIhRKygR+o02pDeanOJXp9wVsTo2yp6Nf/WWjniQenxxueM5MHfimMt1Khpx4ebiIuCOzIn6lhgQ1Aw6z3vVZelqk07zrIEycKJNWsto6a0X7H8McnJDyOlJ/PnbwXwsmcg29jDmNnKc6rGiQ08gK8BaZZfqhdtH8WxKxyUCuowprHslq614/W/4sLNophAOFSyOEFQl1Zqz3Ibe5EVPHbw5paxt9eY8W3gGajY8Bh1BYZOkXmkIgm4UFJHqslal/91Z4CIbLtCjGac0LWrvZaE5QFM8VRLmjgBWij5ajzFP5PI7S9JKJCETj8yrSRE51nAOPq1s1HmxdNQHmBa/xXQP8UahaRsM="
 
 addons:
     apt:
@@ -21,12 +22,15 @@ matrix:
       env: COVERAGE='true'
     - php: '7.2'
     - php: '7.4'
+    - php: '7.4'
+      env: COMPOSER_VERSION='snapshot'
   fast_finish: true
 
 before_install:
   - echo "memory_limit=-1" >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
   - phpenv config-rm xdebug.ini || true
   - source .composer-root-version
+  - composer self-update --$COMPOSER_VERSION --no-interaction
   - |
       if [ "$COVERAGE" == "true" ]; then
         pecl install pcov;

--- a/composer.json
+++ b/composer.json
@@ -21,9 +21,9 @@
     "prefer-stable": true,
     "require": {
         "php": "^7.2",
+        "composer/package-versions-deprecated": "^1.8",
         "jetbrains/phpstorm-stubs": "dev-master",
         "nikic/php-parser": "^4.0",
-        "ocramius/package-versions": "^1.1",
         "symfony/console": "^3.2 || ^4.0",
         "symfony/filesystem": "^3.2 || ^4.0",
         "symfony/finder": "^3.2 || ^4.0"

--- a/composer.lock
+++ b/composer.lock
@@ -4,23 +4,89 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "2097d8aad34fc0fd40a0192a5175d51d",
+    "content-hash": "210810ab5edf00d78487181d46da6bca",
     "packages": [
+        {
+            "name": "composer/package-versions-deprecated",
+            "version": "1.8.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/composer/package-versions-deprecated.git",
+                "reference": "98df7f1b293c0550bd5b1ce6b60b59bdda23aa47"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/composer/package-versions-deprecated/zipball/98df7f1b293c0550bd5b1ce6b60b59bdda23aa47",
+                "reference": "98df7f1b293c0550bd5b1ce6b60b59bdda23aa47",
+                "shasum": ""
+            },
+            "require": {
+                "composer-plugin-api": "^1.1.0 || ^2.0",
+                "php": "^7"
+            },
+            "replace": {
+                "ocramius/package-versions": "1.2 - 1.8.99"
+            },
+            "require-dev": {
+                "composer/composer": "^1.9.3 || ^2.0@dev",
+                "ext-zip": "^1.13",
+                "phpunit/phpunit": "^6.5 || ^7"
+            },
+            "type": "composer-plugin",
+            "extra": {
+                "class": "PackageVersions\\Installer",
+                "branch-alias": {
+                    "dev-master": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "PackageVersions\\": "src/PackageVersions"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Marco Pivetta",
+                    "email": "ocramius@gmail.com"
+                },
+                {
+                    "name": "Jordi Boggiano",
+                    "email": "j.boggiano@seld.be"
+                }
+            ],
+            "description": "Composer plugin that provides efficient querying for installed package versions (no runtime IO)",
+            "funding": [
+                {
+                    "url": "https://packagist.com",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/composer/composer",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2020-04-23T11:49:37+00:00"
+        },
         {
             "name": "jetbrains/phpstorm-stubs",
             "version": "dev-master",
             "source": {
                 "type": "git",
                 "url": "https://github.com/JetBrains/phpstorm-stubs.git",
-                "reference": "4c85d8c07f05e6737d04d1346a2b2e4c8509171d"
+                "reference": "1b7fe33233bd0f29c2ebf3beccf622af8261e78a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/JetBrains/phpstorm-stubs/zipball/4c85d8c07f05e6737d04d1346a2b2e4c8509171d",
-                "reference": "4c85d8c07f05e6737d04d1346a2b2e4c8509171d",
+                "url": "https://api.github.com/repos/JetBrains/phpstorm-stubs/zipball/1b7fe33233bd0f29c2ebf3beccf622af8261e78a",
+                "reference": "1b7fe33233bd0f29c2ebf3beccf622af8261e78a",
                 "shasum": ""
             },
             "require-dev": {
+                "friendsofphp/php-cs-fixer": "^2.16",
                 "nikic/php-parser": "^4",
                 "php": "^7.4",
                 "phpdocumentor/reflection-docblock": "^4.3",
@@ -48,7 +114,7 @@
                 "stubs",
                 "type"
             ],
-            "time": "2020-05-28T11:48:35+00:00"
+            "time": "2020-06-28T10:07:54+00:00"
         },
         {
             "name": "nikic/php-parser",
@@ -101,56 +167,6 @@
                 "php"
             ],
             "time": "2020-06-03T07:24:19+00:00"
-        },
-        {
-            "name": "ocramius/package-versions",
-            "version": "1.4.2",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/Ocramius/PackageVersions.git",
-                "reference": "44af6f3a2e2e04f2af46bcb302ad9600cba41c7d"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/Ocramius/PackageVersions/zipball/44af6f3a2e2e04f2af46bcb302ad9600cba41c7d",
-                "reference": "44af6f3a2e2e04f2af46bcb302ad9600cba41c7d",
-                "shasum": ""
-            },
-            "require": {
-                "composer-plugin-api": "^1.0.0",
-                "php": "^7.1.0"
-            },
-            "require-dev": {
-                "composer/composer": "^1.6.3",
-                "doctrine/coding-standard": "^5.0.1",
-                "ext-zip": "*",
-                "infection/infection": "^0.7.1",
-                "phpunit/phpunit": "^7.5.17"
-            },
-            "type": "composer-plugin",
-            "extra": {
-                "class": "PackageVersions\\Installer",
-                "branch-alias": {
-                    "dev-master": "2.0.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "PackageVersions\\": "src/PackageVersions"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Marco Pivetta",
-                    "email": "ocramius@gmail.com"
-                }
-            ],
-            "description": "Composer plugin that provides efficient querying for installed package versions (no runtime IO)",
-            "time": "2019-11-15T16:17:10+00:00"
         },
         {
             "name": "psr/container",


### PR DESCRIPTION
*php-scoper* cannot be installed with Composer 2 (see below). [More details here](https://github.com/composer/package-versions-deprecated/blob/master/README.md).
```
$ git clone https://github.com/humbug/php-scoper && cd php-scoper
[...]
$ composer --version
Composer version 2.0.0-alpha2 2020-06-24 21:36:18
$ COMPOSER_ROOT_VERSION='0.13.99' composer install
Installing dependencies from lock file (including require-dev)
Verifying lock file contents can be installed on current platform.
Your lock file does not contain a compatible set of packages. Please run composer update.

  Problem 1
    - ocramius/package-versions is locked to version 1.4.2 and an update of this package was not requested.
    - ocramius/package-versions 1.4.2 requires composer-plugin-api ^1.0.0 -> found composer-plugin-api[2.0.0] but it does not match the constraint.
  Problem 2
    - ocramius/package-versions 1.4.2 requires composer-plugin-api ^1.0.0 -> found composer-plugin-api[2.0.0] but it does not match the constraint.
    - humbug/box 3.8.4 requires ocramius/package-versions ^1.4 -> satisfiable by ocramius/package-versions[1.4.2].
    - humbug/box is locked to version 3.8.4 and an update of this package was not requested.

Use the option --with-all-dependencies to allow upgrades, downgrades and removals for packages currently locked to specific versions.

ocramius/package-versions only provides support for Composer 2 in 1.8+, which requires PHP 7.4.
If you can not upgrade PHP you can require composer/package-versions-deprecated to resolve this with PHP 7.0+.

You are using a snapshot build of Composer 2, which some of your plugins seem to be incompatible with. Make sure you update your plugins or report an issue to them to ask them to support Composer 2. To work around this you can run Composer with --ignore-platform-req=composer-plugin-api, but this may result in broken plugins and bigger problems down the line.
```