### PR TITLE
Revert "Add versions to hot-patched symbols" but keep fixed Lexer

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@ cs-check: $(CODE_SNIFFER)
 	$(PHPNOGC) $(CODE_SNIFFER)
 
 .PHONY: phpstan
-PHPSTAN=bin/phpstan
+PHPSTAN=vendor-bin/phpstan/vendor/bin/phpstan
 phpstan: ## Runs PHPStan
 phpstan: $(PHPSTAN)
 	$(PHPNOGC) $(PHPSTAN) analyze src --level max
@@ -432,6 +432,10 @@ vendor-bin/code-sniffer/vendor: vendor-bin/code-sniffer/composer.lock vendor/bam
 	composer bin code-sniffer install
 	touch -c $@
 
+vendor-bin/phpstan/vendor: vendor-bin/phpstan/composer.lock vendor/bamarni
+	composer bin phpstan install
+	touch -c $@
+
 fixtures/set005/vendor: fixtures/set005/composer.lock
 	composer --working-dir=fixtures/set005 install
 	touch -c $@
@@ -513,6 +517,9 @@ vendor-bin/covers-validator/composer.lock: vendor-bin/covers-validator/composer.
 vendor-bin/code-sniffer/composer.lock: vendor-bin/code-sniffer/composer.json
 	@echo code-sniffer composer.lock is not up to date
 
+vendor-bin/phpstan/composer.lock: vendor-bin/phpstan/composer.json
+	@echo phpstan composer.lock is not up to date
+
 fixtures/set005/composer.lock: fixtures/set005/composer.json
 	@echo fixtures/set005/composer.lock is not up to date.
 
@@ -577,7 +584,7 @@ $(CODE_SNIFFER_FIX): vendor-bin/code-sniffer/vendor
 	composer bin code-sniffer install
 	touch -c $@
 
-$(PHPSTAN): vendor/bamarni
+$(PHPSTAN): vendor-bin/phpstan/vendor
 	composer bin phpstan install
 	touch -c $@
 

