### PR TITLE
Add a "inverse-namespaces-whitelist" configuration option.

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ potentially very difficult to debug due to dissimilar or unsupported package ver
                 - [Constants whitelisting](#constants-whitelisting)
                 - [Functions whitelisting](#functions-whitelisting)
         - [Namespaces whitelisting](#namespaces-whitelisting)
+            - [Reversing namespaces whitelisting](#reversing-namespaces-whitelisting)
 - [Building a scoped PHAR](#building-a-scoped-phar)
     - [With Box](#with-box)
     - [Without Box](#without-box)
@@ -152,14 +153,15 @@ with a `--config` option.
 use Isolated\Symfony\Component\Finder\Finder;
 
 return [
-    'prefix' => null,                       // string|null
-    'finders' => [],                        // Finder[]
-    'patchers' => [],                       // callable[]
-    'files-whitelist' => [],                // string[]
-    'whitelist' => [],                      // string[]
-    'whitelist-global-constants' => true,   // bool
-    'whitelist-global-classes' => true,     // bool
-    'whitelist-global-functions' => true,   // bool
+    'prefix' => null,                        // string|null
+    'finders' => [],                         // Finder[]
+    'patchers' => [],                        // callable[]
+    'files-whitelist' => [],                 // string[]
+    'whitelist' => [],                       // string[]
+    'inverse-namespaces-whitelist' => false, // bool
+    'whitelist-global-constants' => true,    // bool
+    'whitelist-global-classes' => true,      // bool
+    'whitelist-global-functions' => true,    // bool
 ];
 ```
 
@@ -541,6 +543,12 @@ return [
 ];
 ```
 
+#### Reversing namespaces whitelisting
+
+If you add an `inverse-namespaces-whitelist` configuration key with a value of `true` 
+then the behavior of the namespaces whitelisting mechanism will be reversed. 
+This means that only classes within a namespace matching the whitelist will be prefixed, 
+and all other classes will be left untouched.
 
 ## Building a Scoped PHAR
 

--- a/src/Configuration.php
+++ b/src/Configuration.php
@@ -46,6 +46,7 @@ final class Configuration
     private const WHITELIST_GLOBAL_CONSTANTS_KEYWORD = 'whitelist-global-constants';
     private const WHITELIST_GLOBAL_CLASSES_KEYWORD = 'whitelist-global-classes';
     private const WHITELIST_GLOBAL_FUNCTIONS_KEYWORD = 'whitelist-global-functions';
+    private const WHITELIST_IS_INVERTED_KEYWORD = 'inverse-namespaces-whitelist';
 
     private const KEYWORDS = [
         self::PREFIX_KEYWORD,
@@ -56,6 +57,7 @@ final class Configuration
         self::WHITELIST_GLOBAL_CONSTANTS_KEYWORD,
         self::WHITELIST_GLOBAL_CLASSES_KEYWORD,
         self::WHITELIST_GLOBAL_FUNCTIONS_KEYWORD,
+        self::WHITELIST_IS_INVERTED_KEYWORD,
     ];
 
     private $path;
@@ -384,7 +386,25 @@ final class Configuration
             }
         }
 
-        return Whitelist::create($whitelistGlobalConstants, $whitelistGlobalClasses, $whitelistGlobalFunctions, ...$whitelist);
+        if (false === array_key_exists(self::WHITELIST_IS_INVERTED_KEYWORD, $config)) {
+            $namespacesWhitelistIsInverted = false;
+        } else {
+            $namespacesWhitelistIsInverted = $config[self::WHITELIST_IS_INVERTED_KEYWORD];
+
+            if (false === is_bool($namespacesWhitelistIsInverted)) {
+                throw new InvalidArgumentException(
+                    sprintf(
+                        'Expected %s to be a boolean, found "%s" instead.',
+                        self::WHITELIST_IS_INVERTED_KEYWORD,
+                        gettype($namespacesWhitelistIsInverted)
+                    )
+                );
+            }
+        }
+
+        $whitelist_instance = Whitelist::create($whitelistGlobalConstants, $whitelistGlobalClasses, $whitelistGlobalFunctions, ...$whitelist);
+        $whitelist_instance->setNamespacesWhitelistIsInverted($namespacesWhitelistIsInverted);
+        return $whitelist_instance;
     }
 
     /**

--- a/src/Configuration.php
+++ b/src/Configuration.php
@@ -402,9 +402,10 @@ final class Configuration
             }
         }
 
-        $whitelist_instance = Whitelist::create($whitelistGlobalConstants, $whitelistGlobalClasses, $whitelistGlobalFunctions, ...$whitelist);
-        $whitelist_instance->setNamespacesWhitelistIsInverted($namespacesWhitelistIsInverted);
-        return $whitelist_instance;
+        $whitelistInstance = Whitelist::create($whitelistGlobalConstants, $whitelistGlobalClasses, $whitelistGlobalFunctions, ...$whitelist);
+        $whitelistInstance->setNamespaceWhitelistIsInverted($namespacesWhitelistIsInverted);
+
+        return $whitelistInstance;
     }
 
     /**

--- a/src/Whitelist.php
+++ b/src/Whitelist.php
@@ -41,7 +41,7 @@ final class Whitelist implements Countable
     private $constants;
     private $namespaces;
     private $patterns;
-    private $namespacesWhitelistIsInverted;
+    private $namespaceWhitelistIsInverted;
 
     private $whitelistGlobalConstants;
     private $whitelistGlobalClasses;
@@ -140,12 +140,12 @@ final class Whitelist implements Countable
         $this->constants = $constants;
         $this->namespaces = $namespaces;
         $this->patterns = $patterns;
-        $this->namespacesWhitelistIsInverted = false;
+        $this->namespaceWhitelistIsInverted = false;
     }
 
     public function belongsToWhitelistedNamespace(string $name): bool
     {
-        return $this->namespacesWhitelistIsInverted ?
+        return $this->namespaceWhitelistIsInverted ?
             !$this->belongsToWhitelistedNamespaceCore($name) :
             $this->belongsToWhitelistedNamespaceCore($name);
     }
@@ -165,7 +165,7 @@ final class Whitelist implements Countable
 
     public function isWhitelistedNamespace(string $name): bool
     {
-        return $this->namespacesWhitelistIsInverted ?
+        return $this->namespaceWhitelistIsInverted ?
             !$this->isWhitelistedNamespaceCore($name) :
             $this->isWhitelistedNamespaceCore($name);
     }
@@ -260,14 +260,14 @@ final class Whitelist implements Countable
         return array_values($this->whitelistedClasses);
     }
 
-    public function getNamespacesWhitelistIsInverted(): bool
+    public function isNamespaceWhitelistInverted(): bool
     {
-        return $this->namespacesWhitelistIsInverted;
+        return $this->namespaceWhitelistIsInverted;
     }
 
-    public function setNamespacesWhitelistIsInverted(bool $value): void
+    public function setNamespaceWhitelistIsInverted(bool $value): void
     {
-        $this->namespacesWhitelistIsInverted = $value;
+        $this->namespaceWhitelistIsInverted = $value;
     }
 
     /**

--- a/src/Whitelist.php
+++ b/src/Whitelist.php
@@ -41,7 +41,7 @@ final class Whitelist implements Countable
     private $constants;
     private $namespaces;
     private $patterns;
-    private $NamespacesWhitelistIsInverted;
+    private $namespacesWhitelistIsInverted;
 
     private $whitelistGlobalConstants;
     private $whitelistGlobalClasses;
@@ -140,12 +140,12 @@ final class Whitelist implements Countable
         $this->constants = $constants;
         $this->namespaces = $namespaces;
         $this->patterns = $patterns;
-        $this->NamespacesWhitelistIsInverted = false;
+        $this->namespacesWhitelistIsInverted = false;
     }
 
     public function belongsToWhitelistedNamespace(string $name): bool
     {
-        return $this->NamespacesWhitelistIsInverted ?
+        return $this->namespacesWhitelistIsInverted ?
             !$this->belongsToWhitelistedNamespaceCore($name) :
             $this->belongsToWhitelistedNamespaceCore($name);
     }
@@ -165,7 +165,7 @@ final class Whitelist implements Countable
 
     public function isWhitelistedNamespace(string $name): bool
     {
-        return $this->NamespacesWhitelistIsInverted ?
+        return $this->namespacesWhitelistIsInverted ?
             !$this->isWhitelistedNamespaceCore($name) :
             $this->isWhitelistedNamespaceCore($name);
     }
@@ -262,12 +262,12 @@ final class Whitelist implements Countable
 
     public function getNamespacesWhitelistIsInverted(): bool
     {
-        return $this->NamespacesWhitelistIsInverted;
+        return $this->namespacesWhitelistIsInverted;
     }
 
     public function setNamespacesWhitelistIsInverted(bool $value): void
     {
-        $this->NamespacesWhitelistIsInverted = $value;
+        $this->namespacesWhitelistIsInverted = $value;
     }
 
     /**

--- a/src/Whitelist.php
+++ b/src/Whitelist.php
@@ -41,6 +41,7 @@ final class Whitelist implements Countable
     private $constants;
     private $namespaces;
     private $patterns;
+    private $NamespacesWhitelistIsInverted;
 
     private $whitelistGlobalConstants;
     private $whitelistGlobalClasses;
@@ -139,9 +140,17 @@ final class Whitelist implements Countable
         $this->constants = $constants;
         $this->namespaces = $namespaces;
         $this->patterns = $patterns;
+        $this->NamespacesWhitelistIsInverted = false;
     }
 
     public function belongsToWhitelistedNamespace(string $name): bool
+    {
+        return $this->NamespacesWhitelistIsInverted ?
+            !$this->belongsToWhitelistedNamespaceCore($name) :
+            $this->belongsToWhitelistedNamespaceCore($name);
+    }
+
+    private function belongsToWhitelistedNamespaceCore(string $name): bool
     {
         $nameNamespace = $this->retrieveNameNamespace($name);
 
@@ -155,6 +164,13 @@ final class Whitelist implements Countable
     }
 
     public function isWhitelistedNamespace(string $name): bool
+    {
+        return $this->NamespacesWhitelistIsInverted ?
+            !$this->isWhitelistedNamespaceCore($name) :
+            $this->isWhitelistedNamespaceCore($name);
+    }
+
+    private function isWhitelistedNamespaceCore(string $name): bool
     {
         $name = strtolower($name);
 
@@ -242,6 +258,16 @@ final class Whitelist implements Countable
     public function getRecordedWhitelistedClasses(): array
     {
         return array_values($this->whitelistedClasses);
+    }
+
+    public function getNamespacesWhitelistIsInverted(): bool
+    {
+        return $this->NamespacesWhitelistIsInverted;
+    }
+
+    public function setNamespacesWhitelistIsInverted(bool $value): void
+    {
+        $this->NamespacesWhitelistIsInverted = $value;
     }
 
     /**

--- a/src/scoper.inc.php.tpl
+++ b/src/scoper.inc.php.tpl
@@ -62,12 +62,19 @@ return [
     // A way to achieve this is by specifying a list of classes to not prefix with the following configuration key. Note
     // that this does not work with functions or constants neither with classes belonging to the global namespace.
     //
+    // To get the inverse behavior (so the whitelist specifies a list of classes to prefix)
+    // you can set `inverse-namespaces-whitelist` to `true`.
+    //
     // Fore more see https://github.com/humbug/php-scoper#whitelist
     'whitelist' => [
         // 'PHPUnit\Framework\TestCase',   // A specific class
         // 'PHPUnit\Framework\*',          // The whole namespace
         // '*',                            // Everything
     ],
+
+    // If `true` then the behavior of `whitelist` will be reversed: only the classes in the specified namespaces
+    // will be prefixed, and all others will be left untouched.
+    'inverse-namespaces-whitelist' => false,
 
     // If `true` then the user defined constants belonging to the global namespace will not be prefixed.
     //

--- a/tests/ConfigurationTest.php
+++ b/tests/ConfigurationTest.php
@@ -36,6 +36,7 @@ class ConfigurationTest extends FileSystemTestCase
         $this->assertNull($configuration->getPrefix());
         $this->assertSame([], $configuration->getFilesWithContents());
         $this->assertEquals([new SymfonyPatcher()], $configuration->getPatchers());
+        $this->assertFalse($configuration->getWhitelist()->getNamespacesWhitelistIsInverted());
     }
 
     public function test_it_cannot_create_a_configuration_with_an_invalid_key(): void
@@ -77,6 +78,7 @@ return [
     'whitelist-global-classes' => false,
     'whitelist-global-functions' => false,
     'whitelist' => ['Foo', 'Bar\*'],
+    'inverse-namespaces-whitelist' => true
 ];
 PHP
         );
@@ -85,13 +87,13 @@ PHP
         $configuration = Configuration::load($this->tmp.DIRECTORY_SEPARATOR.'scoper.inc.php');
 
         $this->assertSame([$this->tmp.DIRECTORY_SEPARATOR.'file1'], $configuration->getWhitelistedFiles());
-        $this->assertEquals(
-            Whitelist::create(false, false, false, 'Foo', 'Bar\*'),
-            $configuration->getWhitelist()
-        );
+        $expectedWhitelist = Whitelist::create(false, false, false, 'Foo', 'Bar\*');
+        $expectedWhitelist->setNamespacesWhitelistIsInverted(true);
+        $this->assertEquals($expectedWhitelist, $configuration->getWhitelist());
         $this->assertSame($this->tmp.DIRECTORY_SEPARATOR.'scoper.inc.php', $configuration->getPath());
         $this->assertSame('MyPrefix', $configuration->getPrefix());
         $this->assertSame([], $configuration->getFilesWithContents());
         $this->assertEquals([new SymfonyPatcher()], $configuration->getPatchers());
+        $this->assertTrue($configuration->getWhitelist()->getNamespacesWhitelistIsInverted());
     }
 }

--- a/tests/ConfigurationTest.php
+++ b/tests/ConfigurationTest.php
@@ -36,7 +36,7 @@ class ConfigurationTest extends FileSystemTestCase
         $this->assertNull($configuration->getPrefix());
         $this->assertSame([], $configuration->getFilesWithContents());
         $this->assertEquals([new SymfonyPatcher()], $configuration->getPatchers());
-        $this->assertFalse($configuration->getWhitelist()->getNamespacesWhitelistIsInverted());
+        $this->assertFalse($configuration->getWhitelist()->isNamespaceWhitelistInverted());
     }
 
     public function test_it_cannot_create_a_configuration_with_an_invalid_key(): void
@@ -88,12 +88,12 @@ PHP
 
         $this->assertSame([$this->tmp.DIRECTORY_SEPARATOR.'file1'], $configuration->getWhitelistedFiles());
         $expectedWhitelist = Whitelist::create(false, false, false, 'Foo', 'Bar\*');
-        $expectedWhitelist->setNamespacesWhitelistIsInverted(true);
+        $expectedWhitelist->setNamespaceWhitelistIsInverted(true);
         $this->assertEquals($expectedWhitelist, $configuration->getWhitelist());
         $this->assertSame($this->tmp.DIRECTORY_SEPARATOR.'scoper.inc.php', $configuration->getPath());
         $this->assertSame('MyPrefix', $configuration->getPrefix());
         $this->assertSame([], $configuration->getFilesWithContents());
         $this->assertEquals([new SymfonyPatcher()], $configuration->getPatchers());
-        $this->assertTrue($configuration->getWhitelist()->getNamespacesWhitelistIsInverted());
+        $this->assertTrue($configuration->getWhitelist()->isNamespaceWhitelistInverted());
     }
 }

--- a/tests/WhitelistTest.php
+++ b/tests/WhitelistTest.php
@@ -170,6 +170,17 @@ class WhitelistTest extends TestCase
     }
 
     /**
+     * @dataProvider provideNamespacedSymbolWhitelists
+     */
+    public function test_it_can_tell_if_a_symbol_belongs_to_a_whitelisted_namespace_in_inclusive_mode(Whitelist $whitelist, string $symbol, bool $expected): void
+    {
+        $whitelist->setNamespacesWhitelistIsInverted(true);
+        $actual = $whitelist->belongsToWhitelistedNamespace($symbol);
+
+        $this->assertSame(!$expected, $actual);
+    }
+
+    /**
      * @dataProvider provideNamespaceWhitelists
      */
     public function test_it_can_tell_if_a_namespace_is_whitelisted(Whitelist $whitelist, string $namespace, bool $expected): void
@@ -177,6 +188,17 @@ class WhitelistTest extends TestCase
         $actual = $whitelist->isWhitelistedNamespace($namespace);
 
         $this->assertSame($expected, $actual);
+    }
+
+    /**
+     * @dataProvider provideNamespaceWhitelists
+     */
+    public function test_it_can_tell_if_a_namespace_is_whitelisted_in_inverted_mode(Whitelist $whitelist, string $namespace, bool $expected): void
+    {
+        $whitelist->setNamespacesWhitelistIsInverted(true);
+        $actual = $whitelist->isWhitelistedNamespace($namespace);
+
+        $this->assertSame(!$expected, $actual);
     }
 
     /**

--- a/tests/WhitelistTest.php
+++ b/tests/WhitelistTest.php
@@ -174,7 +174,7 @@ class WhitelistTest extends TestCase
      */
     public function test_it_can_tell_if_a_symbol_belongs_to_a_whitelisted_namespace_in_inclusive_mode(Whitelist $whitelist, string $symbol, bool $expected): void
     {
-        $whitelist->setNamespacesWhitelistIsInverted(true);
+        $whitelist->setNamespaceWhitelistIsInverted(true);
         $actual = $whitelist->belongsToWhitelistedNamespace($symbol);
 
         $this->assertSame(!$expected, $actual);
@@ -195,7 +195,7 @@ class WhitelistTest extends TestCase
      */
     public function test_it_can_tell_if_a_namespace_is_whitelisted_in_inverted_mode(Whitelist $whitelist, string $namespace, bool $expected): void
     {
-        $whitelist->setNamespacesWhitelistIsInverted(true);
+        $whitelist->setNamespaceWhitelistIsInverted(true);
         $actual = $whitelist->isWhitelistedNamespace($namespace);
 
         $this->assertSame(!$expected, $actual);


### PR DESCRIPTION
Add a `inverse-namespaces-whitelist` option to the `scoper.inc.php`configuration file.

This is a boolean option that defaults to `false`. When set to `true`, the namespaces whitelist mechanism (`whitelist` configuration key) is reversed: only classes matching the namespaces listed will be prefixed, and all others will be left untouched.

This does not affect the whitelisting of global classes, constants or functions.

Closes #406.