### PR TITLE
[WIP] Better WordPress support

### DIFF
--- a/fixtures/set033-identifier-extractor/empty-stubs.php
+++ b/fixtures/set033-identifier-extractor/empty-stubs.php
@@ -1,0 +1,4 @@
+<?php
+namespace {
+
+}

--- a/fixtures/set033-identifier-extractor/stubs.php
+++ b/fixtures/set033-identifier-extractor/stubs.php
@@ -1,0 +1,12 @@
+<?php
+namespace {
+    class ExampleClass {}
+    final class ExampleFinalClass {}
+    abstract class ExampleAbstractClass {}
+
+    interface ExampleInterface {}
+
+    trait ExampleTrait {}
+
+    function example_function () {}
+}

--- a/fixtures/set034-remove-prefix-patcher/original/wordpress-complete-identifiers.php
+++ b/fixtures/set034-remove-prefix-patcher/original/wordpress-complete-identifiers.php
@@ -1,0 +1,10 @@
+<?php
+
+class WordPressExample
+{
+    public function test($slug, $title)
+    {
+        Humbug\add_action('admin_init', function () {});
+        $post = new Humbug\WP_Post(1);
+    }
+}

--- a/fixtures/set034-remove-prefix-patcher/original/wordpress-missing-identifiers.php
+++ b/fixtures/set034-remove-prefix-patcher/original/wordpress-missing-identifiers.php
@@ -1,0 +1,12 @@
+<?php
+
+class WordPressExample
+{
+    public function test($slug, $title)
+    {
+        Humbug\add_action('admin_init', function() {});
+        $post = new Humbug\WP_Post(1);
+
+        $option = Humbug\get_option('test_option');
+    }
+}

--- a/fixtures/set034-remove-prefix-patcher/patched/wordpress-complete-identifiers.php
+++ b/fixtures/set034-remove-prefix-patcher/patched/wordpress-complete-identifiers.php
@@ -1,0 +1,10 @@
+<?php
+
+class WordPressExample
+{
+    public function test($slug, $title)
+    {
+        add_action('admin_init', function () {});
+        $post = new WP_Post(1);
+    }
+}

--- a/fixtures/set034-remove-prefix-patcher/patched/wordpress-missing-identifiers.php
+++ b/fixtures/set034-remove-prefix-patcher/patched/wordpress-missing-identifiers.php
@@ -1,0 +1,12 @@
+<?php
+
+class WordPressExample
+{
+    public function test($slug, $title)
+    {
+        add_action('admin_init', function () {});
+        $post = new WP_Post(1);
+
+        $option = Humbug\get_option('test_option');
+    }
+}

--- a/fixtures/set034-remove-prefix-patcher/stubs.php
+++ b/fixtures/set034-remove-prefix-patcher/stubs.php
@@ -1,0 +1,5 @@
+<?php
+namespace {
+    class WP_Post {}
+    function add_action($tag, $callable, $priority, $accepted_args) {}
+}

--- a/src/Extractor/IdentifierExtractor.php
+++ b/src/Extractor/IdentifierExtractor.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Humbug\PhpScoper\Extractor;
+
+use InvalidArgumentException;
+use PhpParser\ParserFactory;
+
+class IdentifierExtractor
+{
+    public function __construct($statements = null)
+    {
+        $this->stubFiles = [];
+        $this->extractStatements = $statements ?? [
+            "PhpParser\Node\Stmt\Class_",
+            "PhpParser\Node\Stmt\Interface_",
+            "PhpParser\Node\Stmt\Trait_",
+            "PhpParser\Node\Stmt\Function_"
+        ];
+    }
+
+    public function addStub($file)
+    {
+        if (! file_exists($file)) {
+            throw new InvalidArgumentException("File not found: " . $file);
+        }
+
+        $this->stubFiles[] = $file;
+        return $this;
+    }
+
+    public function extract()
+    {
+        $identifiers = [];
+        foreach ($this->stubFiles as $file) {
+            $content = file_get_contents($file);
+            $ast = $this->generateAst($content);
+            $identifiers = array_merge($identifiers, $this->extractIdentifiersFromAst($ast));
+        }
+
+        return $identifiers;
+    }
+
+    protected function generateAst($code)
+    {
+        $parser = (new ParserFactory)->create(ParserFactory::PREFER_PHP7);
+        return $parser->parse($code);
+    }
+
+    protected function extractIdentifiersFromAst($ast)
+    {
+        $globals = [];
+        $items = $ast;
+
+        while (count($items) > 0) {
+            $item = array_pop($items);
+
+            if (isset($item->stmts)) {
+                $items = array_merge($items, $item->stmts);
+            }
+
+            if (in_array(get_class($item), $this->extractStatements)) {
+                $globals[] = $item->name->name;
+            }
+        }
+
+        return $globals;
+    }
+}

