### PR TITLE
[fix] bump php-parser to 4.12 and fix PHP 8.1 constants

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         "composer/package-versions-deprecated": "^1.8",
         "fidry/console": "^0.2.0",
         "jetbrains/phpstorm-stubs": "^v2021.1",
-        "nikic/php-parser": "^v4.10",
+        "nikic/php-parser": "^4.12",
         "symfony/console": "^5.2",
         "symfony/filesystem": "^5.2",
         "symfony/finder": "^5.2",

--- a/src/Reflector.php
+++ b/src/Reflector.php
@@ -63,6 +63,9 @@ final class Reflector
 
     private const MISSING_FUNCTIONS = [];
 
+    /**
+     * Basically mirrors https://github.com/nikic/PHP-Parser/blob/9aebf377fcdf205b2156cb78c0bd6e7b2003f106/lib/PhpParser/Lexer.php#L430
+     */
     private const MISSING_CONSTANTS = [
         'STDIN',
         'STDOUT',
@@ -80,6 +83,9 @@ final class Reflector
         'T_ATTRIBUTE',
         // Added in PHP 8.1
         'T_ENUM',
+        'T_AMPERSAND_NOT_FOLLOWED_BY_VAR_OR_VARARG',
+        'T_AMPERSAND_FOLLOWED_BY_VAR_OR_VARARG',
+        'T_READONLY',
     ];
 
     /**


### PR DESCRIPTION
Split of https://github.com/humbug/php-scoper/pull/535


Fixes PHP 8.1 introduced native constants that should not be prefixed

![Screenshot from 2021-08-11 08-41-24](https://user-images.githubusercontent.com/924196/128981764-1f9ab0ee-d2a7-40d6-9f82-f35dfea5d397.png)

