### PR TITLE
Add an "output-dir" configuration option

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ potentially very difficult to debug due to dissimilar or unsupported package ver
     - [Composer](#composer)
 - [Usage](#usage)
 - [Configuration](#configuration)
+    - [Output directory](#output-directory)
     - [Prefix](#prefix)
     - [Finders and paths](#finders-and-paths)
     - [Patchers](#patchers)
@@ -152,6 +153,7 @@ with a `--config` option.
 use Isolated\Symfony\Component\Finder\Finder;
 
 return [
+    'output-dir' => null,                   // string|null
     'prefix' => null,                       // string|null
     'finders' => [],                        // Finder[]
     'patchers' => [],                       // callable[]
@@ -162,6 +164,11 @@ return [
     'whitelist-global-functions' => true,   // bool
 ];
 ```
+
+### Output directory
+
+The base output directory where the prefixed files will be generated. If `null` is given, "build" is used.
+This setting will be overriden by the command line option of the same name if present. 
 
 
 ### Prefix

--- a/src/Configuration.php
+++ b/src/Configuration.php
@@ -139,8 +139,7 @@ final class Configuration
 
         if (false === array_key_exists(self::OUTPUT_DIR_KEYWORD, $config)) {
             $outputDir = null;
-        }
-        else {
+        } else {
             $outputDir = $config[ self::OUTPUT_DIR_KEYWORD ];
         }
 

--- a/src/Configuration.php
+++ b/src/Configuration.php
@@ -46,6 +46,7 @@ final class Configuration
     private const WHITELIST_GLOBAL_CONSTANTS_KEYWORD = 'whitelist-global-constants';
     private const WHITELIST_GLOBAL_CLASSES_KEYWORD = 'whitelist-global-classes';
     private const WHITELIST_GLOBAL_FUNCTIONS_KEYWORD = 'whitelist-global-functions';
+    private const OUTPUT_DIR_KEYWORD = 'output-dir';
 
     private const KEYWORDS = [
         self::PREFIX_KEYWORD,
@@ -56,6 +57,7 @@ final class Configuration
         self::WHITELIST_GLOBAL_CONSTANTS_KEYWORD,
         self::WHITELIST_GLOBAL_CLASSES_KEYWORD,
         self::WHITELIST_GLOBAL_FUNCTIONS_KEYWORD,
+        self::OUTPUT_DIR_KEYWORD
     ];
 
     private $path;
@@ -64,6 +66,7 @@ final class Configuration
     private $patchers;
     private $whitelist;
     private $whitelistedFiles;
+    private $outputDir;
 
     /**
      * @param string|null $path  Absolute path to the configuration file.
@@ -134,7 +137,14 @@ final class Configuration
         $filesFromPaths = self::retrieveFilesFromPaths($paths);
         $filesWithContents = self::retrieveFilesWithContents(chain($filesFromPaths, ...$finders));
 
-        return new self($path, $prefix, $filesWithContents, $patchers, $whitelist, $whitelistedFiles);
+        if (false === array_key_exists(self::OUTPUT_DIR_KEYWORD, $config)) {
+            $outputDir = null;
+        }
+        else {
+            $outputDir = $config[ self::OUTPUT_DIR_KEYWORD ];
+        }
+
+        return new self($path, $prefix, $filesWithContents, $patchers, $whitelist, $whitelistedFiles, $outputDir);
     }
 
     /**
@@ -154,7 +164,8 @@ final class Configuration
         array $filesWithContents,
         array $patchers,
         Whitelist $whitelist,
-        array $whitelistedFiles
+        array $whitelistedFiles,
+        ?string $outputDir
     ) {
         $this->path = $path;
         $this->prefix = $prefix;
@@ -162,6 +173,7 @@ final class Configuration
         $this->patchers = $patchers;
         $this->whitelist = $whitelist;
         $this->whitelistedFiles = $whitelistedFiles;
+        $this->outputDir = $outputDir;
     }
 
     public function withPaths(array $paths): self
@@ -180,7 +192,8 @@ final class Configuration
             array_merge($this->filesWithContents, $filesWithContents),
             $this->patchers,
             $this->whitelist,
-            $this->whitelistedFiles
+            $this->whitelistedFiles,
+            $this->outputDir
         );
     }
 
@@ -194,7 +207,8 @@ final class Configuration
             $this->filesWithContents,
             $this->patchers,
             $this->whitelist,
-            $this->whitelistedFiles
+            $this->whitelistedFiles,
+            $this->outputDir
         );
     }
 
@@ -232,6 +246,10 @@ final class Configuration
     public function getWhitelistedFiles(): array
     {
         return $this->whitelistedFiles;
+    }
+
+    public function getOutputDir(): ?string {
+    	return $this->outputDir;
     }
 
     private static function validateConfigKeys(array $config): void

--- a/src/Console/Command/AddPrefixCommand.php
+++ b/src/Console/Command/AddPrefixCommand.php
@@ -85,8 +85,7 @@ final class AddPrefixCommand extends BaseCommand
                 self::OUTPUT_DIR_OPT,
                 'o',
                 InputOption::VALUE_REQUIRED,
-                'The output directory in which the prefixed code will be dumped.',
-                'build'
+                'The output directory in which the prefixed code will be dumped.'
             )
             ->addOption(
                 self::FORCE_OPT,
@@ -128,11 +127,12 @@ final class AddPrefixCommand extends BaseCommand
 
         $this->changeWorkingDirectory($input);
 
+        $config = $this->retrieveConfig($input, $output, $io);
+
         $this->validatePrefix($input);
         $this->validatePaths($input);
-        $this->validateOutputDir($input, $io);
+        $this->validateOutputDir($input, $io, $config);
 
-        $config = $this->retrieveConfig($input, $output, $io);
         $output = $input->getOption(self::OUTPUT_DIR_OPT);
 
         if ([] !== $config->getWhitelistedFiles()) {
@@ -301,9 +301,9 @@ final class AddPrefixCommand extends BaseCommand
         $input->setArgument(self::PATH_ARG, $paths);
     }
 
-    private function validateOutputDir(InputInterface $input, OutputStyle $io): void
+    private function validateOutputDir(InputInterface $input, OutputStyle $io, Configuration $config)
     {
-        $outputDir = $input->getOption(self::OUTPUT_DIR_OPT);
+        $outputDir = $input->getOption(self::OUTPUT_DIR_OPT) ?? $config->getOutputDir() ?? 'build';
 
         if (false === $this->fileSystem->isAbsolutePath($outputDir)) {
             $outputDir = getcwd().DIRECTORY_SEPARATOR.$outputDir;

--- a/src/scoper.inc.php.tpl
+++ b/src/scoper.inc.php.tpl
@@ -5,6 +5,10 @@ declare(strict_types=1);
 use Isolated\Symfony\Component\Finder\Finder;
 
 return [
+    // The base output directory for the prefixed files.
+    // This will be overriden by the 'output-dir' command line option if present.
+    'output-dir' => null,
+
     // The prefix configuration. If a non null value will be used, a random prefix will be generated.
     'prefix' => null,
 

--- a/tests/ConfigurationTest.php
+++ b/tests/ConfigurationTest.php
@@ -36,6 +36,7 @@ class ConfigurationTest extends FileSystemTestCase
         $this->assertNull($configuration->getPrefix());
         $this->assertSame([], $configuration->getFilesWithContents());
         $this->assertEquals([new SymfonyPatcher()], $configuration->getPatchers());
+        $this->assertNull($configuration->getOutputDir());
     }
 
     public function test_it_cannot_create_a_configuration_with_an_invalid_key(): void
@@ -77,6 +78,7 @@ return [
     'whitelist-global-classes' => false,
     'whitelist-global-functions' => false,
     'whitelist' => ['Foo', 'Bar\*'],
+    'output-dir' => 'foo/bar'
 ];
 PHP
         );
@@ -93,5 +95,6 @@ PHP
         $this->assertSame('MyPrefix', $configuration->getPrefix());
         $this->assertSame([], $configuration->getFilesWithContents());
         $this->assertEquals([new SymfonyPatcher()], $configuration->getPatchers());
+        $this->assertEquals('foo/bar', $configuration->getOutputDir());
     }
 }


### PR DESCRIPTION
Add an `output-dir` option to the configuration file.

This allows to specify the base output directory for the generated prefixed files in the configuration file, the same way as the
command line option of the same name already does. If both are present, the command line option takes precedence.