### PR TITLE
Introduce the EnrichedReflector

### DIFF
--- a/src/PhpParser/TraverserFactory.php
+++ b/src/PhpParser/TraverserFactory.php
@@ -19,6 +19,7 @@ use Humbug\PhpScoper\PhpParser\NodeVisitor\Resolver\IdentifierResolver;
 use Humbug\PhpScoper\PhpParser\NodeVisitor\UseStmt\UseStmtCollection;
 use Humbug\PhpScoper\Reflector;
 use Humbug\PhpScoper\Scoper\PhpScoper;
+use Humbug\PhpScoper\Symbol\EnrichedReflector;
 use Humbug\PhpScoper\Whitelist;
 use PhpParser\NodeTraverserInterface;
 use PhpParser\NodeVisitor as PhpParserNodeVisitor;
@@ -38,6 +39,11 @@ class TraverserFactory
 
     public function create(PhpScoper $scoper, string $prefix, Whitelist $whitelist): NodeTraverserInterface
     {
+        $enrichedReflector = new EnrichedReflector(
+            $this->reflector,
+            $whitelist,
+        );
+
         $traverser = new NodeTraverser();
 
         $namespaceStatements = new NamespaceStmtCollection();
@@ -69,8 +75,7 @@ class TraverserFactory
                 ),
                 new NodeVisitor\UseStmt\UseStmtPrefixer(
                     $prefix,
-                    $whitelist,
-                    $this->reflector,
+                    $enrichedReflector,
                 ),
 
                 new NodeVisitor\NamespaceStmt\FunctionIdentifierRecorder(
@@ -101,14 +106,13 @@ class TraverserFactory
 
                 new NodeVisitor\ClassAliasStmtAppender(
                     $prefix,
-                    $whitelist,
+                    $enrichedReflector,
                     $identifierResolver,
                 ),
                 new NodeVisitor\MultiConstStmtReplacer(),
                 new NodeVisitor\ConstStmtReplacer(
-                    $whitelist,
                     $identifierResolver,
-                    $this->reflector,
+                    $enrichedReflector,
                 ),
             ],
         );

--- a/src/Symbol/EnrichedReflector.php
+++ b/src/Symbol/EnrichedReflector.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Humbug\PhpScoper\Symbol;
+
+use Humbug\PhpScoper\Reflector;
+use Humbug\PhpScoper\Whitelist;
+
+/**
+ * Combines the API or the "traditional" reflector which is about to tell
+ * if a symbol is internal or not with the more PHP-Scoper specific exposed
+ * API.
+ */
+final class EnrichedReflector
+{
+    private Reflector $reflector;
+    private Whitelist $whitelist;
+
+    public function __construct(Reflector $reflector, Whitelist $whitelist)
+    {
+        $this->reflector = $reflector;
+        $this->whitelist = $whitelist;
+    }
+
+    public function belongsToExcludedNamespace(string $name): bool
+    {
+        return $this->whitelist->belongsToExcludedNamespace($name);
+    }
+
+    public function isFunctionInternal(string $name): bool
+    {
+        return $this->reflector->isFunctionInternal($name);
+    }
+
+    public function isClassInternal(string $name): bool
+    {
+        return $this->reflector->isClassInternal($name);
+    }
+
+    public function isConstantInternal(string $name): bool
+    {
+        return $this->reflector->isConstantInternal($name);
+    }
+
+    public function isExposedClass(string $resolvedName): bool
+    {
+        return !$this->whitelist->belongsToExcludedNamespace($resolvedName)
+            && (
+                $this->whitelist->isExposedClassFromGlobalNamespace($resolvedName)
+                || $this->whitelist->isSymbolExposed($resolvedName)
+            );
+    }
+
+    public function isExposedConstant(string $name): bool
+    {
+        // Special case: internal constants must be treated as exposed symbols.
+        //
+        // Example: when declaring a new internal constant for compatibility
+        // reasons, it must remain un-prefixed.
+        return $this->reflector->isConstantInternal($name)
+            || $this->whitelist->isExposedConstantFromGlobalNamespace($name)
+            || $this->whitelist->isSymbolExposed($name, true);
+    }
+}


### PR DESCRIPTION
The long-term goal is to completely split `Whitelist` into a Reflector and `SymbolsRegistry`. To this effect this new `EnrichedReflector` combines the reflective/expose API of `Whitelist` & `Reflector`. The goal with this new class is to consolidate the way excluded/exposed symbols are checked and provide a smoother API (only one service to check).

The current service is not complete yet however and to not introduce too abrupt changes it will be using both the Reflector and Whitelist underneath the hood for now.