### PR TITLE
Extract configuration keys into a dedicated enum

### DIFF
--- a/src/ConfigurationFactory.php
+++ b/src/ConfigurationFactory.php
@@ -52,29 +52,6 @@ use const SORT_STRING;
 
 final class ConfigurationFactory
 {
-    private const PREFIX_KEYWORD = 'prefix';
-    private const WHITELISTED_FILES_KEYWORD = 'files-whitelist';
-    private const FINDER_KEYWORD = 'finders';
-    private const PATCHERS_KEYWORD = 'patchers';
-    private const WHITELIST_KEYWORD = 'whitelist';
-    private const WHITELIST_GLOBAL_CONSTANTS_KEYWORD = 'whitelist-global-constants';
-    private const WHITELIST_GLOBAL_CLASSES_KEYWORD = 'whitelist-global-classes';
-    private const WHITELIST_GLOBAL_FUNCTIONS_KEYWORD = 'whitelist-global-functions';
-    private const CLASSES_INTERNAL_SYMBOLS_KEYWORD = 'excluded-classes';
-    private const FUNCTIONS_INTERNAL_SYMBOLS_KEYWORD = 'excluded-functions';
-    private const CONSTANTS_INTERNAL_SYMBOLS_KEYWORD = 'excluded-constants';
-
-    private const KEYWORDS = [
-        self::PREFIX_KEYWORD,
-        self::WHITELISTED_FILES_KEYWORD,
-        self::FINDER_KEYWORD,
-        self::PATCHERS_KEYWORD,
-        self::WHITELIST_KEYWORD,
-        self::WHITELIST_GLOBAL_CONSTANTS_KEYWORD,
-        self::WHITELIST_GLOBAL_CLASSES_KEYWORD,
-        self::WHITELIST_GLOBAL_FUNCTIONS_KEYWORD,
-    ];
-
     private Filesystem $fileSystem;
 
     public function __construct(Filesystem $fileSystem)
@@ -157,7 +134,7 @@ final class ConfigurationFactory
 
     public function createWithPrefix(Configuration $config, string $prefix): Configuration
     {
-        $prefix = self::retrievePrefix([self::PREFIX_KEYWORD => $prefix]);
+        $prefix = self::retrievePrefix([ConfigurationKeys::PREFIX_KEYWORD => $prefix]);
 
         return new Configuration(
             $config->getPath(),
@@ -229,7 +206,7 @@ final class ConfigurationFactory
 
     private static function validateConfigKey(string $key): void
     {
-        if (in_array($key, self::KEYWORDS, true)) {
+        if (in_array($key, ConfigurationKeys::KEYWORDS, true)) {
             return;
         }
 
@@ -243,7 +220,7 @@ final class ConfigurationFactory
 
     private static function retrievePrefix(array $config): string
     {
-        $prefix = trim((string) ($config[self::PREFIX_KEYWORD] ?? ''));
+        $prefix = trim((string) ($config[ConfigurationKeys::PREFIX_KEYWORD] ?? ''));
 
         if ('' === $prefix) {
             return self::generateRandomPrefix();
@@ -257,11 +234,11 @@ final class ConfigurationFactory
      */
     private static function retrievePatchers(array $config): array
     {
-        if (!array_key_exists(self::PATCHERS_KEYWORD, $config)) {
+        if (!array_key_exists(ConfigurationKeys::PATCHERS_KEYWORD, $config)) {
             return [];
         }
 
-        $patchers = $config[self::PATCHERS_KEYWORD];
+        $patchers = $config[ConfigurationKeys::PATCHERS_KEYWORD];
 
         if (!is_array($patchers)) {
             throw new InvalidArgumentException(
@@ -290,10 +267,10 @@ final class ConfigurationFactory
 
     private static function retrieveWhitelist(array $config): Whitelist
     {
-        if (!array_key_exists(self::WHITELIST_KEYWORD, $config)) {
+        if (!array_key_exists(ConfigurationKeys::WHITELIST_KEYWORD, $config)) {
             $whitelist = [];
         } else {
-            $whitelist = $config[self::WHITELIST_KEYWORD];
+            $whitelist = $config[ConfigurationKeys::WHITELIST_KEYWORD];
 
             if (!is_array($whitelist)) {
                 throw new InvalidArgumentException(
@@ -318,48 +295,48 @@ final class ConfigurationFactory
             }
         }
 
-        if (!array_key_exists(self::WHITELIST_GLOBAL_CONSTANTS_KEYWORD, $config)) {
+        if (!array_key_exists(ConfigurationKeys::WHITELIST_GLOBAL_CONSTANTS_KEYWORD, $config)) {
             $whitelistGlobalConstants = true;
         } else {
-            $whitelistGlobalConstants = $config[self::WHITELIST_GLOBAL_CONSTANTS_KEYWORD];
+            $whitelistGlobalConstants = $config[ConfigurationKeys::WHITELIST_GLOBAL_CONSTANTS_KEYWORD];
 
             if (!is_bool($whitelistGlobalConstants)) {
                 throw new InvalidArgumentException(
                     sprintf(
                         'Expected %s to be a boolean, found "%s" instead.',
-                        self::WHITELIST_GLOBAL_CONSTANTS_KEYWORD,
+                        ConfigurationKeys::WHITELIST_GLOBAL_CONSTANTS_KEYWORD,
                         gettype($whitelistGlobalConstants),
                     ),
                 );
             }
         }
 
-        if (!array_key_exists(self::WHITELIST_GLOBAL_CLASSES_KEYWORD, $config)) {
+        if (!array_key_exists(ConfigurationKeys::WHITELIST_GLOBAL_CLASSES_KEYWORD, $config)) {
             $whitelistGlobalClasses = true;
         } else {
-            $whitelistGlobalClasses = $config[self::WHITELIST_GLOBAL_CLASSES_KEYWORD];
+            $whitelistGlobalClasses = $config[ConfigurationKeys::WHITELIST_GLOBAL_CLASSES_KEYWORD];
 
             if (!is_bool($whitelistGlobalClasses)) {
                 throw new InvalidArgumentException(
                     sprintf(
                         'Expected %s to be a boolean, found "%s" instead.',
-                        self::WHITELIST_GLOBAL_CLASSES_KEYWORD,
+                        ConfigurationKeys::WHITELIST_GLOBAL_CLASSES_KEYWORD,
                         gettype($whitelistGlobalClasses),
                     ),
                 );
             }
         }
 
-        if (!array_key_exists(self::WHITELIST_GLOBAL_FUNCTIONS_KEYWORD, $config)) {
+        if (!array_key_exists(ConfigurationKeys::WHITELIST_GLOBAL_FUNCTIONS_KEYWORD, $config)) {
             $whitelistGlobalFunctions = true;
         } else {
-            $whitelistGlobalFunctions = $config[self::WHITELIST_GLOBAL_FUNCTIONS_KEYWORD];
+            $whitelistGlobalFunctions = $config[ConfigurationKeys::WHITELIST_GLOBAL_FUNCTIONS_KEYWORD];
 
             if (!is_bool($whitelistGlobalFunctions)) {
                 throw new InvalidArgumentException(
                     sprintf(
                         'Expected %s to be a boolean, found "%s" instead.',
-                        self::WHITELIST_GLOBAL_FUNCTIONS_KEYWORD,
+                        ConfigurationKeys::WHITELIST_GLOBAL_FUNCTIONS_KEYWORD,
                         gettype($whitelistGlobalFunctions),
                     ),
                 );
@@ -379,11 +356,11 @@ final class ConfigurationFactory
      */
     private function retrieveWhitelistedFiles(string $dirPath, array $config): array
     {
-        if (!array_key_exists(self::WHITELISTED_FILES_KEYWORD, $config)) {
+        if (!array_key_exists(ConfigurationKeys::WHITELISTED_FILES_KEYWORD, $config)) {
             return [];
         }
 
-        $whitelistedFiles = $config[self::WHITELISTED_FILES_KEYWORD];
+        $whitelistedFiles = $config[ConfigurationKeys::WHITELISTED_FILES_KEYWORD];
 
         if (!is_array($whitelistedFiles)) {
             throw new InvalidArgumentException(
@@ -419,11 +396,11 @@ final class ConfigurationFactory
      */
     private static function retrieveFinders(array $config): array
     {
-        if (!array_key_exists(self::FINDER_KEYWORD, $config)) {
+        if (!array_key_exists(ConfigurationKeys::FINDER_KEYWORD, $config)) {
             return [];
         }
 
-        $finders = $config[self::FINDER_KEYWORD];
+        $finders = $config[ConfigurationKeys::FINDER_KEYWORD];
 
         if (!is_array($finders)) {
             throw new InvalidArgumentException(
@@ -540,9 +517,9 @@ final class ConfigurationFactory
     private static function retrieveAllInternalSymbols(array $config): array
     {
         return [
-            self::retrieveInternalSymbols($config, self::CLASSES_INTERNAL_SYMBOLS_KEYWORD),
-            self::retrieveInternalSymbols($config, self::FUNCTIONS_INTERNAL_SYMBOLS_KEYWORD),
-            self::retrieveInternalSymbols($config, self::CONSTANTS_INTERNAL_SYMBOLS_KEYWORD),
+            self::retrieveInternalSymbols($config, ConfigurationKeys::CLASSES_INTERNAL_SYMBOLS_KEYWORD),
+            self::retrieveInternalSymbols($config, ConfigurationKeys::FUNCTIONS_INTERNAL_SYMBOLS_KEYWORD),
+            self::retrieveInternalSymbols($config, ConfigurationKeys::CONSTANTS_INTERNAL_SYMBOLS_KEYWORD),
         ];
     }
 

--- a/src/ConfigurationKeys.php
+++ b/src/ConfigurationKeys.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Humbug\PhpScoper;
+
+// TODO: make it an enum once in PHP 8.1
+final class ConfigurationKeys
+{
+    public const PREFIX_KEYWORD = 'prefix';
+    public const WHITELISTED_FILES_KEYWORD = 'files-whitelist';
+    public const FINDER_KEYWORD = 'finders';
+    public const PATCHERS_KEYWORD = 'patchers';
+    public const WHITELIST_KEYWORD = 'whitelist';
+    public const WHITELIST_GLOBAL_CONSTANTS_KEYWORD = 'whitelist-global-constants';
+    public const WHITELIST_GLOBAL_CLASSES_KEYWORD = 'whitelist-global-classes';
+    public const WHITELIST_GLOBAL_FUNCTIONS_KEYWORD = 'whitelist-global-functions';
+    public const CLASSES_INTERNAL_SYMBOLS_KEYWORD = 'excluded-classes';
+    public const FUNCTIONS_INTERNAL_SYMBOLS_KEYWORD = 'excluded-functions';
+    public const CONSTANTS_INTERNAL_SYMBOLS_KEYWORD = 'excluded-constants';
+
+    public const KEYWORDS = [
+        self::PREFIX_KEYWORD,
+        self::WHITELISTED_FILES_KEYWORD,
+        self::FINDER_KEYWORD,
+        self::PATCHERS_KEYWORD,
+        self::WHITELIST_KEYWORD,
+        self::WHITELIST_GLOBAL_CONSTANTS_KEYWORD,
+        self::WHITELIST_GLOBAL_CLASSES_KEYWORD,
+        self::WHITELIST_GLOBAL_FUNCTIONS_KEYWORD,
+        self::CLASSES_INTERNAL_SYMBOLS_KEYWORD,
+        self::FUNCTIONS_INTERNAL_SYMBOLS_KEYWORD,
+        self::CONSTANTS_INTERNAL_SYMBOLS_KEYWORD,
+    ];
+
+    private function __construct() {}
+}

--- a/src/scoper.inc.php.tpl
+++ b/src/scoper.inc.php.tpl
@@ -87,15 +87,15 @@ return [
     // List of classes to consider as internal i.e. to leave untouched.
     //
     // For more see https://github.com/humbug/php-scoper#excluded-symbols
-    'system-classes' => [],
+    'excluded-classes' => [],
 
     // List of functions to consider as internal i.e. to leave untouched.
     //
     // For more see https://github.com/humbug/php-scoper#excluded-symbols
-    'system-functions' => [],
+    'excluded-functions' => [],
 
     // List of constants to consider as internal i.e. to leave untouched.
     //
     // For more see https://github.com/humbug/php-scoper#excluded-symbols
-    'system-constants' => [],
+    'excluded-constants' => [],
 ];

--- a/tests/ConfigurationFactoryTest.php
+++ b/tests/ConfigurationFactoryTest.php
@@ -17,7 +17,9 @@ namespace Humbug\PhpScoper;
 use Humbug\PhpScoper\Patcher\SymfonyPatcher;
 use InvalidArgumentException;
 use Symfony\Component\Filesystem\Filesystem;
+use function array_keys;
 use function KevinGH\Box\FileSystem\dump_file;
+use function Safe\sprintf;
 use function Safe\touch;
 use const DIRECTORY_SEPARATOR;
 
@@ -83,10 +85,23 @@ class ConfigurationFactoryTest extends FileSystemTestCase
                 'whitelist-global-classes' => false,
                 'whitelist-global-functions' => false,
                 'whitelist' => ['Foo', 'Bar\*'],
+                'excluded-constants' => [],
+                'excluded-classes' => [],
+                'excluded-functions' => [],
+                'patchers' => [],
+                'finders' => [],
             ];
             PHP,
         );
         touch('file1');
+
+        $rawConfig = include $this->tmp.DIRECTORY_SEPARATOR.'scoper.inc.php';
+
+        self::assertEqualsCanonicalizing(
+            ConfigurationKeys::KEYWORDS,
+            array_keys($rawConfig),
+            'The complete config must contain all the known configuration keys',
+        );
 
         $configuration = $this->createConfigFromStandardFile();
 

--- a/tests/ConfigurationKeysTest.php
+++ b/tests/ConfigurationKeysTest.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Humbug\PhpScoper;
+
+use Humbug\PhpScoper\ConfigurationKeys;
+use PHPUnit\Framework\TestCase;
+use ReflectionClass;
+use function array_values;
+
+/**
+ * @covers \Humbug\PhpScoper\ConfigurationKeys
+ */
+final class ConfigurationKeysTest extends TestCase
+{
+    public function test_keywords_contains_all_the_known_configuration_keys(): void
+    {
+        $configKeys = self::retrieveConfigurationKeys();
+        $keywords = self::retrieveKeywords();
+
+        self::assertEqualsCanonicalizing($configKeys, $keywords);
+    }
+
+    /**
+     * @return list<string>
+     */
+    private static function retrieveConfigurationKeys(): array
+    {
+        $configKeysReflection = new ReflectionClass(ConfigurationKeys::class);
+        // TODO in PHP 8.0 pass ReflectionClassConstant::IS_PUBLIC as a filter
+        //  and rename `$constants` to `$publicConstants`
+        $constants = $configKeysReflection->getConstants();
+
+        unset($constants['KEYWORDS']);
+
+        foreach ($constants as $name => $value) {
+            self::assertNonEmptyStringConstantValue(
+                $value,
+                $name,
+            );
+        }
+
+        return array_values($constants);
+    }
+
+    /**
+     * @return list<string>
+     */
+    private static function retrieveKeywords(): array
+    {
+        $configKeysReflection = new ReflectionClass(ConfigurationKeys::class);
+
+        $constant = $configKeysReflection->getConstant('KEYWORDS');
+
+        foreach ($constant as $index => $value) {
+            self::assertNonEmptyStringConstantValue(
+                $value,
+                (string) $index,
+            );
+        }
+
+        return $constant;
+    }
+
+    /**
+     * @param mixed $value
+     */
+    private static function assertNonEmptyStringConstantValue(
+        $value,
+        string $name
+    ): void
+    {
+        self::assertIsString($value, $name);
+        self::assertNotSame('', $value, $name);
+    }
+}

--- a/tests/Scoper/PhpScoperSpecTest.php
+++ b/tests/Scoper/PhpScoperSpecTest.php
@@ -16,6 +16,7 @@ namespace Humbug\PhpScoper\Scoper;
 
 use Error;
 use Generator;
+use Humbug\PhpScoper\ConfigurationKeys;
 use Humbug\PhpScoper\PhpParser\TraverserFactory;
 use Humbug\PhpScoper\Reflector;
 use Humbug\PhpScoper\Scoper;
@@ -60,27 +61,27 @@ class PhpScoperSpecTest extends TestCase
         'minPhpVersion',
         'maxPhpVersion',
         'title',
-        'prefix',
-        'whitelist',
-        'whitelist-global-constants',
-        'whitelist-global-classes',
-        'whitelist-global-functions',
-        'excluded-constants',
-        'excluded-classes',
-        'excluded-functions',
+        ConfigurationKeys::PREFIX_KEYWORD,
+        ConfigurationKeys::WHITELIST_KEYWORD,
+        ConfigurationKeys::WHITELIST_GLOBAL_CONSTANTS_KEYWORD,
+        ConfigurationKeys::WHITELIST_GLOBAL_CLASSES_KEYWORD,
+        ConfigurationKeys::WHITELIST_GLOBAL_FUNCTIONS_KEYWORD,
+        ConfigurationKeys::CONSTANTS_INTERNAL_SYMBOLS_KEYWORD,
+        ConfigurationKeys::CLASSES_INTERNAL_SYMBOLS_KEYWORD,
+        ConfigurationKeys::FUNCTIONS_INTERNAL_SYMBOLS_KEYWORD,
         'registered-classes',
         'registered-functions',
     ];
 
     private const SPECS_SPEC_KEYS = [
-        'prefix',
-        'whitelist',
-        'whitelist-global-constants',
-        'whitelist-global-classes',
-        'whitelist-global-functions',
-        'excluded-constants',
-        'excluded-classes',
-        'excluded-functions',
+        ConfigurationKeys::PREFIX_KEYWORD,
+        ConfigurationKeys::WHITELIST_KEYWORD,
+        ConfigurationKeys::WHITELIST_GLOBAL_CONSTANTS_KEYWORD,
+        ConfigurationKeys::WHITELIST_GLOBAL_CLASSES_KEYWORD,
+        ConfigurationKeys::WHITELIST_GLOBAL_FUNCTIONS_KEYWORD,
+        ConfigurationKeys::CONSTANTS_INTERNAL_SYMBOLS_KEYWORD,
+        ConfigurationKeys::CLASSES_INTERNAL_SYMBOLS_KEYWORD,
+        ConfigurationKeys::FUNCTIONS_INTERNAL_SYMBOLS_KEYWORD,
         'registered-classes',
         'registered-functions',
         'payload',
@@ -319,16 +320,16 @@ class PhpScoperSpecTest extends TestCase
             $file,
             $spec,
             $payloadParts[0],   // Input
-            $fixtureSet['prefix'] ?? $meta['prefix'],
+            $fixtureSet[ConfigurationKeys::PREFIX_KEYWORD] ?? $meta[ConfigurationKeys::PREFIX_KEYWORD],
             Whitelist::create(
-                $fixtureSet['whitelist-global-constants'] ?? $meta['whitelist-global-constants'],
-                $fixtureSet['whitelist-global-classes'] ?? $meta['whitelist-global-classes'],
-                $fixtureSet['whitelist-global-functions'] ?? $meta['whitelist-global-functions'],
-                ...($fixtureSet['whitelist'] ?? $meta['whitelist'])
+                $fixtureSet[ConfigurationKeys::WHITELIST_GLOBAL_CONSTANTS_KEYWORD] ?? $meta[ConfigurationKeys::WHITELIST_GLOBAL_CONSTANTS_KEYWORD],
+                $fixtureSet[ConfigurationKeys::WHITELIST_GLOBAL_CLASSES_KEYWORD] ?? $meta[ConfigurationKeys::WHITELIST_GLOBAL_CLASSES_KEYWORD],
+                $fixtureSet[ConfigurationKeys::WHITELIST_GLOBAL_FUNCTIONS_KEYWORD] ?? $meta[ConfigurationKeys::WHITELIST_GLOBAL_FUNCTIONS_KEYWORD],
+                ...($fixtureSet[ConfigurationKeys::WHITELIST_KEYWORD] ?? $meta[ConfigurationKeys::WHITELIST_KEYWORD])
             ),
-            $fixtureSet['excluded-classes'] ?? $meta['excluded-classes'],
-            $fixtureSet['excluded-functions'] ?? $meta['excluded-functions'],
-            $fixtureSet['excluded-constants'] ?? $meta['excluded-constants'],
+            $fixtureSet[ConfigurationKeys::CLASSES_INTERNAL_SYMBOLS_KEYWORD] ?? $meta[ConfigurationKeys::CLASSES_INTERNAL_SYMBOLS_KEYWORD],
+            $fixtureSet[ConfigurationKeys::FUNCTIONS_INTERNAL_SYMBOLS_KEYWORD] ?? $meta[ConfigurationKeys::FUNCTIONS_INTERNAL_SYMBOLS_KEYWORD],
+            $fixtureSet[ConfigurationKeys::CONSTANTS_INTERNAL_SYMBOLS_KEYWORD] ?? $meta[ConfigurationKeys::CONSTANTS_INTERNAL_SYMBOLS_KEYWORD],
             '' === $payloadParts[1] ? null : $payloadParts[1],   // Expected output; null means an exception is expected,
             $fixtureSet['registered-classes'] ?? $meta['registered-classes'],
             $fixtureSet['registered-functions'] ?? $meta['registered-functions'],

--- a/tests/TemplateFileTest.php
+++ b/tests/TemplateFileTest.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Humbug\PhpScoper;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @coversNothing
+ */
+final class TemplateFileTest extends TestCase
+{
+    public function test_the_template_file_contains_an_entry_for_each_configuration_key(): void
+    {
+        $this->markTestSkipped('TODO');
+    }
+}

--- a/tests/TemplateFileTest.php
+++ b/tests/TemplateFileTest.php
@@ -5,14 +5,37 @@ declare(strict_types=1);
 namespace Humbug\PhpScoper;
 
 use PHPUnit\Framework\TestCase;
+use function Safe\file_get_contents;
+use function Safe\preg_match_all;
 
 /**
  * @coversNothing
  */
 final class TemplateFileTest extends TestCase
 {
+    private const TEMPLATE_PATH = __DIR__.'/../src/scoper.inc.php.tpl';
+
     public function test_the_template_file_contains_an_entry_for_each_configuration_key(): void
     {
-        $this->markTestSkipped('TODO');
+        $templateConfigKeys = self::retrieveKeys();
+
+        self::assertEqualsCanonicalizing(
+            ConfigurationKeys::KEYWORDS,
+            $templateConfigKeys,
+        );
+    }
+
+    /**
+     * @return list<string>
+     */
+    private static function retrieveKeys(): array
+    {
+        $template = file_get_contents(self::TEMPLATE_PATH);
+
+        if (preg_match_all('/\'(.*?)\' => .*/', $template, $matches)) {
+            return $matches[1];
+        }
+
+        return [];
     }
 }


### PR DESCRIPTION
This allows for easier re-use of the configuration keys and add complementary tests to better avoid introducing issues when adding/changing/removing a new config entry.