--- a/src/Extractor/IdentifierExtractor.php
+++ b/src/Extractor/IdentifierExtractor.php
@@ -6,6 +6,13 @@ namespace Humbug\PhpScoper\Extractor;
 
 use InvalidArgumentException;
 use PhpParser\ParserFactory;
+use function array_merge;
+use function array_pop;
+use function count;
+use function file_exists;
+use function file_get_contents;
+use function get_class;
+use function in_array;
 
 class IdentifierExtractor
 {
@@ -20,7 +27,11 @@ class IdentifierExtractor
         ];
     }
 
-    public function addStub($file)
+    /**
+     * @param string $file
+     * @return self
+     */
+    public function addStub($file): self
     {
         if (! file_exists($file)) {
             throw new InvalidArgumentException("File not found: " . $file);
@@ -30,7 +41,10 @@ class IdentifierExtractor
         return $this;
     }
 
-    public function extract()
+    /**
+     * @return array
+     */
+    public function extract(): array
     {
         $identifiers = [];
         foreach ($this->stubFiles as $file) {
@@ -42,13 +56,21 @@ class IdentifierExtractor
         return $identifiers;
     }
 
-    protected function generateAst($code)
+    /**
+     * @param string $code
+     * @return array<Node\Stmt[]>|null
+     */
+    protected function generateAst($code): array
     {
         $parser = (new ParserFactory)->create(ParserFactory::PREFER_PHP7);
         return $parser->parse($code);
     }
 
-    protected function extractIdentifiersFromAst($ast)
+    /**
+     * @param array<Node\Stmt[]> $ast
+     * @return array<Node\Stmt[]>|null
+     */
+    protected function extractIdentifiersFromAst($ast): array
     {
         $globals = [];
         $items = $ast;

--- a/src/Patcher/RemovePrefixFromIdentifiersPatcher.php
+++ b/src/Patcher/RemovePrefixFromIdentifiersPatcher.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Humbug\PhpScoper\Patcher;
 
+use function str_replace;
+
 class RemovePrefixFromIdentifiersPatcher
 {
     public function __construct($identifiers)
@@ -11,7 +13,7 @@ class RemovePrefixFromIdentifiersPatcher
         $this->identifiers = $identifiers;
     }
 
-    public function __invoke($filePath, $prefix, $content)
+    public function __invoke($filePath, $prefix, $content): string
     {
         $prefixDoubleSlashed = str_replace('\\', '\\\\', $prefix);
         $quotes = ['\'', '"', '`'];

--- a/src/Patcher/RemovePrefixFromIdentifiersPatcher.php
+++ b/src/Patcher/RemovePrefixFromIdentifiersPatcher.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Humbug\PhpScoper\Patcher;
+
+class RemovePrefixFromIdentifiersPatcher
+{
+    public function __construct($identifiers)
+    {
+        $this->identifiers = $identifiers;
+    }
+
+    public function __invoke($filePath, $prefix, $content)
+    {
+        $prefixDoubleSlashed = str_replace('\\', '\\\\', $prefix);
+        $quotes = ['\'', '"', '`'];
+
+        foreach ($this->identifiers as $identifier) {
+            // "PREFIX\foo()", or "foo extends nativeClass"
+            $identifierDoubleSlashed = str_replace('\\', '\\\\', $identifier);
+            $content = str_replace($prefix . '\\' . $identifier, $identifier, $content);
+
+            // Replace in strings, e. g.  "if( function_exists('PREFIX\\foo') )"
+            foreach ($quotes as $quote) {
+                $content = str_replace(
+                    $quote . $prefixDoubleSlashed . '\\\\' . $identifierDoubleSlashed . $quote,
+                    $quote . $identifierDoubleSlashed . $quote,
+                    $content
+                );
+            }
+        }
+
+        return $content;
+    }
+}

--- a/tests/Extractor/IdentifierExtractorTest.php
+++ b/tests/Extractor/IdentifierExtractorTest.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Humbug\PhpScoper\Patcher;
+
+use Humbug\PhpScoper\Extractor\IdentifierExtractor;
+use InvalidArgumentException;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers \Humbug\PhpScoper\Extractor\IdentifierExtractor
+ */
+class IdentifierExtractorTest extends TestCase
+{
+    private const FIXTURE_PATH = __DIR__.'/../../fixtures/set033-identifier-extractor';
+
+    public function test_can_extract_identifiers(): void
+    {
+        $identifiers = (new IdentifierExtractor())
+                        ->addStub(self::FIXTURE_PATH . '/stubs.php')
+                        ->extract();
+
+        $this->assertIsArray($identifiers);
+        $this->assertEquals(
+            $identifiers,
+            [
+                'example_function',
+                'ExampleTrait',
+                'ExampleInterface',
+                'ExampleAbstractClass',
+                'ExampleFinalClass',
+                'ExampleClass',
+            ]
+        );
+    }
+
+    public function test_returns_empty_array_when_using_empty_stubs_file(): void
+    {
+        $identifiers = (new IdentifierExtractor())
+                        ->addStub(self::FIXTURE_PATH . '/empty-stubs.php')
+                        ->extract();
+
+        $this->assertEmpty($identifiers);
+    }
+
+    public function test_fails_with_invalid_stub_file(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        (new IdentifierExtractor())
+            ->addStub(self::FIXTURE_PATH . '/invalid-stub-file.php')
+            ->extract();
+    }
+}

--- a/tests/Patcher/RemovePrefixFromIdentifiersPatcherTest.php
+++ b/tests/Patcher/RemovePrefixFromIdentifiersPatcherTest.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Humbug\PhpScoper\Patcher;
+
+use Generator;
+use Humbug\PhpScoper\Extractor\IdentifierExtractor;
+use Humbug\PhpScoper\Patcher\RemovePrefixFromIdentifiersPatcher;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers \Humbug\PhpScoper\Patcher\RemovePrefixFromIdentifiersPatcher
+ */
+class RemovePrefixFromIdentifiersPatcherTest extends TestCase
+{
+    private const FIXTURE_PATH = __DIR__.'/../../fixtures/set034-remove-prefix-patcher';
+
+    /**
+     * @dataProvider provideFiles
+     */
+    public function test_patch_wordpress_files(string $filePath, string $contents, string $expected): void
+    {
+        $identifiers = (new IdentifierExtractor())
+                            ->addStub(self::FIXTURE_PATH . '/stubs.php')
+                            ->extract();
+
+        $actual = (new RemovePrefixFromIdentifiersPatcher($identifiers))->__invoke($filePath, 'Humbug', $contents);
+
+        $this->assertSame($expected, $actual);
+    }
+
+    public function provideFiles(): Generator
+    {
+        $files = [
+            'original/wordpress-missing-identifiers.php' => 'patched/wordpress-missing-identifiers.php',
+            'original/wordpress-complete-identifiers.php' => 'patched/wordpress-complete-identifiers.php'
+        ];
+
+        foreach ($files as $originalFile => $patchedFile) {
+            $originalContent = file_get_contents(self::FIXTURE_PATH.'/'.$originalFile);
+            $patchedContent = file_get_contents(self::FIXTURE_PATH.'/'.$patchedFile);
+
+            $originalContent = preg_replace('/\s*/', '', $originalContent);
+            $patchedContent = preg_replace('/\s*/', '', $patchedContent);
+
+            yield [$originalFile, $originalContent, $patchedContent];
+        }
+    }
+}

--- a/tests/Patcher/RemovePrefixFromIdentifiersPatcherTest.php
+++ b/tests/Patcher/RemovePrefixFromIdentifiersPatcherTest.php
@@ -8,6 +8,8 @@ use Generator;
 use Humbug\PhpScoper\Extractor\IdentifierExtractor;
 use Humbug\PhpScoper\Patcher\RemovePrefixFromIdentifiersPatcher;
 use PHPUnit\Framework\TestCase;
+use function file_get_contents;
+use function preg_replace;
 
 /**
  * @covers \Humbug\PhpScoper\Patcher\RemovePrefixFromIdentifiersPatcher


### PR DESCRIPTION
This PR includes the extractor and patcher from [pxlrbt/php-scoper-prefix-remover](https://github.com/pxlrbt/php-scoper-prefix-remover) into PHP-Scoper core to provide better WordPress plugin/theme support out of the box. See https://github.com/humbug/php-scoper/issues/303

Added an extractor to extract the WordPress identifiers from the files, a patcher to remove the prefix on the given identifiers, tests and documentation on how to use it.

Couldn't figure out how to expose the extractor/patcher to be used inside the `scoper.inc.php` file. Any feedback is welcome.