--- a/src/Container.php
+++ b/src/Container.php
@@ -55,14 +55,7 @@ final class Container
     public function getParser(): Parser
     {
         if (null === $this->parser) {
-            $phpVersion = Lexer\Emulative::PHP_7_3;
-            if (PHP_VERSION_ID >= 80000) {
-                $phpVersion = Lexer\Emulative::PHP_8_0;
-            } elseif (PHP_VERSION_ID >= 70400) {
-                $phpVersion = Lexer\Emulative::PHP_7_4;
-            }
-
-            $this->parser = (new ParserFactory())->create(ParserFactory::ONLY_PHP7, new Lexer\Emulative(['phpVersion' => $phpVersion]));
+            $this->parser = (new ParserFactory())->create(ParserFactory::ONLY_PHP7, new Lexer());
         }
 
         return $this->parser;

--- a/src/Container.php
+++ b/src/Container.php
@@ -55,7 +55,14 @@ final class Container
     public function getParser(): Parser
     {
         if (null === $this->parser) {
-            $this->parser = (new ParserFactory())->create(ParserFactory::ONLY_PHP7, new Lexer());
+            $phpVersion = Lexer\Emulative::PHP_7_3;
+            if (PHP_VERSION_ID >= 80000) {
+                $phpVersion = Lexer\Emulative::PHP_8_0;
+            } elseif (PHP_VERSION_ID >= 70400) {
+                $phpVersion = Lexer\Emulative::PHP_7_4;
+            }
+
+            $this->parser = (new ParserFactory())->create(ParserFactory::ONLY_PHP7, new Lexer\Emulative(['phpVersion' => $phpVersion]));
         }
 
         return $this->parser;

--- a/src/Reflector.php
+++ b/src/Reflector.php
@@ -15,13 +15,10 @@ declare(strict_types=1);
 namespace Humbug\PhpScoper;
 
 use JetBrains\PHPStormStub\PhpStormStubsMap;
-use function array_diff;
 use function array_fill_keys;
-use function array_filter;
 use function array_keys;
 use function array_merge;
 use function strtolower;
-use const PHP_VERSION_ID;
 
 /**
  * @private
@@ -30,55 +27,55 @@ final class Reflector
 {
     private const MISSING_CLASSES = [
         // https://github.com/JetBrains/phpstorm-stubs/pull/594
-        'parallel\Channel' => 0,
-        'parallel\Channel\Error' => 0,
-        'parallel\Channel\Error\Closed' => 0,
-        'parallel\Channel\Error\Existence' => 0,
-        'parallel\Channel\Error\IllegalValue' => 0,
-        'parallel\Error' => 0,
-        'parallel\Events' => 0,
-        'parallel\Events\Error' => 0,
-        'parallel\Events\Error\Existence' => 0,
-        'parallel\Events\Error\Timeout' => 0,
-        'parallel\Events\Event' => 0,
-        'parallel\Events\Event\Type' => 0,
-        'parallel\Events\Input' => 0,
-        'parallel\Events\Input\Error' => 0,
-        'parallel\Events\Input\Error\Existence' => 0,
-        'parallel\Events\Input\Error\IllegalValue' => 0,
-        'parallel\Future' => 0,
-        'parallel\Future\Error' => 0,
-        'parallel\Future\Error\Cancelled' => 0,
-        'parallel\Future\Error\Foreign' => 0,
-        'parallel\Future\Error\Killed' => 0,
-        'parallel\Runtime' => 0,
-        'parallel\Runtime\Bootstrap' => 0,
-        'parallel\Runtime\Error' => 0,
-        'parallel\Runtime\Error\Bootstrap' => 0,
-        'parallel\Runtime\Error\Closed' => 0,
-        'parallel\Runtime\Error\IllegalFunction' => 0,
-        'parallel\Runtime\Error\IllegalInstruction' => 0,
-        'parallel\Runtime\Error\IllegalParameter' => 0,
-        'parallel\Runtime\Error\IllegalReturn' => 0,
+        'parallel\Channel',
+        'parallel\Channel\Error',
+        'parallel\Channel\Error\Closed',
+        'parallel\Channel\Error\Existence',
+        'parallel\Channel\Error\IllegalValue',
+        'parallel\Error',
+        'parallel\Events',
+        'parallel\Events\Error',
+        'parallel\Events\Error\Existence',
+        'parallel\Events\Error\Timeout',
+        'parallel\Events\Event',
+        'parallel\Events\Event\Type',
+        'parallel\Events\Input',
+        'parallel\Events\Input\Error',
+        'parallel\Events\Input\Error\Existence',
+        'parallel\Events\Input\Error\IllegalValue',
+        'parallel\Future',
+        'parallel\Future\Error',
+        'parallel\Future\Error\Cancelled',
+        'parallel\Future\Error\Foreign',
+        'parallel\Future\Error\Killed',
+        'parallel\Runtime',
+        'parallel\Runtime\Bootstrap',
+        'parallel\Runtime\Error',
+        'parallel\Runtime\Error\Bootstrap',
+        'parallel\Runtime\Error\Closed',
+        'parallel\Runtime\Error\IllegalFunction',
+        'parallel\Runtime\Error\IllegalInstruction',
+        'parallel\Runtime\Error\IllegalParameter',
+        'parallel\Runtime\Error\IllegalReturn',
     ];
 
     private const MISSING_FUNCTIONS = [];
 
     private const MISSING_CONSTANTS = [
-        'STDIN' => 0,
-        'STDOUT' => 0,
-        'STDERR' => 0,
+        'STDIN',
+        'STDOUT',
+        'STDERR',
         // Added in PHP 7.4
-        'T_BAD_CHARACTER' => 70400,
-        'T_FN' => 70400,
-        'T_COALESCE_EQUAL' => 70400,
+        'T_BAD_CHARACTER',
+        'T_FN',
+        'T_COALESCE_EQUAL',
         // Added in PHP 8.0
-        'T_NAME_QUALIFIED' => 80000,
-        'T_NAME_FULLY_QUALIFIED' => 80000,
-        'T_NAME_RELATIVE' => 80000,
-        'T_MATCH' => 80000,
-        'T_NULLSAFE_OBJECT_OPERATOR' => 80000,
-        'T_ATTRIBUTE' => 80000,
+        'T_NAME_QUALIFIED',
+        'T_NAME_FULLY_QUALIFIED',
+        'T_NAME_RELATIVE',
+        'T_MATCH',
+        'T_NULLSAFE_OBJECT_OPERATOR',
+        'T_ATTRIBUTE',
     ];
 
     private static $CLASSES;
@@ -90,7 +87,7 @@ final class Reflector
     /**
      * @param array<string,string>|null $symbols
      * @param array<string,string>      $source
-     * @param array<string, int>        $missingSymbols
+     * @param string[]                  $missingSymbols
      */
     private static function initSymbolList(?array &$symbols, array $source, array $missingSymbols): void
     {
@@ -98,22 +95,10 @@ final class Reflector
             return;
         }
 
-        $excludingSymbols = array_keys(
-            array_filter(
-                $missingSymbols,
-                static function ($version) {
-                    return PHP_VERSION_ID < $version;
-                }
-            )
-        );
-
         $symbols = array_fill_keys(
-            array_diff(
-                array_merge(
-                    array_keys($source),
-                    array_keys($missingSymbols)
-                ),
-                $excludingSymbols
+            array_merge(
+                array_keys($source),
+                $missingSymbols
             ),
             true
         );

--- a/tests/ReflectorTest.php
+++ b/tests/ReflectorTest.php
@@ -163,10 +163,5 @@ class ReflectorTest extends TestCase
             'FTP_ASCII',
             true,
         ];
-
-        yield 'T_MATCH constant' => [
-            'T_MATCH',
-            PHP_VERSION_ID >= 80000,
-        ];
     }
 }


### PR DESCRIPTION
I was wrong with the Reflector approach. It will prevent us scoping the php-parser.

It is related to https://github.com/box-project/box/pull/499