### PR TITLE
Fix InstalledPackagesScoper with Composer v2

### DIFF
--- a/src/Scoper/Composer/InstalledPackagesScoper.php
+++ b/src/Scoper/Composer/InstalledPackagesScoper.php
@@ -43,7 +43,12 @@ final class InstalledPackagesScoper implements Scoper
 
         $decodedJson = json_decode($contents, false);
 
-        $decodedJson = $this->prefixLockPackages((array) $decodedJson, $prefix, $whitelist);
+        // compatibility with Composer 2
+        if (isset($decodedJson->packages)) {
+            $decodedJson->packages = $this->prefixLockPackages($decodedJson->packages, $prefix, $whitelist);
+        } else {
+            $decodedJson = $this->prefixLockPackages((array) $decodedJson, $prefix, $whitelist);
+        }
 
         return json_encode(
             $decodedJson,

--- a/tests/Scoper/Composer/InstalledPackagesScoperTest.php
+++ b/tests/Scoper/Composer/InstalledPackagesScoperTest.php
@@ -327,5 +327,131 @@ JSON
 ]
 JSON
         ];
+        yield [
+            <<<'JSON'
+{
+    "dev": true,
+    "packages": [
+        {
+            "name": "beberlei/assert",
+            "version": "v2.7.6",
+            "version_normalized": "2.7.6.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/beberlei/assert.git",
+                "reference": "8726e183ebbb0169cb6cb4832e22ebd355524563"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/beberlei/assert/zipball/8726e183ebbb0169cb6cb4832e22ebd355524563",
+                "reference": "8726e183ebbb0169cb6cb4832e22ebd355524563",
+                "shasum": ""
+            },
+            "require": {
+                "ext-mbstring": "*",
+                "php": ">=5.3"
+            },
+            "require-dev": {
+                "friendsofphp/php-cs-fixer": "^2.1.1",
+                "phpunit/phpunit": "^4|^5"
+            },
+            "time": "2017-05-04T02:00:24+00:00",
+            "type": "library",
+            "installation-source": "dist",
+            "autoload": {
+                "psr-4": {
+                    "Assert\\": "lib/Assert"
+                },
+                "files": [
+                    "lib/Assert/functions.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-2-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Benjamin Eberlei",
+                    "email": "kontakt@beberlei.de",
+                    "role": "Lead Developer"
+                },
+                {
+                    "name": "Richard Quadling",
+                    "email": "rquadling@gmail.com",
+                    "role": "Collaborator"
+                }
+            ],
+            "description": "Thin assertion library for input validation in business models.",
+            "keywords": [],
+            "platform": {}
+        }
+    ]
+}
+
+JSON
+            ,
+            <<<'JSON'
+{
+    "dev": true,
+    "packages": [
+        {
+            "name": "beberlei\/assert",
+            "version": "v2.7.6",
+            "version_normalized": "2.7.6.0",
+            "source": {
+                "type": "git",
+                "url": "https:\/\/github.com\/beberlei\/assert.git",
+                "reference": "8726e183ebbb0169cb6cb4832e22ebd355524563"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https:\/\/api.github.com\/repos\/beberlei\/assert\/zipball\/8726e183ebbb0169cb6cb4832e22ebd355524563",
+                "reference": "8726e183ebbb0169cb6cb4832e22ebd355524563",
+                "shasum": ""
+            },
+            "require": {
+                "ext-mbstring": "*",
+                "php": ">=5.3"
+            },
+            "require-dev": {
+                "friendsofphp\/php-cs-fixer": "^2.1.1",
+                "phpunit\/phpunit": "^4|^5"
+            },
+            "time": "2017-05-04T02:00:24+00:00",
+            "type": "library",
+            "installation-source": "dist",
+            "autoload": {
+                "psr-4": {
+                    "Foo\\Assert\\": "lib\/Assert"
+                },
+                "files": [
+                    "lib\/Assert\/functions.php"
+                ]
+            },
+            "notification-url": "https:\/\/packagist.org\/downloads\/",
+            "license": [
+                "BSD-2-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Benjamin Eberlei",
+                    "email": "kontakt@beberlei.de",
+                    "role": "Lead Developer"
+                },
+                {
+                    "name": "Richard Quadling",
+                    "email": "rquadling@gmail.com",
+                    "role": "Collaborator"
+                }
+            ],
+            "description": "Thin assertion library for input validation in business models.",
+            "keywords": [],
+            "platform": {}
+        }
+    ]
+}
+JSON
+        ];
     }
 }


### PR DESCRIPTION
The format of `installed.json` has changed in Composer v2. See:

https://github.com/composer/composer/blob/56811b4c8fec9c2eda5bd47a2c079e121c668eb4/src/Composer/Repository/FilesystemRepository.php#L72-L75