### PR TITLE
Introduce ScoperFactory

### DIFF
--- a/src/Console/Application.php
+++ b/src/Console/Application.php
@@ -24,6 +24,9 @@ use function Safe\sprintf;
 use function strpos;
 use function trim;
 
+/**
+ * @private
+ */
 final class Application implements FidryApplication
 {
     private const LOGO = <<<'ASCII'

--- a/src/Console/Application.php
+++ b/src/Console/Application.php
@@ -105,7 +105,7 @@ ASCII;
         return [
             new AddPrefixCommand(
                 $this->container->getFileSystem(),
-                $this->container->getScoper(),
+                $this->container->getScoperFactory(),
                 $this,
                 $this->container->getConfigurationFactory(),
             ),

--- a/src/Console/Command/AddPrefixCommand.php
+++ b/src/Console/Command/AddPrefixCommand.php
@@ -37,6 +37,9 @@ use function Safe\getcwd;
 use function Safe\sprintf;
 use const DIRECTORY_SEPARATOR;
 
+/**
+ * @private
+ */
 final class AddPrefixCommand implements Command, CommandAware
 {
     use CommandAwareness;

--- a/src/Console/Command/AddPrefixCommand.php
+++ b/src/Console/Command/AddPrefixCommand.php
@@ -25,7 +25,7 @@ use Humbug\PhpScoper\Configuration;
 use Humbug\PhpScoper\ConfigurationFactory;
 use Humbug\PhpScoper\Console\ConfigLoader;
 use Humbug\PhpScoper\Console\ConsoleScoper;
-use Humbug\PhpScoper\Scoper;
+use Humbug\PhpScoper\ScoperFactory;
 use Symfony\Component\Console\Exception\RuntimeException;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputOption;
@@ -51,19 +51,19 @@ final class AddPrefixCommand implements Command, CommandAware
     private const NO_CONFIG_OPT = 'no-config';
 
     private Filesystem $fileSystem;
-    private Scoper $scoper;
+    private ScoperFactory $scoperFactory;
     private bool $init = false;
     private Application $application;
     private ConfigurationFactory $configFactory;
 
     public function __construct(
         Filesystem $fileSystem,
-        Scoper $scoper,
+        ScoperFactory $scoperFactory,
         Application $application,
         ConfigurationFactory $configFactory
     ) {
         $this->fileSystem = $fileSystem;
-        $this->scoper = $scoper;
+        $this->scoperFactory = $scoperFactory;
         $this->application = $application;
         $this->configFactory = $configFactory;
     }
@@ -236,7 +236,7 @@ final class AddPrefixCommand implements Command, CommandAware
         return new ConsoleScoper(
             $this->fileSystem,
             $this->application,
-            $this->scoper,
+            $this->scoperFactory,
         );
     }
 }

--- a/src/Console/Command/ChangeableDirectory.php
+++ b/src/Console/Command/ChangeableDirectory.php
@@ -23,6 +23,9 @@ use function file_exists;
 use function Safe\getcwd;
 use function Safe\sprintf;
 
+/**
+ * @private
+ */
 final class ChangeableDirectory
 {
     private const WORKING_DIR_OPT = 'working-dir';

--- a/src/Console/Command/InitCommand.php
+++ b/src/Console/Command/InitCommand.php
@@ -26,6 +26,9 @@ use function Safe\getcwd;
 use function Safe\sprintf;
 use const DIRECTORY_SEPARATOR;
 
+/**
+ * @private
+ */
 final class InitCommand implements Command
 {
     private const CONFIG_FILE_OPT = 'config';

--- a/src/Console/ConsoleScoper.php
+++ b/src/Console/ConsoleScoper.php
@@ -9,6 +9,7 @@ use Fidry\Console\IO;
 use Humbug\PhpScoper\Autoload\ScoperAutoloadGenerator;
 use Humbug\PhpScoper\Configuration;
 use Humbug\PhpScoper\Scoper;
+use Humbug\PhpScoper\ScoperFactory;
 use Humbug\PhpScoper\Throwable\Exception\ParsingException;
 use Symfony\Component\Filesystem\Filesystem;
 use Throwable;
@@ -34,17 +35,17 @@ final class ConsoleScoper
 
     private Filesystem $fileSystem;
     private Application $application;
-    private Scoper $scoper;
+    private ScoperFactory $scoperFactory;
 
     public function __construct(
         Filesystem $fileSystem,
         Application $application,
-        Scoper $scoper
+        ScoperFactory $scoperFactory
     )
     {
         $this->fileSystem = $fileSystem;
         $this->application = $application;
-        $this->scoper = $scoper;
+        $this->scoperFactory = $scoperFactory;
     }
 
     public function scope(
@@ -96,8 +97,11 @@ final class ConsoleScoper
 
         $logger->outputFileCount(count($files));
 
+        $scoper = $this->scoperFactory->createScoper(/* $config */);
+
         foreach ($files as [$inputFilePath, $inputContents, $outputFilePath]) {
             $this->scopeFile(
+                $scoper,
                 $inputFilePath,
                 $inputContents,
                 $outputFilePath,
@@ -182,6 +186,7 @@ final class ConsoleScoper
     }
 
     private function scopeFile(
+        Scoper $scoper,
         string $inputFilePath,
         string $inputContents,
         string $outputFilePath,
@@ -190,7 +195,7 @@ final class ConsoleScoper
         ScoperLogger $logger
     ): void {
         try {
-            $scoppedContent = $this->scoper->scope(
+            $scoppedContent = $scoper->scope(
                 $inputFilePath,
                 $inputContents,
                 $config->getPrefix(),

--- a/src/Container.php
+++ b/src/Container.php
@@ -14,13 +14,6 @@ declare(strict_types=1);
 
 namespace Humbug\PhpScoper;
 
-use Humbug\PhpScoper\PhpParser\TraverserFactory;
-use Humbug\PhpScoper\Scoper\Composer\InstalledPackagesScoper;
-use Humbug\PhpScoper\Scoper\Composer\JsonFileScoper;
-use Humbug\PhpScoper\Scoper\NullScoper;
-use Humbug\PhpScoper\Scoper\PatchScoper;
-use Humbug\PhpScoper\Scoper\PhpScoper;
-use Humbug\PhpScoper\Scoper\SymfonyScoper;
 use PhpParser\Lexer;
 use PhpParser\Parser;
 use PhpParser\ParserFactory;
@@ -31,7 +24,7 @@ final class Container
     private Filesystem $filesystem;
     private ConfigurationFactory $configFactory;
     private Parser $parser;
-    private Scoper $scoper;
+    private ScoperFactory $scoperFactory;
 
     public function getFileSystem(): Filesystem
     {
@@ -53,25 +46,13 @@ final class Container
         return $this->configFactory;
     }
 
-    public function getScoper(): Scoper
+    public function getScoperFactory(): ScoperFactory
     {
-        if (!isset($this->scoper)) {
-            $this->scoper = new PatchScoper(
-                new PhpScoper(
-                    $this->getParser(),
-                    new JsonFileScoper(
-                        new InstalledPackagesScoper(
-                            new SymfonyScoper(
-                                new NullScoper()
-                            )
-                        )
-                    ),
-                    new TraverserFactory(new Reflector())
-                )
-            );
+        if (!isset($this->scoperFactory)) {
+            $this->scoperFactory = new ScoperFactory($this->getParser());
         }
 
-        return $this->scoper;
+        return $this->scoperFactory;
     }
 
     public function getParser(): Parser

--- a/src/ScoperFactory.php
+++ b/src/ScoperFactory.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the humbug/php-scoper package.
+ *
+ * Copyright (c) 2017 Théo FIDRY <theo.fidry@gmail.com>,
+ *                    Pádraic Brady <padraic.brady@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Humbug\PhpScoper;
+
+use Humbug\PhpScoper\PhpParser\TraverserFactory;
+use Humbug\PhpScoper\Scoper\Composer\InstalledPackagesScoper;
+use Humbug\PhpScoper\Scoper\Composer\JsonFileScoper;
+use Humbug\PhpScoper\Scoper\NullScoper;
+use Humbug\PhpScoper\Scoper\PatchScoper;
+use Humbug\PhpScoper\Scoper\PhpScoper;
+use Humbug\PhpScoper\Scoper\SymfonyScoper;
+use PhpParser\Parser;
+
+final class ScoperFactory
+{
+    private Parser $parser;
+
+    public function __construct(Parser $parser)
+    {
+        $this->parser = $parser;
+    }
+
+    public function createScoper(/* Configuration $configuration */): Scoper
+    {
+        return new PatchScoper(
+            new PhpScoper(
+                $this->parser,
+                new JsonFileScoper(
+                    new InstalledPackagesScoper(
+                        new SymfonyScoper(
+                            new NullScoper()
+                        )
+                    )
+                ),
+                new TraverserFactory(new Reflector(/* Configuration $configuration */))
+            )
+        );
+    }
+}

--- a/src/ScoperFactory.php
+++ b/src/ScoperFactory.php
@@ -23,7 +23,10 @@ use Humbug\PhpScoper\Scoper\PhpScoper;
 use Humbug\PhpScoper\Scoper\SymfonyScoper;
 use PhpParser\Parser;
 
-final class ScoperFactory
+/**
+ * @final
+ */
+class ScoperFactory
 {
     private Parser $parser;
 

--- a/tests/Console/Command/AddPrefixCommandTest.php
+++ b/tests/Console/Command/AddPrefixCommandTest.php
@@ -22,9 +22,12 @@ use Humbug\PhpScoper\Console\ConsoleScoper;
 use Humbug\PhpScoper\Container;
 use Humbug\PhpScoper\FileSystemTestCase;
 use Humbug\PhpScoper\Patcher\SymfonyPatcher;
+use Humbug\PhpScoper\PhpParser\FakeParser;
 use Humbug\PhpScoper\Scoper;
+use Humbug\PhpScoper\ScoperFactory;
 use Humbug\PhpScoper\Whitelist;
 use InvalidArgumentException;
+use PhpParser\Parser;
 use Prophecy\Argument;
 use Prophecy\PhpUnit\ProphecyTrait;
 use Prophecy\Prophecy\ObjectProphecy;
@@ -62,7 +65,7 @@ class AddPrefixCommandTest extends FileSystemTestCase
     private ObjectProphecy $fileSystemProphecy;
 
     /**
-     * @var ObjectProphecy<ConsoleScoper>
+     * @var ObjectProphecy<Scoper>
      */
     private ObjectProphecy $scoperProphecy;
 
@@ -823,7 +826,7 @@ EOF;
         /** @var Filesystem $fileSystem */
         $fileSystem = $this->fileSystemProphecy->reveal();
 
-        /** @var ConsoleScoper $scoper */
+        /** @var Scoper $scoper */
         $scoper = $this->scoperProphecy->reveal();
 
         $application = new SymfonyApplication(
@@ -839,7 +842,7 @@ EOF;
             new SymfonyCommand(
                 new AddPrefixCommand(
                     $fileSystem,
-                    $scoper,
+                    new DummyScoperFactory(new FakeParser(), $scoper),
                     $innerApp,
                     new ConfigurationFactory($fileSystem),
                 ),

--- a/tests/Console/Command/DummyScoperFactory.php
+++ b/tests/Console/Command/DummyScoperFactory.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Humbug\PhpScoper\Console\Command;
+
+use Humbug\PhpScoper\Scoper;
+use Humbug\PhpScoper\ScoperFactory;
+use PhpParser\Parser;
+
+final class DummyScoperFactory extends ScoperFactory
+{
+    private Scoper $scoper;
+
+    public function __construct(Parser $parser, Scoper $scoper)
+    {
+        parent::__construct($parser);
+
+        $this->scoper = $scoper;
+    }
+
+    public function createScoper(): Scoper
+    {
+        return $this->scoper;
+    }
+}


### PR DESCRIPTION
Related to #303, this will allow to enrich the configuration and forward options from the configuration to the scoper itself, e.g. to inject the native symbols.

**BC Breaks**:
- `Container::getScoper()` has been replaced by `Container::getScoperFactory()`