### PR TITLE
Add an "on-existing-output-dir" configuration option

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ potentially very difficult to debug due to dissimilar or unsupported package ver
     - [Composer](#composer)
 - [Usage](#usage)
 - [Configuration](#configuration)
+    - [Behavior on existing output directory](#behavior-on-existing-output-directory)
     - [Prefix](#prefix)
     - [Finders and paths](#finders-and-paths)
     - [Patchers](#patchers)
@@ -152,6 +153,7 @@ with a `--config` option.
 use Isolated\Symfony\Component\Finder\Finder;
 
 return [
+    'on-existing-output-dir' => 'ask',      // string
     'prefix' => null,                       // string|null
     'finders' => [],                        // Finder[]
     'patchers' => [],                       // callable[]
@@ -162,6 +164,18 @@ return [
     'whitelist-global-functions' => true,   // bool
 ];
 ```
+
+### Behavior on existing output directory
+
+The `on-existing-output-dir` key controls the behavior of PHP Scoper when the output
+directory (or a file with the same name) already exists. Three values are allowed:
+
+* `ask`: Ask the user for confirmation on overwriting. This is the default behavior. 
+* `overwrite`: Overwrite the existing output directory without being asked to confirm.
+* `abort`: Abort the scoping process without being asked to confirm.
+
+Note that if the `--force` option is specified when running the command then the value
+of this configuration key will be ignored (a value of `overwrite` will be assumed).
 
 
 ### Prefix
@@ -573,7 +587,9 @@ code untouched. The default location is `./build`. You can change the default
 location using the `--output-dir` option. By default, it also generates a random
 prefix string. You can set a specific prefix string using the `--prefix` option.
 If automating builds, you can set the `--force` option to overwrite any code
-existing in the output directory without being asked to confirm.
+existing in the output directory without being asked to confirm (see also the
+ "[Behavior on existing output directory](#behavior-on-existing-output-directory)"
+ configuration key).
 
 Onto the basic command assuming default options from your project's root
 directory:

--- a/src/Configuration.php
+++ b/src/Configuration.php
@@ -35,6 +35,8 @@ use SplFileInfo;
 use function sprintf;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Finder\Finder;
+use function in_array;
+use function implode;
 
 final class Configuration
 {
@@ -562,11 +564,6 @@ final class Configuration
         );
     }
 
-    /**
-     * @param array $config
-     *
-     * @return string
-     */
     private static function retrieveOnExistingOutputDir(array $config): string
     {
         if (false === array_key_exists(self::ON_EXISTING_OUTPUT_DIR_KEYWORD, $config)) {
@@ -586,13 +583,13 @@ final class Configuration
         }
 
         $allowedOnExistingOutputDirValues = ['ask', 'overwrite', 'abort'];
-        if(!in_array($onExistingOutputDir, $allowedOnExistingOutputDirValues)) {
+        if(!in_array($onExistingOutputDir, $allowedOnExistingOutputDirValues, true)) {
             throw new InvalidArgumentException(
                 sprintf(
-                    'Found value of "%s" for %s; allowed values are %s.',
-                    $onExistingOutputDir,
-                    self::ON_EXISTING_OUTPUT_DIR_KEYWORD,
-                    implode(', ', $allowedOnExistingOutputDirValues)
+	                'Expected one of "%s" for "%s". Got "%s".',
+	                implode('", "', $allowedOnExistingOutputDirValues),
+	                self::ON_EXISTING_OUTPUT_DIR_KEYWORD,
+	                $onExistingOutputDir
                 )
             );
         }

--- a/src/Console/Command/AddPrefixCommand.php
+++ b/src/Console/Command/AddPrefixCommand.php
@@ -33,6 +33,8 @@ use Symfony\Component\Console\Style\OutputStyle;
 use Symfony\Component\Console\Style\SymfonyStyle;
 use Symfony\Component\Filesystem\Filesystem;
 use Throwable;
+use function is_dir;
+use function sprintf;
 
 final class AddPrefixCommand extends BaseCommand
 {
@@ -305,9 +307,6 @@ final class AddPrefixCommand extends BaseCommand
     }
 
     /**
-     * @param InputInterface $input
-     * @param OutputStyle $io
-     *
      * @return bool True if the command execution must continue after the function returns, false otherwise
      */
     private function validateOutputDir(InputInterface $input, OutputStyle $io, Configuration $config): bool

--- a/src/Console/Command/AddPrefixCommand.php
+++ b/src/Console/Command/AddPrefixCommand.php
@@ -130,9 +130,12 @@ final class AddPrefixCommand extends BaseCommand
 
         $this->validatePrefix($input);
         $this->validatePaths($input);
-        $this->validateOutputDir($input, $io);
 
         $config = $this->retrieveConfig($input, $output, $io);
+        if(!$this->validateOutputDir($input, $io, $config)) {
+            return 1;
+        };
+
         $output = $input->getOption(self::OUTPUT_DIR_OPT);
 
         if ([] !== $config->getWhitelistedFiles()) {
@@ -301,7 +304,13 @@ final class AddPrefixCommand extends BaseCommand
         $input->setArgument(self::PATH_ARG, $paths);
     }
 
-    private function validateOutputDir(InputInterface $input, OutputStyle $io): void
+    /**
+     * @param InputInterface $input
+     * @param OutputStyle $io
+     *
+     * @return bool True if the command execution must continue after the function returns, false otherwise
+     */
+    private function validateOutputDir(InputInterface $input, OutputStyle $io, Configuration $config): bool
     {
         $outputDir = $input->getOption(self::OUTPUT_DIR_OPT);
 
@@ -312,7 +321,7 @@ final class AddPrefixCommand extends BaseCommand
         $input->setOption(self::OUTPUT_DIR_OPT, $outputDir);
 
         if (false === $this->fileSystem->exists($outputDir)) {
-            return;
+            return true;
         }
 
         if (false === is_writable($outputDir)) {
@@ -325,9 +334,26 @@ final class AddPrefixCommand extends BaseCommand
         }
 
         if ($input->getOption(self::FORCE_OPT)) {
+            $onExistingOutputDirBehavior = 'overwrite';
+        } else {
+            $onExistingOutputDirBehavior = $config->getOnExistingOutputDir();
+        }
+
+        if ('overwrite' === $onExistingOutputDirBehavior) {
             $this->fileSystem->remove($outputDir);
 
-            return;
+            return true;
+        }
+
+        if ('abort' === $onExistingOutputDirBehavior) {
+            $io->writeln(
+                sprintf(
+                    '%s "<comment>%s</comment>" already exists, aborting.',
+                    is_dir($outputDir) ? 'Directory' : 'File',
+                    $outputDir
+                )
+            );
+            return false;
         }
 
         if (false === is_dir($outputDir)) {
@@ -341,7 +367,7 @@ final class AddPrefixCommand extends BaseCommand
             );
 
             if (false === $canDeleteFile) {
-                return;
+                return false;
             }
 
             $this->fileSystem->remove($outputDir);
@@ -356,10 +382,12 @@ final class AddPrefixCommand extends BaseCommand
             );
 
             if (false === $canDeleteFile) {
-                return;
+                return false;
             }
 
             $this->fileSystem->remove($outputDir);
+
+            return true;
         }
     }
 

--- a/src/scoper.inc.php.tpl
+++ b/src/scoper.inc.php.tpl
@@ -5,6 +5,10 @@ declare(strict_types=1);
 use Isolated\Symfony\Component\Finder\Finder;
 
 return [
+    // Behavior when the output directory already exists. Allowed values are
+    // 'ask' (default), 'overwrite' and 'abort'.
+    'on-existing-output-dir' => 'ask',
+
     // The prefix configuration. If a non null value will be used, a random prefix will be generated.
     'prefix' => null,
 

--- a/tests/ConfigurationTest.php
+++ b/tests/ConfigurationTest.php
@@ -33,6 +33,7 @@ class ConfigurationTest extends FileSystemTestCase
             $configuration->getWhitelist()
         );
         $this->assertNull($configuration->getPath());
+        $this->assertSame('ask', $configuration->getOnExistingOutputDir());
         $this->assertNull($configuration->getPrefix());
         $this->assertSame([], $configuration->getFilesWithContents());
         $this->assertEquals([new SymfonyPatcher()], $configuration->getPatchers());

--- a/tests/ConfigurationTest.php
+++ b/tests/ConfigurationTest.php
@@ -71,6 +71,7 @@ PHP
 <?php
 
 return [
+    'on-existing-output-dir' => 'overwrite',
     'prefix' => 'MyPrefix',
     'files-whitelist' => ['file1', 'file2'],
     'whitelist-global-constants' => false,
@@ -90,6 +91,7 @@ PHP
             $configuration->getWhitelist()
         );
         $this->assertSame($this->tmp.DIRECTORY_SEPARATOR.'scoper.inc.php', $configuration->getPath());
+        $this->assertSame('overwrite', $configuration->getOnExistingOutputDir());
         $this->assertSame('MyPrefix', $configuration->getPrefix());
         $this->assertSame([], $configuration->getFilesWithContents());
         $this->assertEquals([new SymfonyPatcher()], $configuration->getPatchers());


### PR DESCRIPTION
This pull request fixes a bug and adds a new feature. The former is a prerequisite for the later.

#### Fixed bug

`validateOutputDir` in `AddPrefixCommand` asks the user for confirmation if the output directory already exists, however it ignores user input and proceeds with the scoping process regardless of what the user responds.

This has been fixed by having `validateOutputDir` return a boolean (which will be `false` if the user responds "no"); the `execute` function, in turn, will return immediately with an error code of 1 if `validateOutputDir` returns `false`.

#### New feature

Added a new `on-existing-output-dir` configuration option to decide what to do if the output directory already exists. Allowed values are 'ask' (default), 'overwrite' and 'abort'. The later is equivalent to the user responding "no" (so `execute` will return immediately with an error code of 1).

The `--force` command line option, if present, overrides the configuration option and works as 'overwrite' for compatibility.