### PR TITLE
Correct function in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -393,7 +393,7 @@ With:
 
 $loader = require_once __DIR__.'/autoload.php';
 
-class_alias('Humbug\\Acme\\Foo');   // Triggers the autoloading of
+class_exists('Humbug\\Acme\\Foo');   // Triggers the autoloading of
                                     // `Humbug\Acme\Foo` after the
                                     // Composer autoload is registered
 


### PR DESCRIPTION
Documentation says that `class_exists()` is used to autoload the aliased class, but `class_alias()` is used in the example.