### PR TITLE
Also check for interfaces and traits in existence checks

### DIFF
--- a/fixtures/set011/composer.json
+++ b/fixtures/set011/composer.json
@@ -3,6 +3,7 @@
         "bin/greet.php"
     ],
     "autoload": {
+        "classmap": ["polyfill"],
         "psr-4": {
             "Set011\\": "src/"
         }

--- a/fixtures/set011/polyfill/Iterator.php
+++ b/fixtures/set011/polyfill/Iterator.php
@@ -1,0 +1,18 @@
+<?php
+
+/**
+ * Let's polyfill the iterator interface.
+ *
+ * We use it as example to alias an interface into the root namespace.
+ * It will never get loaded for real as it exists on all PHP versions.
+ *
+ * @link https://php.net/manual/en/class.iterator.php.
+ * @link https://github.com/humbug/php-scoper/issues/403
+ */
+interface Iterator extends Traversable {
+    public function current();
+    public function next(): void;
+    public function key();
+    public function valid(): bool;
+    public function rewind(): void;
+}

--- a/src/Autoload/ScoperAutoloadGenerator.php
+++ b/src/Autoload/ScoperAutoloadGenerator.php
@@ -113,8 +113,8 @@ PHP;
 
                 return sprintf(
                     <<<'PHP'
-if (!class_exists('%s', false)) {
-    class_exists('%s');
+if (!class_exists('%1$s', false) && !interface_exists('%1$s', false) && !trait_exists('%1$s', false)) {
+    spl_autoload_call('%2$s');
 }
 PHP
                     ,

--- a/tests/Autoload/ScoperAutoloadGeneratorTest.php
+++ b/tests/Autoload/ScoperAutoloadGeneratorTest.php
@@ -187,8 +187,8 @@ $loader = require_once __DIR__.'/autoload.php';
 
 // Aliases for the whitelisted classes. For more information see:
 // https://github.com/humbug/php-scoper/blob/master/README.md#class-whitelisting
-if (!class_exists('A\Foo', false)) {
-    class_exists('Humbug\A\Foo');
+if (!class_exists('A\Foo', false) && !interface_exists('A\Foo', false) && !trait_exists('A\Foo', false)) {
+    spl_autoload_call('Humbug\A\Foo');
 }
 
 return $loader;
@@ -221,11 +221,11 @@ $loader = require_once __DIR__.'/autoload.php';
 
 // Aliases for the whitelisted classes. For more information see:
 // https://github.com/humbug/php-scoper/blob/master/README.md#class-whitelisting
-if (!class_exists('Foo', false)) {
-    class_exists('Humbug\Foo');
+if (!class_exists('Foo', false) && !interface_exists('Foo', false) && !trait_exists('Foo', false)) {
+    spl_autoload_call('Humbug\Foo');
 }
-if (!class_exists('Bar', false)) {
-    class_exists('Humbug\Bar');
+if (!class_exists('Bar', false) && !interface_exists('Bar', false) && !trait_exists('Bar', false)) {
+    spl_autoload_call('Humbug\Bar');
 }
 
 return $loader;
@@ -281,8 +281,8 @@ namespace {
 // Aliases for the whitelisted classes. For more information see:
 // https://github.com/humbug/php-scoper/blob/master/README.md#class-whitelisting
 namespace {
-    if (!class_exists('A\Foo', false)) {
-        class_exists('Humbug\A\Foo');
+    if (!class_exists('A\Foo', false) && !interface_exists('A\Foo', false) && !trait_exists('A\Foo', false)) {
+        spl_autoload_call('Humbug\A\Foo');
     }
 }
 


### PR DESCRIPTION
Only performing `class_exists()` is not sufficient as interfaces and
traits are different kind of autoloadable things.
Therefore we have to test that none of these exist prior trying to
autoload an alias them.

Fixes #403