### PR TITLE
Use native preg_match functions

### DIFF
--- a/src/Console/Command/AddPrefixCommand.php
+++ b/src/Console/Command/AddPrefixCommand.php
@@ -39,6 +39,7 @@ use function file_exists;
 use function Humbug\PhpScoper\get_common_path;
 use function is_dir;
 use function is_writable;
+use function preg_match as native_preg_match;
 use function random_bytes;
 use function Safe\file_get_contents;
 use function Safe\getcwd;
@@ -211,7 +212,7 @@ final class AddPrefixCommand extends BaseCommand
             $outputFilePath = $output.str_replace($commonPath, '', $inputFilePath);
 
             $pattern = '~((?:.*)\\'.DIRECTORY_SEPARATOR.'vendor)\\'.DIRECTORY_SEPARATOR.'.*~';
-            if (preg_match($pattern, $outputFilePath, $matches)) {
+            if (native_preg_match($pattern, $outputFilePath, $matches)) {
                 $vendorDirs[$matches[1]] = true;
             }
 
@@ -290,7 +291,7 @@ final class AddPrefixCommand extends BaseCommand
     {
         $prefix = $input->getOption(self::PREFIX_OPT);
 
-        if (null !== $prefix && 1 === preg_match('/(?<prefix>.*?)\\\\*$/', $prefix, $matches)) {
+        if (null !== $prefix && 1 === native_preg_match('/(?<prefix>.*?)\\\\*$/', $prefix, $matches)) {
             $prefix = $matches['prefix'];
         }
 

--- a/src/PhpParser/NodeVisitor/StringScalarPrefixer.php
+++ b/src/PhpParser/NodeVisitor/StringScalarPrefixer.php
@@ -42,6 +42,7 @@ use function implode;
 use function in_array;
 use function is_string;
 use function ltrim;
+use function preg_match as native_preg_match;
 use function Safe\preg_match;
 use function strpos;
 use function strtolower;
@@ -105,7 +106,7 @@ final class StringScalarPrefixer extends NodeVisitorAbstract
     private function prefixStringScalar(String_ $string): String_
     {
         if (false === (ParentNodeAppender::hasParent($string) && is_string($string->value))
-            || 1 !== preg_match('/^((\\\\)?[\p{L}_\d]+)$|((\\\\)?(?:[\p{L}_\d]+\\\\+)+[\p{L}_\d]+)$/u', $string->value)
+            || 1 !== native_preg_match('/^((\\\\)?[\p{L}_\d]+)$|((\\\\)?(?:[\p{L}_\d]+\\\\+)+[\p{L}_\d]+)$/u', $string->value)
         ) {
             return $string;
         }

--- a/src/Scoper/Composer/InstalledPackagesScoper.php
+++ b/src/Scoper/Composer/InstalledPackagesScoper.php
@@ -18,6 +18,7 @@ use Humbug\PhpScoper\Scoper;
 use Humbug\PhpScoper\Whitelist;
 use function Humbug\PhpScoper\json_decode;
 use function Humbug\PhpScoper\json_encode;
+use function preg_match as native_preg_match;
 use function Safe\preg_match;
 use const JSON_PRETTY_PRINT;
 
@@ -39,7 +40,7 @@ final class InstalledPackagesScoper implements Scoper
      */
     public function scope(string $filePath, string $contents, string $prefix, array $patchers, Whitelist $whitelist): string
     {
-        if (1 !== preg_match(self::$filePattern, $filePath)) {
+        if (1 !== native_preg_match(self::$filePattern, $filePath)) {
             return $this->decoratedScoper->scope($filePath, $contents, $prefix, $patchers, $whitelist);
         }
 

--- a/src/Scoper/Composer/JsonFileScoper.php
+++ b/src/Scoper/Composer/JsonFileScoper.php
@@ -21,6 +21,7 @@ use stdClass;
 use function gettype;
 use function Humbug\PhpScoper\json_decode;
 use function Humbug\PhpScoper\json_encode;
+use function preg_match as native_preg_match;
 use function Safe\preg_match;
 use function Safe\sprintf;
 use const JSON_PRETTY_PRINT;
@@ -41,7 +42,7 @@ final class JsonFileScoper implements Scoper
      */
     public function scope(string $filePath, string $contents, string $prefix, array $patchers, Whitelist $whitelist): string
     {
-        if (1 !== preg_match('/composer\.json$/', $filePath)) {
+        if (1 !== native_preg_match('/composer\.json$/', $filePath)) {
             return $this->decoratedScoper->scope($filePath, $contents, $prefix, $patchers, $whitelist);
         }
 

--- a/src/Scoper/PhpScoper.php
+++ b/src/Scoper/PhpScoper.php
@@ -23,6 +23,7 @@ use PhpParser\PrettyPrinter\Standard;
 use function basename;
 use function func_get_args;
 use function ltrim;
+use function preg_match as native_preg_match;
 use function Safe\preg_match;
 
 final class PhpScoper implements Scoper
@@ -72,18 +73,18 @@ final class PhpScoper implements Scoper
 
     private function isPhpFile(string $filePath, string $contents): bool
     {
-        if (1 === preg_match(self::FILE_PATH_PATTERN, $filePath)) {
+        if (1 === native_preg_match(self::FILE_PATH_PATTERN, $filePath)) {
             return true;
         }
 
-        if (1 === preg_match(self::NOT_FILE_BINARY, basename($filePath))) {
+        if (1 === native_preg_match(self::NOT_FILE_BINARY, basename($filePath))) {
             return false;
         }
 
-        if (1 === preg_match(self::PHP_TAG, ltrim($contents))) {
+        if (1 === native_preg_match(self::PHP_TAG, ltrim($contents))) {
             return true;
         }
 
-        return 1 === preg_match(self::PHP_BINARY, $contents);
+        return 1 === native_preg_match(self::PHP_BINARY, $contents);
     }
 }

--- a/src/Scoper/Symfony/XmlScoper.php
+++ b/src/Scoper/Symfony/XmlScoper.php
@@ -19,6 +19,8 @@ use Humbug\PhpScoper\Whitelist;
 use PhpParser\Node\Name\FullyQualified;
 use function array_filter;
 use function func_get_args;
+use function preg_match as native_preg_match;
+use function preg_match_all as native_preg_match_all;
 use function Safe\preg_match;
 use function Safe\preg_match_all;
 use function Safe\substr;
@@ -45,7 +47,7 @@ final class XmlScoper implements Scoper
      */
     public function scope(string $filePath, string $contents, string $prefix, array $patchers, Whitelist $whitelist): string
     {
-        if (1 !== preg_match(self::FILE_PATH_PATTERN, $filePath)) {
+        if (1 !== native_preg_match(self::FILE_PATH_PATTERN, $filePath)) {
             return $this->decoratedScoper->scope(...func_get_args());
         }
 
@@ -57,7 +59,7 @@ final class XmlScoper implements Scoper
 
     private function scopeClasses(string $contents, string $prefix, Whitelist $whitelist): string
     {
-        if (1 > preg_match_all('/(?:(?<singleClass>(?:[\p{L}_\d]+(?<singleSeparator>\\\\(?:\\\\)?))):)|(?<class>(?:[\p{L}_\d]+(?<separator>\\\\(?:\\\\)?)+)+[\p{L}_\d]+)/u', $contents, $matches)) {
+        if (1 > native_preg_match_all('/(?:(?<singleClass>(?:[\p{L}_\d]+(?<singleSeparator>\\\\(?:\\\\)?))):)|(?<class>(?:[\p{L}_\d]+(?<separator>\\\\(?:\\\\)?)+)+[\p{L}_\d]+)/u', $contents, $matches)) {
             return $contents;
         }
 
@@ -82,7 +84,7 @@ final class XmlScoper implements Scoper
 
     private function scopeNamespaces(string $contents, string $prefix, Whitelist $whitelist): string
     {
-        if (1 > preg_match_all('/<prototype.*\snamespace="(?:(?<namespace>(?:[^\\\\]+(?<separator>\\\\(?:\\\\)?))))"/', $contents, $matches)) {
+        if (1 > native_preg_match_all('/<prototype.*\snamespace="(?:(?<namespace>(?:[^\\\\]+(?<separator>\\\\(?:\\\\)?))))"/', $contents, $matches)) {
             return $contents;
         }
 

--- a/src/Scoper/Symfony/YamlScoper.php
+++ b/src/Scoper/Symfony/YamlScoper.php
@@ -19,6 +19,8 @@ use Humbug\PhpScoper\Whitelist;
 use PhpParser\Node\Name\FullyQualified;
 use function array_filter;
 use function func_get_args;
+use function preg_match as native_preg_match;
+use function preg_match_all as native_preg_match_all;
 use function Safe\preg_match;
 use function Safe\preg_match_all;
 use function Safe\substr;
@@ -45,11 +47,11 @@ final class YamlScoper implements Scoper
      */
     public function scope(string $filePath, string $contents, string $prefix, array $patchers, Whitelist $whitelist): string
     {
-        if (1 !== preg_match(self::FILE_PATH_PATTERN, $filePath)) {
+        if (1 !== native_preg_match(self::FILE_PATH_PATTERN, $filePath)) {
             return $this->decoratedScoper->scope(...func_get_args());
         }
 
-        if (1 > preg_match_all('/(?:(?<singleClass>(?:[\p{L}_\d]+(?<singleSeparator>\\\\(?:\\\\)?))):)|(?<class>(?:[\p{L}_\d]+(?<separator>\\\\(?:\\\\)?)+)+[\p{L}_\d]+)/u', $contents, $matches)) {
+        if (1 > native_preg_match_all('/(?:(?<singleClass>(?:[\p{L}_\d]+(?<singleSeparator>\\\\(?:\\\\)?))):)|(?<class>(?:[\p{L}_\d]+(?<separator>\\\\(?:\\\\)?)+)+[\p{L}_\d]+)/u', $contents, $matches)) {
             return $contents;
         }
 

--- a/src/Whitelist.php
+++ b/src/Whitelist.php
@@ -26,6 +26,7 @@ use function array_values;
 use function count;
 use function explode;
 use function implode;
+use function preg_match as native_preg_match;
 use function Safe\array_flip;
 use function Safe\preg_match;
 use function Safe\sprintf;
@@ -112,7 +113,7 @@ final class Whitelist implements Countable
 
     private static function assertValidPattern(string $element): void
     {
-        if (1 !== preg_match('/^(([\p{L}_]+\\\\)+)?[\p{L}_]*\*$/u', $element)) {
+        if (1 !== native_preg_match('/^(([\p{L}_]+\\\\)+)?[\p{L}_]*\*$/u', $element)) {
             throw new InvalidArgumentException(sprintf('Invalid whitelist pattern "%s".', $element));
         }
     }
@@ -267,7 +268,7 @@ final class Whitelist implements Countable
         foreach ($this->patterns as $pattern) {
             $pattern = false === $constant ? $pattern.'i' : $pattern;
 
-            if (1 === preg_match($pattern, $name)) {
+            if (1 === native_preg_match($pattern, $name)) {
                 return true;
             }
         }


### PR DESCRIPTION
It can be that the string being matched is not a valid UTF-8 string in which case with the safe extension an exception will be thrown since we want to match it against a regex with unicode support.

In the case of PHP-Scoper though, I am not entirely sure if it's relevant: it can be that PHP-Scoper is scoping non-UTF8 files in general. I am however not sure if it's working at all and rather than introducing more code that is supposed to help this scenario, I would prefer a proper support to be introduced where the use case is clear and proper tests can be added