### PR TITLE
Specs tweaks

### DIFF
--- a/specs/binary/simple.php
+++ b/specs/binary/simple.php
@@ -32,8 +32,8 @@ return [
         'exclude-classes' => [],
         'exclude-functions' => [],
 
-        'registered-classes' => [],
-        'registered-functions' => [],
+        'expected-recorded-classes' => [],
+        'expected-recorded-functions' => [],
     ],
 
     'Some statements made directly in the global namespace' => <<<'PHP'

--- a/specs/class-const/global-scope-single-level-with-single-level-use-statement-and-alias.php
+++ b/specs/class-const/global-scope-single-level-with-single-level-use-statement-and-alias.php
@@ -32,8 +32,8 @@ return [
         'exclude-classes' => [],
         'exclude-functions' => [],
 
-        'registered-classes' => [],
-        'registered-functions' => [],
+        'expected-recorded-classes' => [],
+        'expected-recorded-functions' => [],
     ],
 
     'Constant call on a aliased class which is imported via an aliased use statement and which belongs to the global namespace' => [

--- a/specs/class-const/global-scope-single-level-with-single-level-use-statement.php
+++ b/specs/class-const/global-scope-single-level-with-single-level-use-statement.php
@@ -32,8 +32,8 @@ return [
         'exclude-classes' => [],
         'exclude-functions' => [],
 
-        'registered-classes' => [],
-        'registered-functions' => [],
+        'expected-recorded-classes' => [],
+        'expected-recorded-functions' => [],
     ],
 
     'Constant call on a class which is imported via a use statement and which belongs to the global namespace' => [

--- a/specs/class-const/global-scope-single-level.php
+++ b/specs/class-const/global-scope-single-level.php
@@ -32,8 +32,8 @@ return [
         'exclude-classes' => [],
         'exclude-functions' => [],
 
-        'registered-classes' => [],
-        'registered-functions' => [],
+        'expected-recorded-classes' => [],
+        'expected-recorded-functions' => [],
     ],
 
     'Constant call on a class belonging to the global namespace' => [

--- a/specs/class-const/global-scope-two-level-with-single-level-use-and-alias.php
+++ b/specs/class-const/global-scope-two-level-with-single-level-use-and-alias.php
@@ -32,8 +32,8 @@ return [
         'exclude-classes' => [],
         'exclude-functions' => [],
 
-        'registered-classes' => [],
-        'registered-functions' => [],
+        'expected-recorded-classes' => [],
+        'expected-recorded-functions' => [],
     ],
 
     'Constant call on a namespaced class partially imported with an aliased use statement' => [
@@ -143,7 +143,7 @@ PHP
 
     'FQ Constant call on a whitelisted namespaced class partially imported with an aliased use statement' => [
         'whitelist' => ['Foo\Bar'],
-        'registered-classes' => [
+        'expected-recorded-classes' => [
             ['Foo\Bar', 'Humbug\Foo\Bar'],
         ],
         'payload' => <<<'PHP'

--- a/specs/class-const/global-scope-two-level-with-single-level-use.php
+++ b/specs/class-const/global-scope-two-level-with-single-level-use.php
@@ -32,8 +32,8 @@ return [
         'exclude-classes' => [],
         'exclude-functions' => [],
 
-        'registered-classes' => [],
-        'registered-functions' => [],
+        'expected-recorded-classes' => [],
+        'expected-recorded-functions' => [],
     ],
 
     'Constant call on a namespaced class partially imported with a use statement' => [
@@ -152,7 +152,7 @@ PHP
 
     'FQ Constant call on a whitelisted namespaced class partially imported with a use statement' => [
         'whitelist' => ['Foo\Bar'],
-        'registered-classes' => [
+        'expected-recorded-classes' => [
             ['Foo\Bar', 'Humbug\Foo\Bar'],
         ],
         'payload' => <<<'PHP'
@@ -195,7 +195,7 @@ PHP
 
     'FQ constant call on a whitelisted namespaced class imported with a use statement' => [
         'whitelist' => ['Foo\Bar'],
-        'registered-classes' => [
+        'expected-recorded-classes' => [
             ['Foo\Bar', 'Humbug\Foo\Bar'],
         ],
         'payload' => <<<'PHP'

--- a/specs/class-const/global-scope-two-level.php
+++ b/specs/class-const/global-scope-two-level.php
@@ -32,8 +32,8 @@ return [
         'exclude-classes' => [],
         'exclude-functions' => [],
 
-        'registered-classes' => [],
-        'registered-functions' => [],
+        'expected-recorded-classes' => [],
+        'expected-recorded-functions' => [],
     ],
 
     'Constant call on a namespaced class' => [
@@ -90,7 +90,7 @@ PHP
 
     'Constant call on a whitelisted namespaced class' => [
         'whitelist' => ['PHPUnit\Command'],
-        'registered-classes' => [
+        'expected-recorded-classes' => [
             ['PHPUnit\Command', 'Humbug\PHPUnit\Command'],
         ],
         'payload' => <<<'PHP'
@@ -121,7 +121,7 @@ PHP
 
     'FQ constant call on a whitelisted namespaced class' => [
         'whitelist' => ['PHPUnit\Command'],
-        'registered-classes' => [
+        'expected-recorded-classes' => [
             ['PHPUnit\Command', 'Humbug\PHPUnit\Command'],
         ],
         'payload' => <<<'PHP'

--- a/specs/class-const/namespace-scope-single-level-with-single-level-use-statement-and-alias.php
+++ b/specs/class-const/namespace-scope-single-level-with-single-level-use-statement-and-alias.php
@@ -32,8 +32,8 @@ return [
         'exclude-classes' => [],
         'exclude-functions' => [],
 
-        'registered-classes' => [],
-        'registered-functions' => [],
+        'expected-recorded-classes' => [],
+        'expected-recorded-functions' => [],
     ],
 
     'Constant call on a aliased class which is imported via an aliased use statement and which belongs to the global namespace' => [

--- a/specs/class-const/namespace-scope-single-level.php
+++ b/specs/class-const/namespace-scope-single-level.php
@@ -32,8 +32,8 @@ return [
         'exclude-classes' => [],
         'exclude-functions' => [],
 
-        'registered-classes' => [],
-        'registered-functions' => [],
+        'expected-recorded-classes' => [],
+        'expected-recorded-functions' => [],
     ],
 
     'Constant call on a class belonging to the global namespace or the current namespace' => [

--- a/specs/class-const/namespace-scope-two-level-with-single-level-use-and-alias.php
+++ b/specs/class-const/namespace-scope-two-level-with-single-level-use-and-alias.php
@@ -32,8 +32,8 @@ return [
         'exclude-classes' => [],
         'exclude-functions' => [],
 
-        'registered-classes' => [],
-        'registered-functions' => [],
+        'expected-recorded-classes' => [],
+        'expected-recorded-functions' => [],
     ],
 
     'Constant call on a namespaced class partially imported with an aliased use statement' => [
@@ -143,7 +143,7 @@ PHP
 
     'FQ Constant call on a whitelisted namespaced class partially imported with an aliased use statement' => [
         'whitelist' => ['Foo\Bar'],
-        'registered-classes' => [
+        'expected-recorded-classes' => [
             ['Foo\Bar', 'Humbug\Foo\Bar'],
         ],
         'payload' => <<<'PHP'

--- a/specs/class-const/namespace-scope-two-level-with-single-level-use.php
+++ b/specs/class-const/namespace-scope-two-level-with-single-level-use.php
@@ -32,8 +32,8 @@ return [
         'exclude-classes' => [],
         'exclude-functions' => [],
 
-        'registered-classes' => [],
-        'registered-functions' => [],
+        'expected-recorded-classes' => [],
+        'expected-recorded-functions' => [],
     ],
 
     'Constant call on a namespaced class partially imported with a use statement' => [
@@ -152,7 +152,7 @@ PHP
 
     'FQ Constant call on a whitelisted namespaced class partially imported with a use statement' => [
         'whitelist' => ['Foo\Bar'],
-        'registered-classes' => [
+        'expected-recorded-classes' => [
             ['Foo\Bar', 'Humbug\Foo\Bar'],
         ],
         'payload' => <<<'PHP'
@@ -195,7 +195,7 @@ PHP
 
     'FQ constant call on a whitelisted namespaced class imported with a use statement' => [
         'whitelist' => ['Foo\Bar'],
-        'registered-classes' => [
+        'expected-recorded-classes' => [
             ['Foo\Bar', 'Humbug\Foo\Bar'],
         ],
         'payload' => <<<'PHP'

--- a/specs/class-const/namespace-scope-two-level.php
+++ b/specs/class-const/namespace-scope-two-level.php
@@ -32,8 +32,8 @@ return [
         'exclude-classes' => [],
         'exclude-functions' => [],
 
-        'registered-classes' => [],
-        'registered-functions' => [],
+        'expected-recorded-classes' => [],
+        'expected-recorded-functions' => [],
     ],
 
     'Constant call on a namespaced class' => [
@@ -90,7 +90,7 @@ PHP
 
     'Constant call on a whitelisted namespaced class' => [
         'whitelist' => ['X\PHPUnit\Command'],
-        'registered-classes' => [
+        'expected-recorded-classes' => [
             ['X\PHPUnit\Command', 'Humbug\X\PHPUnit\Command'],
         ],
         'payload' => <<<'PHP'
@@ -175,7 +175,7 @@ PHP
 
     'FQ constant call on a whitelisted namespaced class' => [
         'whitelist' => ['PHPUnit\Command'],
-        'registered-classes' => [
+        'expected-recorded-classes' => [
             ['PHPUnit\Command', 'Humbug\PHPUnit\Command'],
         ],
         'payload' => <<<'PHP'

--- a/specs/class-const/namespace-single-part-with-single-level-use-statement.php
+++ b/specs/class-const/namespace-single-part-with-single-level-use-statement.php
@@ -32,8 +32,8 @@ return [
         'exclude-classes' => [],
         'exclude-functions' => [],
 
-        'registered-classes' => [],
-        'registered-functions' => [],
+        'expected-recorded-classes' => [],
+        'expected-recorded-functions' => [],
     ],
 
     'Constant call on a class which is imported via a use statement and which belongs to the global namespace' => [

--- a/specs/class-static-prop/global-scope-single-level-with-single-level-use-statement-and-alias.php
+++ b/specs/class-static-prop/global-scope-single-level-with-single-level-use-statement-and-alias.php
@@ -32,8 +32,8 @@ return [
         'exclude-classes' => [],
         'exclude-functions' => [],
 
-        'registered-classes' => [],
-        'registered-functions' => [],
+        'expected-recorded-classes' => [],
+        'expected-recorded-functions' => [],
     ],
 
     'Constant call on a aliased class which is imported via an aliased use statement and which belongs to the global namespace' => <<<'PHP'

--- a/specs/class-static-prop/global-scope-single-level-with-single-level-use-statement.php
+++ b/specs/class-static-prop/global-scope-single-level-with-single-level-use-statement.php
@@ -32,8 +32,8 @@ return [
         'exclude-classes' => [],
         'exclude-functions' => [],
 
-        'registered-classes' => [],
-        'registered-functions' => [],
+        'expected-recorded-classes' => [],
+        'expected-recorded-functions' => [],
     ],
 
     'Constant call on a class which is imported via a use statement and which belongs to the global namespace' => <<<'PHP'

--- a/specs/class-static-prop/global-scope-single-level.php
+++ b/specs/class-static-prop/global-scope-single-level.php
@@ -32,8 +32,8 @@ return [
         'exclude-classes' => [],
         'exclude-functions' => [],
 
-        'registered-classes' => [],
-        'registered-functions' => [],
+        'expected-recorded-classes' => [],
+        'expected-recorded-functions' => [],
     ],
 
     'Constant call on a class belonging to the global namespace' => <<<'PHP'

--- a/specs/class-static-prop/global-scope-two-level-with-single-level-use-and-alias.php
+++ b/specs/class-static-prop/global-scope-two-level-with-single-level-use-and-alias.php
@@ -32,8 +32,8 @@ return [
         'exclude-classes' => [],
         'exclude-functions' => [],
 
-        'registered-classes' => [],
-        'registered-functions' => [],
+        'expected-recorded-classes' => [],
+        'expected-recorded-functions' => [],
     ],
 
     'Constant call on a namespaced class partially imported with an aliased use statement' => <<<'PHP'
@@ -140,7 +140,7 @@ PHP
 
     'FQ Constant call on a whitelisted namespaced class partially imported with an aliased use statement' => [
         'whitelist' => ['Foo\Bar'],
-        'registered-classes' => [
+        'expected-recorded-classes' => [
             ['Foo\Bar', 'Humbug\Foo\Bar'],
         ],
         'payload' => <<<'PHP'

--- a/specs/class-static-prop/global-scope-two-level-with-single-level-use.php
+++ b/specs/class-static-prop/global-scope-two-level-with-single-level-use.php
@@ -32,8 +32,8 @@ return [
         'exclude-classes' => [],
         'exclude-functions' => [],
 
-        'registered-classes' => [],
-        'registered-functions' => [],
+        'expected-recorded-classes' => [],
+        'expected-recorded-functions' => [],
     ],
 
     'Constant call on a namespaced class partially imported with a use statement' => <<<'PHP'
@@ -149,7 +149,7 @@ PHP
 
     'FQ Constant call on a whitelisted namespaced class partially imported with a use statement' => [
         'whitelist' => ['Foo\Bar'],
-        'registered-classes' => [
+        'expected-recorded-classes' => [
             ['Foo\Bar', 'Humbug\Foo\Bar'],
         ],
         'payload' => <<<'PHP'
@@ -192,7 +192,7 @@ PHP
 
     'FQ constant call on a whitelisted namespaced class imported with a use statement' => [
         'whitelist' => ['Foo\Bar'],
-        'registered-classes' => [
+        'expected-recorded-classes' => [
             ['Foo\Bar', 'Humbug\Foo\Bar'],
         ],
         'payload' => <<<'PHP'

--- a/specs/class-static-prop/global-scope-two-level.php
+++ b/specs/class-static-prop/global-scope-two-level.php
@@ -32,8 +32,8 @@ return [
         'exclude-classes' => [],
         'exclude-functions' => [],
 
-        'registered-classes' => [],
-        'registered-functions' => [],
+        'expected-recorded-classes' => [],
+        'expected-recorded-functions' => [],
     ],
 
     'Constant call on a namespaced class' => <<<'PHP'
@@ -88,7 +88,7 @@ PHP
 
     'Constant call on a whitelisted namespaced class' => [
         'whitelist' => ['PHPUnit\Command'],
-        'registered-classes' => [
+        'expected-recorded-classes' => [
             ['PHPUnit\Command', 'Humbug\PHPUnit\Command'],
         ],
         'payload' => <<<'PHP'
@@ -119,7 +119,7 @@ PHP
 
     'FQ constant call on a whitelisted namespaced class' => [
         'whitelist' => ['PHPUnit\Command'],
-        'registered-classes' => [
+        'expected-recorded-classes' => [
             ['PHPUnit\Command', 'Humbug\PHPUnit\Command'],
         ],
         'payload' => <<<'PHP'

--- a/specs/class-static-prop/namespace-scope-single-level-with-single-level-use-statement-and-alias.php
+++ b/specs/class-static-prop/namespace-scope-single-level-with-single-level-use-statement-and-alias.php
@@ -32,8 +32,8 @@ return [
         'exclude-classes' => [],
         'exclude-functions' => [],
 
-        'registered-classes' => [],
-        'registered-functions' => [],
+        'expected-recorded-classes' => [],
+        'expected-recorded-functions' => [],
     ],
 
     'Constant call on a aliased class which is imported via an aliased use statement and which belongs to the global namespace' => <<<'PHP'

--- a/specs/class-static-prop/namespace-scope-single-level.php
+++ b/specs/class-static-prop/namespace-scope-single-level.php
@@ -32,8 +32,8 @@ return [
         'exclude-classes' => [],
         'exclude-functions' => [],
 
-        'registered-classes' => [],
-        'registered-functions' => [],
+        'expected-recorded-classes' => [],
+        'expected-recorded-functions' => [],
     ],
 
     'Constant call on a class belonging to the global namespace or the current namespace' => <<<'PHP'

--- a/specs/class-static-prop/namespace-scope-two-level-with-single-level-use-and-alias.php
+++ b/specs/class-static-prop/namespace-scope-two-level-with-single-level-use-and-alias.php
@@ -32,8 +32,8 @@ return [
         'exclude-classes' => [],
         'exclude-functions' => [],
 
-        'registered-classes' => [],
-        'registered-functions' => [],
+        'expected-recorded-classes' => [],
+        'expected-recorded-functions' => [],
     ],
 
     'Constant call on a namespaced class partially imported with an aliased use statement' => <<<'PHP'
@@ -140,7 +140,7 @@ PHP
 
     'FQ Constant call on a whitelisted namespaced class partially imported with an aliased use statement' => [
         'whitelist' => ['Foo\Bar'],
-        'registered-classes' => [
+        'expected-recorded-classes' => [
             ['Foo\Bar', 'Humbug\Foo\Bar'],
         ],
         'payload' => <<<'PHP'

--- a/specs/class-static-prop/namespace-scope-two-level-with-single-level-use.php
+++ b/specs/class-static-prop/namespace-scope-two-level-with-single-level-use.php
@@ -32,8 +32,8 @@ return [
         'exclude-classes' => [],
         'exclude-functions' => [],
 
-        'registered-classes' => [],
-        'registered-functions' => [],
+        'expected-recorded-classes' => [],
+        'expected-recorded-functions' => [],
     ],
 
     'Constant call on a namespaced class partially imported with a use statement' => <<<'PHP'
@@ -149,7 +149,7 @@ PHP
 
     'FQ Constant call on a whitelisted namespaced class partially imported with a use statement' => [
         'whitelist' => ['Foo\Bar'],
-        'registered-classes' => [
+        'expected-recorded-classes' => [
             ['Foo\Bar', 'Humbug\Foo\Bar'],
         ],
         'payload' => <<<'PHP'
@@ -192,7 +192,7 @@ PHP
 
     'FQ constant call on a whitelisted namespaced class imported with a use statement' => [
         'whitelist' => ['Foo\Bar'],
-        'registered-classes' => [
+        'expected-recorded-classes' => [
             ['Foo\Bar', 'Humbug\Foo\Bar'],
         ],
         'payload' => <<<'PHP'

--- a/specs/class-static-prop/namespace-scope-two-level.php
+++ b/specs/class-static-prop/namespace-scope-two-level.php
@@ -32,8 +32,8 @@ return [
         'exclude-classes' => [],
         'exclude-functions' => [],
 
-        'registered-classes' => [],
-        'registered-functions' => [],
+        'expected-recorded-classes' => [],
+        'expected-recorded-functions' => [],
     ],
 
     'Constant call on a namespaced class' => <<<'PHP'
@@ -88,7 +88,7 @@ PHP
 
     'Constant call on a whitelisted namespaced class' => [
         'whitelist' => ['X\PHPUnit\Command'],
-        'registered-classes' => [
+        'expected-recorded-classes' => [
             ['X\PHPUnit\Command', 'Humbug\X\PHPUnit\Command'],
         ],
         'payload' => <<<'PHP'
@@ -119,7 +119,7 @@ PHP
 
     'FQ constant call on a whitelisted namespaced class' => [
         'whitelist' => ['PHPUnit\Command'],
-        'registered-classes' => [
+        'expected-recorded-classes' => [
             ['PHPUnit\Command', 'Humbug\PHPUnit\Command'],
         ],
         'payload' => <<<'PHP'

--- a/specs/class-static-prop/namespace-single-part-with-single-level-use-statement.php
+++ b/specs/class-static-prop/namespace-single-part-with-single-level-use-statement.php
@@ -32,8 +32,8 @@ return [
         'exclude-classes' => [],
         'exclude-functions' => [],
 
-        'registered-classes' => [],
-        'registered-functions' => [],
+        'expected-recorded-classes' => [],
+        'expected-recorded-functions' => [],
     ],
 
     'Constant call on a class which is imported via a use statement and which belongs to the global namespace' => <<<'PHP'

--- a/specs/class/abstract.php
+++ b/specs/class/abstract.php
@@ -32,8 +32,8 @@ return [
         'exclude-classes' => [],
         'exclude-functions' => [],
 
-        'registered-classes' => [],
-        'registered-functions' => [],
+        'expected-recorded-classes' => [],
+        'expected-recorded-functions' => [],
     ],
 
     'Declaration in the global namespace' => <<<'PHP'
@@ -61,7 +61,7 @@ PHP
 
     'Declaration in the global namespace with global classes whitelisted' => [
         'expose-global-classes' => true,
-        'registered-classes' => [
+        'expected-recorded-classes' => [
             ['A', 'Humbug\A'],
         ],
         'payload' => <<<'PHP'
@@ -116,7 +116,7 @@ PHP
 
     'Declaration of a whitelisted class in the global namespace' => [
         'whitelist' => ['A'],
-        'registered-classes' => [
+        'expected-recorded-classes' => [
             ['A', 'Humbug\A'],
         ],
         'payload' => <<<'PHP'
@@ -146,7 +146,7 @@ PHP
     'Declaration of a whitelisted class in the global namespace which is whitelisted' => [
         'whitelist' => ['A'],
         'exclude-namespaces' => ['/^$/'],
-        'registered-classes' => [
+        'expected-recorded-classes' => [
             ['A', 'Humbug\A'],
         ],
         'payload' => <<<'PHP'
@@ -254,7 +254,7 @@ PHP
 
     'Declaration of a whitelisted class in a namespace' => [
         'whitelist' => ['Foo\A'],
-        'registered-classes' => [
+        'expected-recorded-classes' => [
             ['Foo\A', 'Humbug\Foo\A'],
         ],
         'payload' => <<<'PHP'
@@ -285,7 +285,7 @@ PHP
 
     'Declaration of a namespaced class whitelisted with a pattern' => [
         'exclude-namespaces' => ['/^Foo\\\\A.*$/'],
-        'registered-classes' => [],
+        'expected-recorded-classes' => [],
         'payload' => <<<'PHP'
 <?php
 
@@ -331,7 +331,7 @@ PHP
 
     'Declaration of a whitelisted class in a namespace with FQCN for the whitelist' => [
         'whitelist' => ['\Foo\A'],
-        'registered-classes' => [
+        'expected-recorded-classes' => [
             ['Foo\A', 'Humbug\Foo\A'],
         ],
         'payload' => <<<'PHP'
@@ -389,7 +389,7 @@ PHP
 
     'Multiple declarations in different namespaces with whitelisted classes' => [
         'whitelist' => ['Foo\WA', 'Bar\WB', 'WC'],
-        'registered-classes' => [
+        'expected-recorded-classes' => [
             ['Foo\WA', 'Humbug\Foo\WA'],
             ['Bar\WB', 'Humbug\Bar\WB'],
             ['WC', 'Humbug\WC'],

--- a/specs/class/anonymous.php
+++ b/specs/class/anonymous.php
@@ -32,8 +32,8 @@ return [
         'exclude-classes' => [],
         'exclude-functions' => [],
 
-        'registered-classes' => [],
-        'registered-functions' => [],
+        'expected-recorded-classes' => [],
+        'expected-recorded-functions' => [],
     ],
 
     'Declaration in the global namespace' => <<<'PHP'
@@ -104,7 +104,7 @@ PHP
 
     'Declaration in the global namespace with global classes whitelisted' => [
         'expose-global-classes' => true,
-        'registered-classes' => [
+        'expected-recorded-classes' => [
             ['A', 'Humbug\A'],
             ['B', 'Humbug\B'],
             ['C', 'Humbug\C'],
@@ -249,7 +249,7 @@ PHP
 
     'Declaration in the global namespace with some whitelisted classes' => [
         'whitelist' => ['A', 'C'],
-        'registered-classes' => [
+        'expected-recorded-classes' => [
             ['A', 'Humbug\A'],
             ['C', 'Humbug\C'],
         ],

--- a/specs/class/conditional.php
+++ b/specs/class/conditional.php
@@ -32,8 +32,8 @@ return [
         'exclude-classes' => [],
         'exclude-functions' => [],
 
-        'registered-classes' => [],
-        'registered-functions' => [],
+        'expected-recorded-classes' => [],
+        'expected-recorded-functions' => [],
     ],
 
     'Declaration in the global namespace' => <<<'PHP'
@@ -58,7 +58,7 @@ PHP
 
     'Declaration of a whitelisted class in the global namespace' => [
         'whitelist' => ['A'],
-        'registered-classes' => [
+        'expected-recorded-classes' => [
             ['A', 'Humbug\A'],
         ],
         'payload' => <<<'PHP'
@@ -105,7 +105,7 @@ PHP
 
     'Declaration of a whitelisted class' => [
         'whitelist' => ['Foo\A'],
-        'registered-classes' => [
+        'expected-recorded-classes' => [
             ['Foo\A', 'Humbug\Foo\A'],
         ],
         'payload' => <<<'PHP'

--- a/specs/class/final.php
+++ b/specs/class/final.php
@@ -32,8 +32,8 @@ return [
         'exclude-classes' => [],
         'exclude-functions' => [],
 
-        'registered-classes' => [],
-        'registered-functions' => [],
+        'expected-recorded-classes' => [],
+        'expected-recorded-functions' => [],
     ],
 
     'Declaration in the global namespace' => <<<'PHP'
@@ -54,7 +54,7 @@ PHP
 
     'Declaration in the global namespace with global classes whitelisted' => [
         'expose-global-classes' => true,
-        'registered-classes' => [
+        'expected-recorded-classes' => [
             ['A', 'Humbug\A'],
         ],
         'payload' => <<<'PHP'
@@ -114,7 +114,7 @@ PHP
 
     'Declaration of a whitelisted final class' => [
         'whitelist' => ['Foo\A'],
-        'registered-classes' => [
+        'expected-recorded-classes' => [
             ['Foo\A', 'Humbug\Foo\A'],
         ],
         'payload' => <<<'PHP'

--- a/specs/class/interface.php
+++ b/specs/class/interface.php
@@ -32,8 +32,8 @@ return [
         'exclude-classes' => [],
         'exclude-functions' => [],
 
-        'registered-classes' => [],
-        'registered-functions' => [],
+        'expected-recorded-classes' => [],
+        'expected-recorded-functions' => [],
     ],
 
     'Declaration in the global namespace' => <<<'PHP'
@@ -66,7 +66,7 @@ PHP
 
     'Declaration in the global namespace with global classes whitelisted' => [
         'expose-global-classes' => true,
-        'registered-classes' => [
+        'expected-recorded-classes' => [
             ['A', 'Humbug\A'],
             ['C', 'Humbug\C'],
             ['D', 'Humbug\D'],
@@ -174,7 +174,7 @@ PHP
 
     'Declaration of a whitelisted interface' => [
         'whitelist' => ['Foo\A'],
-        'registered-classes' => [
+        'expected-recorded-classes' => [
             ['Foo\A', 'Humbug\Foo\A'],
         ],
         'payload' => <<<'PHP'
@@ -214,7 +214,7 @@ PHP
 
     'Declaration of a whitelisted interface whitelisted with a pattern' => [
         'whitelist' => ['Foo\A*'],
-        'registered-classes' => [
+        'expected-recorded-classes' => [
             ['Foo\A', 'Humbug\Foo\A'],
             ['Foo\AA', 'Humbug\Foo\AA'],
             ['Foo\A\B', 'Humbug\Foo\A\B'],

--- a/specs/class/regular-extend.php
+++ b/specs/class/regular-extend.php
@@ -32,8 +32,8 @@ return [
         'exclude-classes' => [],
         'exclude-functions' => [],
 
-        'registered-classes' => [],
-        'registered-functions' => [],
+        'expected-recorded-classes' => [],
+        'expected-recorded-functions' => [],
     ],
 
     'Declaration in the global namespace' => <<<'PHP'
@@ -97,7 +97,7 @@ PHP
 
     'Declaration of a whitelisted class' => [
         'whitelist' => ['Foo\B'],
-        'registered-classes' => [
+        'expected-recorded-classes' => [
             ['Foo\B', 'Humbug\Foo\B'],
         ],
         'payload' => <<<'PHP'

--- a/specs/class/regular.php
+++ b/specs/class/regular.php
@@ -32,8 +32,8 @@ return [
         'exclude-classes' => [],
         'exclude-functions' => [],
 
-        'registered-classes' => [],
-        'registered-functions' => [],
+        'expected-recorded-classes' => [],
+        'expected-recorded-functions' => [],
     ],
 
     'Declaration in the global namespace' => <<<'PHP'
@@ -59,7 +59,7 @@ PHP
 
     'Declaration in the global namespace with global classes whitelisted' => [
         'expose-global-classes' => true,
-        'registered-classes' => [
+        'expected-recorded-classes' => [
             ['A', 'Humbug\A'],
         ],
         'payload' => <<<'PHP'
@@ -134,7 +134,7 @@ PHP
 
     'Declaration of a whitelisted class' => [
         'whitelist' => ['Foo\A'],
-        'registered-classes' => [
+        'expected-recorded-classes' => [
             ['Foo\A', 'Humbug\Foo\A'],
         ],
         'payload' => <<<'PHP'
@@ -163,7 +163,7 @@ PHP
 
     'Declaration of a whitelisted class whitelisted with a pattern' => [
         'whitelist' => ['Foo\A*'],
-        'registered-classes' => [
+        'expected-recorded-classes' => [
             ['Foo\A', 'Humbug\Foo\A'],
             ['Foo\AA', 'Humbug\Foo\AA'],
             ['Foo\A\B', 'Humbug\Foo\A\B'],
@@ -273,7 +273,7 @@ PHP
             'Foo\A',
             'Bar\B',
         ],
-        'registered-classes' => [
+        'expected-recorded-classes' => [
             ['Foo\A', 'Humbug\Foo\A'],
             ['Bar\B', 'Humbug\Bar\B'],
         ],

--- a/specs/class/trait.php
+++ b/specs/class/trait.php
@@ -32,8 +32,8 @@ return [
         'exclude-classes' => [],
         'exclude-functions' => [],
 
-        'registered-classes' => [],
-        'registered-functions' => [],
+        'expected-recorded-classes' => [],
+        'expected-recorded-functions' => [],
     ],
 
     'Declaration in the global namespace' => <<<'PHP'
@@ -89,7 +89,7 @@ PHP
 
     'Declaration in the global namespace with global classes whitelisted' => [
         'expose-global-classes' => true,
-        'registered-classes' => [
+        'expected-recorded-classes' => [
             ['B', 'Humbug\B'],
         ],
         'payload' => <<<'PHP'

--- a/specs/class/typed-properties.php
+++ b/specs/class/typed-properties.php
@@ -32,8 +32,8 @@ return [
         'exclude-classes' => [],
         'exclude-functions' => [],
 
-        'registered-classes' => [],
-        'registered-functions' => [],
+        'expected-recorded-classes' => [],
+        'expected-recorded-functions' => [],
     ],
 
     'Declaration in the global namespace' => <<<'PHP'
@@ -71,7 +71,7 @@ PHP
 
     'Declaration in the global namespace with global classes whitelisted' => [
         'expose-global-classes' => true,
-        'registered-classes' => [
+        'expected-recorded-classes' => [
             ['A', 'Humbug\A'],
         ],
         'payload' => <<<'PHP'
@@ -170,7 +170,7 @@ PHP
             'Foo\A',
             'Foo\B',
         ],
-        'registered-classes' => [
+        'expected-recorded-classes' => [
             ['Foo\A', 'Humbug\Foo\A'],
         ],
         'payload' => <<<'PHP'

--- a/specs/const/const-declaration-with-global-whitelisting.php
+++ b/specs/const/const-declaration-with-global-whitelisting.php
@@ -32,8 +32,8 @@ return [
         'exclude-classes' => [],
         'exclude-functions' => [],
 
-        'registered-classes' => [],
-        'registered-functions' => [],
+        'expected-recorded-classes' => [],
+        'expected-recorded-functions' => [],
     ],
 
     'Constants declaration in the global namespace' => [

--- a/specs/const/const-declaration.php
+++ b/specs/const/const-declaration.php
@@ -32,8 +32,8 @@ return [
         'exclude-classes' => [],
         'exclude-functions' => [],
 
-        'registered-classes' => [],
-        'registered-functions' => [],
+        'expected-recorded-classes' => [],
+        'expected-recorded-functions' => [],
     ],
 
     'Constants declaration in the global namespace' => [

--- a/specs/const/global-scope-global-with-global-whitelisting.php
+++ b/specs/const/global-scope-global-with-global-whitelisting.php
@@ -32,8 +32,8 @@ return [
         'exclude-classes' => [],
         'exclude-functions' => [],
 
-        'registered-classes' => [],
-        'registered-functions' => [],
+        'expected-recorded-classes' => [],
+        'expected-recorded-functions' => [],
     ],
 
     'Constant call in the global namespace' => <<<'PHP'

--- a/specs/const/global-scope-global-with-single-level-use-statement-and-alias.php
+++ b/specs/const/global-scope-global-with-single-level-use-statement-and-alias.php
@@ -32,8 +32,8 @@ return [
         'exclude-classes' => [],
         'exclude-functions' => [],
 
-        'registered-classes' => [],
-        'registered-functions' => [],
+        'expected-recorded-classes' => [],
+        'expected-recorded-functions' => [],
     ],
 
     'Constant call imported with an aliased use statement' => <<<'PHP'

--- a/specs/const/global-scope-global-with-single-level-use-statement-with-global-whitelisting.php
+++ b/specs/const/global-scope-global-with-single-level-use-statement-with-global-whitelisting.php
@@ -32,8 +32,8 @@ return [
         'exclude-classes' => [],
         'exclude-functions' => [],
 
-        'registered-classes' => [],
-        'registered-functions' => [],
+        'expected-recorded-classes' => [],
+        'expected-recorded-functions' => [],
     ],
 
     'Constant call imported with a use statement' => <<<'PHP'

--- a/specs/const/global-scope-global-with-single-level-use-statement.php
+++ b/specs/const/global-scope-global-with-single-level-use-statement.php
@@ -32,8 +32,8 @@ return [
         'exclude-classes' => [],
         'exclude-functions' => [],
 
-        'registered-classes' => [],
-        'registered-functions' => [],
+        'expected-recorded-classes' => [],
+        'expected-recorded-functions' => [],
     ],
 
     'Constant call imported with a use statement' => <<<'PHP'

--- a/specs/const/global-scope-global.php
+++ b/specs/const/global-scope-global.php
@@ -32,8 +32,8 @@ return [
         'exclude-classes' => [],
         'exclude-functions' => [],
 
-        'registered-classes' => [],
-        'registered-functions' => [],
+        'expected-recorded-classes' => [],
+        'expected-recorded-functions' => [],
     ],
 
     'Constant call in the global namespace' => <<<'PHP'

--- a/specs/const/global-scope-single-part-namespaced-with-single-level-use-alias.php
+++ b/specs/const/global-scope-single-part-namespaced-with-single-level-use-alias.php
@@ -32,8 +32,8 @@ return [
         'exclude-classes' => [],
         'exclude-functions' => [],
 
-        'registered-classes' => [],
-        'registered-functions' => [],
+        'expected-recorded-classes' => [],
+        'expected-recorded-functions' => [],
     ],
 
     'Constant call on an imported single-level namespace' => <<<'PHP'

--- a/specs/const/global-scope-single-part-namespaced-with-single-level-use.php
+++ b/specs/const/global-scope-single-part-namespaced-with-single-level-use.php
@@ -32,8 +32,8 @@ return [
         'exclude-classes' => [],
         'exclude-functions' => [],
 
-        'registered-classes' => [],
-        'registered-functions' => [],
+        'expected-recorded-classes' => [],
+        'expected-recorded-functions' => [],
     ],
 
     'Constant call on an imported single-level namespace' => <<<'PHP'

--- a/specs/const/global-scope-single-part-namespaced.php
+++ b/specs/const/global-scope-single-part-namespaced.php
@@ -32,8 +32,8 @@ return [
         'exclude-classes' => [],
         'exclude-functions' => [],
 
-        'registered-classes' => [],
-        'registered-functions' => [],
+        'expected-recorded-classes' => [],
+        'expected-recorded-functions' => [],
     ],
 
     'Namespaced constant call' => <<<'PHP'

--- a/specs/const/global-scope-two-parts-namespaced-with-single-level-use-and-alias.php
+++ b/specs/const/global-scope-two-parts-namespaced-with-single-level-use-and-alias.php
@@ -32,8 +32,8 @@ return [
         'exclude-classes' => [],
         'exclude-functions' => [],
 
-        'registered-classes' => [],
-        'registered-functions' => [],
+        'expected-recorded-classes' => [],
+        'expected-recorded-functions' => [],
     ],
 
     'Namespaced constant call with namespace partially imported' => <<<'PHP'

--- a/specs/const/global-scope-two-parts-namespaced-with-single-level-use.php
+++ b/specs/const/global-scope-two-parts-namespaced-with-single-level-use.php
@@ -32,8 +32,8 @@ return [
         'exclude-classes' => [],
         'exclude-functions' => [],
 
-        'registered-classes' => [],
-        'registered-functions' => [],
+        'expected-recorded-classes' => [],
+        'expected-recorded-functions' => [],
     ],
 
     'Namespaced constant call with namespace partially imported' => <<<'PHP'

--- a/specs/const/global-scope-two-parts-namespaced.php
+++ b/specs/const/global-scope-two-parts-namespaced.php
@@ -32,8 +32,8 @@ return [
         'exclude-classes' => [],
         'exclude-functions' => [],
 
-        'registered-classes' => [],
-        'registered-functions' => [],
+        'expected-recorded-classes' => [],
+        'expected-recorded-functions' => [],
     ],
 
     'Namespaced constant call' => <<<'PHP'

--- a/specs/const/namespace-global-with-global-whitelisting.php
+++ b/specs/const/namespace-global-with-global-whitelisting.php
@@ -32,8 +32,8 @@ return [
         'exclude-classes' => [],
         'exclude-functions' => [],
 
-        'registered-classes' => [],
-        'registered-functions' => [],
+        'expected-recorded-classes' => [],
+        'expected-recorded-functions' => [],
     ],
 
     'Constant call in a namespace' => <<<'PHP'

--- a/specs/const/namespace-global-with-single-level-use-statement-and-alias.php
+++ b/specs/const/namespace-global-with-single-level-use-statement-and-alias.php
@@ -32,8 +32,8 @@ return [
         'exclude-classes' => [],
         'exclude-functions' => [],
 
-        'registered-classes' => [],
-        'registered-functions' => [],
+        'expected-recorded-classes' => [],
+        'expected-recorded-functions' => [],
     ],
 
     'Constant call imported with an aliased use statement' => <<<'PHP'

--- a/specs/const/namespace-global-with-single-level-use-statement.php
+++ b/specs/const/namespace-global-with-single-level-use-statement.php
@@ -32,8 +32,8 @@ return [
         'exclude-classes' => [],
         'exclude-functions' => [],
 
-        'registered-classes' => [],
-        'registered-functions' => [],
+        'expected-recorded-classes' => [],
+        'expected-recorded-functions' => [],
     ],
 
     'Constant call imported with a use statement' => <<<'PHP'

--- a/specs/const/namespace-global.php
+++ b/specs/const/namespace-global.php
@@ -32,8 +32,8 @@ return [
         'exclude-classes' => [],
         'exclude-functions' => [],
 
-        'registered-classes' => [],
-        'registered-functions' => [],
+        'expected-recorded-classes' => [],
+        'expected-recorded-functions' => [],
     ],
 
     'Constant call in a namespace' => <<<'PHP'

--- a/specs/const/namespace-single-part-namespaced.php
+++ b/specs/const/namespace-single-part-namespaced.php
@@ -32,8 +32,8 @@ return [
         'exclude-classes' => [],
         'exclude-functions' => [],
 
-        'registered-classes' => [],
-        'registered-functions' => [],
+        'expected-recorded-classes' => [],
+        'expected-recorded-functions' => [],
     ],
 
     'Namespaced constant call' => <<<'PHP'

--- a/specs/const/native-const-with-global-whitelisting.php
+++ b/specs/const/native-const-with-global-whitelisting.php
@@ -32,8 +32,8 @@ return [
         'exclude-classes' => [],
         'exclude-functions' => [],
 
-        'registered-classes' => [],
-        'registered-functions' => [],
+        'expected-recorded-classes' => [],
+        'expected-recorded-functions' => [],
     ],
 
     'Internal function in a namespace' => <<<'PHP'

--- a/specs/const/native-const.php
+++ b/specs/const/native-const.php
@@ -32,8 +32,8 @@ return [
         'exclude-classes' => [],
         'exclude-functions' => [],
 
-        'registered-classes' => [],
-        'registered-functions' => [],
+        'expected-recorded-classes' => [],
+        'expected-recorded-functions' => [],
     ],
 
     'Internal function in a namespace' => <<<'PHP'

--- a/specs/exp/cast.php
+++ b/specs/exp/cast.php
@@ -32,8 +32,8 @@ return [
         'exclude-classes' => [],
         'exclude-functions' => [],
 
-        'registered-classes' => [],
-        'registered-functions' => [],
+        'expected-recorded-classes' => [],
+        'expected-recorded-functions' => [],
     ],
 
     'Cast variable' => <<<'PHP'

--- a/specs/exp/catch.php
+++ b/specs/exp/catch.php
@@ -32,8 +32,8 @@ return [
         'exclude-classes' => [],
         'exclude-functions' => [],
 
-        'registered-classes' => [],
-        'registered-functions' => [],
+        'expected-recorded-classes' => [],
+        'expected-recorded-functions' => [],
     ],
 
     'Catch an internal class' => <<<'PHP'

--- a/specs/exp/coalescing-assignment.php
+++ b/specs/exp/coalescing-assignment.php
@@ -33,8 +33,8 @@ return [
         'exclude-classes' => [],
         'exclude-functions' => [],
 
-        'registered-classes' => [],
-        'registered-functions' => [],
+        'expected-recorded-classes' => [],
+        'expected-recorded-functions' => [],
     ],
 
     'Instance of an internal class' => <<<'PHP'

--- a/specs/exp/instanceof.php
+++ b/specs/exp/instanceof.php
@@ -32,8 +32,8 @@ return [
         'exclude-classes' => [],
         'exclude-functions' => [],
 
-        'registered-classes' => [],
-        'registered-functions' => [],
+        'expected-recorded-classes' => [],
+        'expected-recorded-functions' => [],
     ],
 
     'Instance of an internal class' => <<<'PHP'

--- a/specs/func-arrow/global-scope.php
+++ b/specs/func-arrow/global-scope.php
@@ -33,8 +33,8 @@ return [
         'exclude-classes' => [],
         'exclude-functions' => [],
 
-        'registered-classes' => [],
-        'registered-functions' => [],
+        'expected-recorded-classes' => [],
+        'expected-recorded-functions' => [],
     ],
 
     'Global function call in the global scope' => <<<'PHP'

--- a/specs/func-arrow/namespace-with-use-stmt.php
+++ b/specs/func-arrow/namespace-with-use-stmt.php
@@ -33,8 +33,8 @@ return [
         'exclude-classes' => [],
         'exclude-functions' => [],
 
-        'registered-classes' => [],
-        'registered-functions' => [],
+        'expected-recorded-classes' => [],
+        'expected-recorded-functions' => [],
     ],
 
     'Global function call in the global scope' => <<<'PHP'

--- a/specs/func-arrow/namespace.php
+++ b/specs/func-arrow/namespace.php
@@ -33,8 +33,8 @@ return [
         'exclude-classes' => [],
         'exclude-functions' => [],
 
-        'registered-classes' => [],
-        'registered-functions' => [],
+        'expected-recorded-classes' => [],
+        'expected-recorded-functions' => [],
     ],
 
     'Global function call in the global scope' => <<<'PHP'

--- a/specs/func-closure/global.php
+++ b/specs/func-closure/global.php
@@ -32,8 +32,8 @@ return [
         'exclude-classes' => [],
         'exclude-functions' => [],
 
-        'registered-classes' => [],
-        'registered-functions' => [],
+        'expected-recorded-classes' => [],
+        'expected-recorded-functions' => [],
     ],
 
     'Global function call in the global scope' => <<<'PHP'

--- a/specs/func-closure/namespace-with-use-stmt.php
+++ b/specs/func-closure/namespace-with-use-stmt.php
@@ -32,8 +32,8 @@ return [
         'exclude-classes' => [],
         'exclude-functions' => [],
 
-        'registered-classes' => [],
-        'registered-functions' => [],
+        'expected-recorded-classes' => [],
+        'expected-recorded-functions' => [],
     ],
 
     'Global function call in the global scope' => <<<'PHP'

--- a/specs/func-closure/namespace.php
+++ b/specs/func-closure/namespace.php
@@ -32,8 +32,8 @@ return [
         'exclude-classes' => [],
         'exclude-functions' => [],
 
-        'registered-classes' => [],
-        'registered-functions' => [],
+        'expected-recorded-classes' => [],
+        'expected-recorded-functions' => [],
     ],
 
     'Global function call in the global scope' => <<<'PHP'

--- a/specs/func-declaration/global.php
+++ b/specs/func-declaration/global.php
@@ -32,12 +32,12 @@ return [
         'exclude-classes' => [],
         'exclude-functions' => [],
 
-        'registered-classes' => [],
-        'registered-functions' => [],
+        'expected-recorded-classes' => [],
+        'expected-recorded-functions' => [],
     ],
 
     'Simple function declaration' => [
-        'registered-functions' => [
+        'expected-recorded-functions' => [
             ['foo', 'Humbug\foo'],
         ],
         'payload' => <<<'PHP'
@@ -59,7 +59,7 @@ PHP
 
     'Simple whitelisted function' => [
         'whitelist' => ['foo'],
-        'registered-functions' => [
+        'expected-recorded-functions' => [
             ['foo', 'Humbug\foo'],
         ],
         'payload' => <<<'PHP'
@@ -82,7 +82,7 @@ PHP
     'Simple whitelisted function with global functions non whitelisted' => [
         'expose-global-functions' => false,
         'whitelist' => ['foo'],
-        'registered-functions' => [
+        'expected-recorded-functions' => [
             ['foo', 'Humbug\foo'],
         ],
         'payload' => <<<'PHP'
@@ -104,10 +104,10 @@ PHP
 
     'Function declaration in the global namespace' => [
         'whitelist' => ['X\Y', 'BAR_CONST'],
-        'registered-classes' => [
+        'expected-recorded-classes' => [
             ['X\Y', 'Humbug\X\Y'],
         ],
-        'registered-functions' => [
+        'expected-recorded-functions' => [
             ['foo', 'Humbug\foo'],
         ],
         'payload' => <<<'PHP'
@@ -174,7 +174,7 @@ PHP
 
     'Function declaration in the global namespace with globally whitelisted constants' => [
         'expose-global-constants' => true,
-        'registered-functions' => [
+        'expected-recorded-functions' => [
             ['foo', 'Humbug\foo'],
         ],
         'payload' => <<<'PHP'
@@ -195,10 +195,10 @@ PHP
 
     'Function declaration in the global namespace with use statements' => [
         'whitelist' => ['X\Y'],
-        'registered-classes' => [
+        'expected-recorded-classes' => [
             ['X\Y', 'Humbug\X\Y'],
         ],
-        'registered-functions' => [
+        'expected-recorded-functions' => [
             ['foo', 'Humbug\foo'],
         ],
         'payload' => <<<'PHP'
@@ -286,10 +286,10 @@ PHP
 
     'Function declarations with return types in the global namespace with use statements' => [
         'whitelist' => ['X\Y'],
-        'registered-classes' => [
+        'expected-recorded-classes' => [
             ['X\Y', 'Humbug\X\Y'],
         ],
-        'registered-functions' => [
+        'expected-recorded-functions' => [
             ['foo', 'Humbug\foo'],
         ],
         'payload' => <<<'PHP'

--- a/specs/func-declaration/method.php
+++ b/specs/func-declaration/method.php
@@ -32,13 +32,13 @@ return [
         'exclude-classes' => [],
         'exclude-functions' => [],
 
-        'registered-classes' => [],
-        'registered-functions' => [],
+        'expected-recorded-classes' => [],
+        'expected-recorded-functions' => [],
     ],
 
     'Method declarations' => [
         'whitelist' => ['X\Y', 'BAR_CONST'],
-        'registered-classes' => [
+        'expected-recorded-classes' => [
             ['X\Y', 'Humbug\X\Y'],
         ],
         'payload' => <<<'PHP'
@@ -126,7 +126,7 @@ PHP
 
     'Method declarations with return types' => [
         'whitelist' => ['X\Y'],
-        'registered-classes' => [
+        'expected-recorded-classes' => [
             ['X\Y', 'Humbug\X\Y'],
         ],
         'payload' => <<<'PHP'

--- a/specs/func-declaration/namespace.php
+++ b/specs/func-declaration/namespace.php
@@ -32,8 +32,8 @@ return [
         'exclude-classes' => [],
         'exclude-functions' => [],
 
-        'registered-classes' => [],
-        'registered-functions' => [],
+        'expected-recorded-classes' => [],
+        'expected-recorded-functions' => [],
     ],
 
     'Simple function declaration' => <<<'PHP'
@@ -57,7 +57,7 @@ PHP
 
     'Simple whitelisted function' => [
         'whitelist' => ['Acme\foo'],
-        'registered-functions' => [
+        'expected-recorded-functions' => [
             ['Acme\foo', 'Humbug\Acme\foo'],
         ],
         'payload' => <<<'PHP'
@@ -81,7 +81,7 @@ PHP
 
     'Function declaration in a namespace' => [
         'whitelist' => ['X\Y'],
-        'registered-classes' => [
+        'expected-recorded-classes' => [
             ['X\Y', 'Humbug\X\Y'],
         ],
         'payload' => <<<'PHP'
@@ -168,7 +168,7 @@ PHP
 
     'Function declaration in a namespace with whitelisted classes' => [
         'whitelist' => ['X\Y'],
-        'registered-classes' => [
+        'expected-recorded-classes' => [
             ['X\Y', 'Humbug\X\Y'],
         ],
         'payload' => <<<'PHP'
@@ -255,7 +255,7 @@ PHP
 
     'Function declaration in a namespace with use statements' => [
         'whitelist' => ['X\Y'],
-        'registered-classes' => [
+        'expected-recorded-classes' => [
             ['X\Y', 'Humbug\X\Y'],
         ],
         'payload' => <<<'PHP'
@@ -417,7 +417,7 @@ PHP
 
     'Function declarations with return types in a namespace with use statements' => [
         'whitelist' => ['X\Y'],
-        'registered-classes' => [
+        'expected-recorded-classes' => [
             ['X\Y', 'Humbug\X\Y'],
         ],
         'payload' => <<<'PHP'

--- a/specs/function/global-scope-global-func-with-single-level-use-statement-and-alias.php
+++ b/specs/function/global-scope-global-func-with-single-level-use-statement-and-alias.php
@@ -32,8 +32,8 @@ return [
         'exclude-classes' => [],
         'exclude-functions' => [],
 
-        'registered-classes' => [],
-        'registered-functions' => [],
+        'expected-recorded-classes' => [],
+        'expected-recorded-functions' => [],
     ],
 
     'Global function call imported with a use statement in the global scope' => <<<'PHP'
@@ -55,7 +55,7 @@ PHP
 
     'Global function call imported with a use statement in the global scope with global functions whitelisted' => [
         'expose-global-functions' => true,
-        'registered-functions' => [
+        'expected-recorded-functions' => [
             ['main', 'Humbug\main'],
         ],
         'payload' => <<<'PHP'
@@ -94,7 +94,7 @@ PHP
 
     'Global FQ function call imported with a use statement in the global scope with global functions whitelisted' => [
         'expose-global-functions' => true,
-        'registered-functions' => [
+        'expected-recorded-functions' => [
             ['foo', 'Humbug\foo'],
         ],
         'payload' => <<<'PHP'

--- a/specs/function/global-scope-global-func-with-single-level-use-statement.php
+++ b/specs/function/global-scope-global-func-with-single-level-use-statement.php
@@ -32,8 +32,8 @@ return [
         'exclude-classes' => [],
         'exclude-functions' => [],
 
-        'registered-classes' => [],
-        'registered-functions' => [],
+        'expected-recorded-classes' => [],
+        'expected-recorded-functions' => [],
     ],
 
     'Global function call imported with a use statement in the global scope' => <<<'PHP'
@@ -72,7 +72,7 @@ PHP
 
     'Global function call imported with a use statement in the global scope with global functions whitelisted' => [
         'expose-global-functions' => true,
-        'registered-functions' => [
+        'expected-recorded-functions' => [
             ['main', 'Humbug\main'],
         ],
         'payload' => <<<'PHP'
@@ -111,7 +111,7 @@ PHP
 
     'Global FQ function call imported with a use statement in the global scope with global functions whitelisted' => [
         'expose-global-functions' => true,
-        'registered-functions' => [
+        'expected-recorded-functions' => [
             ['main', 'Humbug\main'],
         ],
         'payload' => <<<'PHP'
@@ -133,7 +133,7 @@ PHP
 
     'Uppercase global FQ function call imported with a use statement in the global scope with global functions whitelisted' => [
         'expose-global-functions' => true,
-        'registered-functions' => [
+        'expected-recorded-functions' => [
             ['MAIN', 'Humbug\MAIN'],
         ],
         'payload' => <<<'PHP'

--- a/specs/function/global-scope-global-func.php
+++ b/specs/function/global-scope-global-func.php
@@ -32,8 +32,8 @@ return [
         'exclude-classes' => [],
         'exclude-functions' => [],
 
-        'registered-classes' => [],
-        'registered-functions' => [],
+        'expected-recorded-classes' => [],
+        'expected-recorded-functions' => [],
     ],
 
     'Global function call in the global scope' => <<<'PHP'

--- a/specs/function/global-scope-single-part-namespaced-func-with-single-level-use-and-alias.php
+++ b/specs/function/global-scope-single-part-namespaced-func-with-single-level-use-and-alias.php
@@ -32,8 +32,8 @@ return [
         'exclude-classes' => [],
         'exclude-functions' => [],
 
-        'registered-classes' => [],
-        'registered-functions' => [],
+        'expected-recorded-classes' => [],
+        'expected-recorded-functions' => [],
     ],
 
     'Namespaced function call imported with a partial use statement in the global scope' => <<<'PHP'
@@ -112,7 +112,7 @@ PHP
 
     'Whitelisted namespaced function call imported with a partial use statement in the global scope' => [
         'whitelist' => ['Foo\main'],
-        'registered-functions' => [
+        'expected-recorded-functions' => [
             ['Foo\main', 'Humbug\Foo\main'],
         ],
         'payload' => <<<'PHP'

--- a/specs/function/global-scope-single-part-namespaced-func-with-single-level-use.php
+++ b/specs/function/global-scope-single-part-namespaced-func-with-single-level-use.php
@@ -32,8 +32,8 @@ return [
         'exclude-classes' => [],
         'exclude-functions' => [],
 
-        'registered-classes' => [],
-        'registered-functions' => [],
+        'expected-recorded-classes' => [],
+        'expected-recorded-functions' => [],
     ],
 
     'Namespaced function call imported with a partial use statement in the global scope' => <<<'PHP'
@@ -82,7 +82,7 @@ PHP
 
     'Whitelisted namespaced function call imported with a partial use statement in the global scope' => [
         'whitelist' => ['Foo\main'],
-        'registered-functions' => [
+        'expected-recorded-functions' => [
             ['Foo\main', 'Humbug\Foo\main'],
         ],
         'payload' => <<<'PHP'

--- a/specs/function/global-scope-single-part-namespaced-func.php
+++ b/specs/function/global-scope-single-part-namespaced-func.php
@@ -32,8 +32,8 @@ return [
         'exclude-classes' => [],
         'exclude-functions' => [],
 
-        'registered-classes' => [],
-        'registered-functions' => [],
+        'expected-recorded-classes' => [],
+        'expected-recorded-functions' => [],
     ],
 
     'Namespaced function call' => <<<'PHP'
@@ -66,7 +66,7 @@ PHP
 
     'Whitelisted namespaced function call' => [
         'whitelist' => ['PHPUnit\main'],
-        'registered-functions' => [
+        'expected-recorded-functions' => [
             ['PHPUnit\main', 'Humbug\PHPUnit\main'],
         ],
         'payload' => <<<'PHP'
@@ -85,7 +85,7 @@ PHP
 
     'FQ whitelisted namespaced function call' => [
         'whitelist' => ['PHPUnit\main'],
-        'registered-functions' => [
+        'expected-recorded-functions' => [
             ['PHPUnit\main', 'Humbug\PHPUnit\main'],
         ],
         'payload' => <<<'PHP'

--- a/specs/function/namespace-global-func-with-single-level-use-statement-and-alias.php
+++ b/specs/function/namespace-global-func-with-single-level-use-statement-and-alias.php
@@ -32,8 +32,8 @@ return [
         'exclude-classes' => [],
         'exclude-functions' => [],
 
-        'registered-classes' => [],
-        'registered-functions' => [],
+        'expected-recorded-classes' => [],
+        'expected-recorded-functions' => [],
     ],
 
     'Global function call imported with a use statement in a namespace' => <<<'PHP'

--- a/specs/function/namespace-global-func-with-single-level-use-statement.php
+++ b/specs/function/namespace-global-func-with-single-level-use-statement.php
@@ -32,8 +32,8 @@ return [
         'exclude-classes' => [],
         'exclude-functions' => [],
 
-        'registered-classes' => [],
-        'registered-functions' => [],
+        'expected-recorded-classes' => [],
+        'expected-recorded-functions' => [],
     ],
 
     'Global function call imported with a use statement in a namespace' => <<<'PHP'

--- a/specs/function/namespace-global-func.php
+++ b/specs/function/namespace-global-func.php
@@ -32,8 +32,8 @@ return [
         'exclude-classes' => [],
         'exclude-functions' => [],
 
-        'registered-classes' => [],
-        'registered-functions' => [],
+        'expected-recorded-classes' => [],
+        'expected-recorded-functions' => [],
     ],
 
     'Global function call in a namespace' => <<<'PHP'

--- a/specs/function/namespace-global-scope-func.php
+++ b/specs/function/namespace-global-scope-func.php
@@ -32,8 +32,8 @@ return [
         'exclude-classes' => [],
         'exclude-functions' => [],
 
-        'registered-classes' => [],
-        'registered-functions' => [],
+        'expected-recorded-classes' => [],
+        'expected-recorded-functions' => [],
     ],
 
     // We don't do anything as there is no ways to distinguish between a namespaced function call

--- a/specs/function/namespace-single-part-namespaced-func.php
+++ b/specs/function/namespace-single-part-namespaced-func.php
@@ -32,8 +32,8 @@ return [
         'exclude-classes' => [],
         'exclude-functions' => [],
 
-        'registered-classes' => [],
-        'registered-functions' => [],
+        'expected-recorded-classes' => [],
+        'expected-recorded-functions' => [],
     ],
 
     'Namespaced function call' => <<<'PHP'
@@ -89,7 +89,7 @@ PHP
 
     'FQ whitelisted namespaced function call' => [
         'whitelist' => ['PHPUnit\main'],
-        'registered-functions' => [
+        'expected-recorded-functions' => [
             ['PHPUnit\main', 'Humbug\PHPUnit\main'],
         ],
         'payload' => <<<'PHP'

--- a/specs/function/native-func.php
+++ b/specs/function/native-func.php
@@ -32,8 +32,8 @@ return [
         'exclude-classes' => [],
         'exclude-functions' => [],
 
-        'registered-classes' => [],
-        'registered-functions' => [],
+        'expected-recorded-classes' => [],
+        'expected-recorded-functions' => [],
     ],
 
     'Internal function in a namespace' => <<<'PHP'

--- a/specs/function/whitelist-func-existence-checked.php
+++ b/specs/function/whitelist-func-existence-checked.php
@@ -32,8 +32,8 @@ return [
         'exclude-classes' => [],
         'exclude-functions' => [],
 
-        'registered-classes' => [],
-        'registered-functions' => [],
+        'expected-recorded-classes' => [],
+        'expected-recorded-functions' => [],
     ],
 
     'Non whitelisted global function call' => <<<'PHP'
@@ -52,7 +52,7 @@ PHP
 
     'Whitelisted global function call' => [
         'whitelist' => ['main'],
-        'registered-functions' => [
+        'expected-recorded-functions' => [
             ['main', 'Humbug\main'],
         ],
         'payload' => <<<'PHP'
@@ -71,7 +71,7 @@ PHP
 
     'Global function call with whitelisted global functions' => [
         'expose-global-functions' => true,
-        'registered-functions' => [
+        'expected-recorded-functions' => [
             ['main', 'Humbug\main'],
         ],
         'payload' => <<<'PHP'
@@ -104,7 +104,7 @@ PHP
 
     'Whitelisted namespaced function call' => [
         'whitelist' => ['Acme\main'],
-        'registered-functions' => [
+        'expected-recorded-functions' => [
             ['Acme\main', 'Humbug\Acme\main'],
         ],
         'payload' => <<<'PHP'

--- a/specs/function/whitelist-func-used.php
+++ b/specs/function/whitelist-func-used.php
@@ -32,8 +32,8 @@ return [
         'exclude-classes' => [],
         'exclude-functions' => [],
 
-        'registered-classes' => [],
-        'registered-functions' => [],
+        'expected-recorded-classes' => [],
+        'expected-recorded-functions' => [],
     ],
 
     'Non whitelisted global function call' => <<<'PHP'
@@ -52,7 +52,7 @@ PHP
 
     'Whitelisted global function call' => [
         'whitelist' => ['main'],
-        'registered-functions' => [
+        'expected-recorded-functions' => [
             ['main', 'Humbug\main'],
         ],
         'payload' => <<<'PHP'
@@ -71,7 +71,7 @@ PHP
 
     'Global function call with whitelisted global functions' => [
         'expose-global-functions' => true,
-        'registered-functions' => [
+        'expected-recorded-functions' => [
             ['main', 'Humbug\main'],
         ],
         'payload' => <<<'PHP'
@@ -104,7 +104,7 @@ PHP
 
     'Whitelisted namespaced function call' => [
         'whitelist' => ['Acme\main'],
-        'registered-functions' => [],   // Nothing registered here since the FQ could not be resolved
+        'expected-recorded-functions' => [],   // Nothing registered here since the FQ could not be resolved
         'payload' => <<<'PHP'
 <?php
 

--- a/specs/misc/class-FQ.php
+++ b/specs/misc/class-FQ.php
@@ -32,13 +32,13 @@ return [
         'exclude-classes' => [],
         'exclude-functions' => [],
 
-        'registered-classes' => [],
-        'registered-functions' => [],
+        'expected-recorded-classes' => [],
+        'expected-recorded-functions' => [],
     ],
 
     'Different kind of whitelisted class constant calls in the global scope' => [
         'whitelist' => ['Foo\Bar', 'Foo\Bar\Poz'],
-        'registered-classes' => [
+        'expected-recorded-classes' => [
             ['Foo\Bar', 'Humbug\Foo\Bar'],
             ['Foo\Bar\Poz', 'Humbug\Foo\Bar\Poz'],
         ],
@@ -200,7 +200,7 @@ PHP
             'A\Aoz',
             'A\Aoo\Aoz\Poz',
         ],
-        'registered-classes' => [
+        'expected-recorded-classes' => [
             ['Foo\Bar', 'Humbug\Foo\Bar'],
             ['Foo\Bar\Poz', 'Humbug\Foo\Bar\Poz'],
 

--- a/specs/misc/custom-internal-symbols.php
+++ b/specs/misc/custom-internal-symbols.php
@@ -32,8 +32,8 @@ return [
         'exclude-classes' => [],
         'exclude-functions' => [],
 
-        'registered-classes' => [],
-        'registered-functions' => [],
+        'expected-recorded-classes' => [],
+        'expected-recorded-functions' => [],
     ],
 
     'Known non-internal symbols (sanity test)' => <<<'PHP'

--- a/specs/misc/date.php
+++ b/specs/misc/date.php
@@ -32,8 +32,8 @@ return [
         'exclude-classes' => [],
         'exclude-functions' => [],
 
-        'registered-classes' => [],
-        'registered-functions' => [],
+        'expected-recorded-classes' => [],
+        'expected-recorded-functions' => [],
     ],
 
     'date values' => <<<'PHP'

--- a/specs/misc/eval.php
+++ b/specs/misc/eval.php
@@ -32,8 +32,8 @@ return [
         'exclude-classes' => [],
         'exclude-functions' => [],
 
-        'registered-classes' => [],
-        'registered-functions' => [],
+        'expected-recorded-classes' => [],
+        'expected-recorded-functions' => [],
     ],
 
     'string' => <<<'PHP'
@@ -187,7 +187,7 @@ PHP
 
      'string with whitelisted function' => [
          'whitelist' => ['Acme\foo'],
-         'registered-functions' => [
+         'expected-recorded-functions' => [
              ['Acme\foo', 'Humbug\Acme\foo'],
          ],
          'payload' => <<<'PHP'

--- a/specs/misc/internal-symbols.php
+++ b/specs/misc/internal-symbols.php
@@ -32,8 +32,8 @@ return [
         'exclude-classes' => [],
         'exclude-functions' => [],
 
-        'registered-classes' => [],
-        'registered-functions' => [],
+        'expected-recorded-classes' => [],
+        'expected-recorded-functions' => [],
     ],
 
     'Known internal symbols that used to or still require a patch in the Reflector' => <<<'PHP'

--- a/specs/misc/match.php
+++ b/specs/misc/match.php
@@ -33,8 +33,8 @@ return [
         'exclude-classes' => [],
         'exclude-functions' => [],
 
-        'registered-classes' => [],
-        'registered-functions' => [],
+        'expected-recorded-classes' => [],
+        'expected-recorded-functions' => [],
     ],
     'match' => <<<'PHP'
 <?php declare(strict_types=1);

--- a/specs/misc/misc.php
+++ b/specs/misc/misc.php
@@ -32,8 +32,8 @@ return [
         'exclude-classes' => [],
         'exclude-functions' => [],
 
-        'registered-classes' => [],
-        'registered-functions' => [],
+        'expected-recorded-classes' => [],
+        'expected-recorded-functions' => [],
     ],
 
     'Empty file' => <<<'PHP'

--- a/specs/misc/name-resolution.php
+++ b/specs/misc/name-resolution.php
@@ -32,12 +32,12 @@ return [
         'exclude-classes' => [],
         'exclude-functions' => [],
 
-        'registered-classes' => [],
-        'registered-functions' => [],
+        'expected-recorded-classes' => [],
+        'expected-recorded-functions' => [],
     ],
 
     'Internal class & function with the same name' => [
-        'registered-functions' => [],
+        'expected-recorded-functions' => [],
         'payload' => <<<'PHP'
 <?php
 
@@ -69,7 +69,7 @@ PHP
     ],
 
     'Internal class & const with the same name' => [
-        'registered-functions' => [],
+        'expected-recorded-functions' => [],
         'payload' => <<<'PHP'
 <?php
 

--- a/specs/misc/nowdoc.php
+++ b/specs/misc/nowdoc.php
@@ -32,8 +32,8 @@ return [
         'exclude-classes' => [],
         'exclude-functions' => [],
 
-        'registered-classes' => [],
-        'registered-functions' => [],
+        'expected-recorded-classes' => [],
+        'expected-recorded-functions' => [],
     ],
 
     'string' => <<<'PHP'

--- a/specs/misc/null.php
+++ b/specs/misc/null.php
@@ -32,8 +32,8 @@ return [
         'exclude-classes' => [],
         'exclude-functions' => [],
 
-        'registered-classes' => [],
-        'registered-functions' => [],
+        'expected-recorded-classes' => [],
+        'expected-recorded-functions' => [],
     ],
 
     'Usages of null' => <<<'PHP'

--- a/specs/misc/unicode-string.php
+++ b/specs/misc/unicode-string.php
@@ -32,8 +32,8 @@ return [
         'exclude-classes' => [],
         'exclude-functions' => [],
 
-        'registered-classes' => [],
-        'registered-functions' => [],
+        'expected-recorded-classes' => [],
+        'expected-recorded-functions' => [],
     ],
 
     // https://github.com/humbug/php-scoper/issues/464

--- a/specs/misc/whitelist-case-sensitiveness.php
+++ b/specs/misc/whitelist-case-sensitiveness.php
@@ -32,13 +32,13 @@ return [
         'exclude-classes' => [],
         'exclude-functions' => [],
 
-        'registered-classes' => [],
-        'registered-functions' => [],
+        'expected-recorded-classes' => [],
+        'expected-recorded-functions' => [],
     ],
 
     'Class whitelists are case insensitive' => [
         'whitelist' => ['acme\foo'],
-        'registered-classes' => [
+        'expected-recorded-classes' => [
             ['Acme\Foo', 'Humbug\Acme\Foo'],
         ],
         'payload' => <<<'PHP'

--- a/specs/namespace/after-hashbang.php
+++ b/specs/namespace/after-hashbang.php
@@ -32,8 +32,8 @@ return [
         'exclude-classes' => [],
         'exclude-functions' => [],
 
-        'registered-classes' => [],
-        'registered-functions' => [],
+        'expected-recorded-classes' => [],
+        'expected-recorded-functions' => [],
     ],
 
     <<<'PHP'

--- a/specs/namespace/braces.php
+++ b/specs/namespace/braces.php
@@ -32,8 +32,8 @@ return [
         'exclude-classes' => [],
         'exclude-functions' => [],
 
-        'registered-classes' => [],
-        'registered-functions' => [],
+        'expected-recorded-classes' => [],
+        'expected-recorded-functions' => [],
     ],
 
     'One level namespace' => <<<'PHP'

--- a/specs/namespace/creation-for-whitelist.php
+++ b/specs/namespace/creation-for-whitelist.php
@@ -32,8 +32,8 @@ return [
         'exclude-classes' => [],
         'exclude-functions' => [],
 
-        'registered-classes' => [],
-        'registered-functions' => [],
+        'expected-recorded-classes' => [],
+        'expected-recorded-functions' => [],
     ],
 
     'Single class should receive namespace' => <<<'PHP'

--- a/specs/namespace/no-braces.php
+++ b/specs/namespace/no-braces.php
@@ -32,8 +32,8 @@ return [
         'exclude-classes' => [],
         'exclude-functions' => [],
 
-        'registered-classes' => [],
-        'registered-functions' => [],
+        'expected-recorded-classes' => [],
+        'expected-recorded-functions' => [],
     ],
 
     'Root namespace' => <<<'PHP'

--- a/specs/namespace/outside-statements.php
+++ b/specs/namespace/outside-statements.php
@@ -32,8 +32,8 @@ return [
         'exclude-classes' => [],
         'exclude-functions' => [],
 
-        'registered-classes' => [],
-        'registered-functions' => [],
+        'expected-recorded-classes' => [],
+        'expected-recorded-functions' => [],
     ],
 
     'Declare statement' => <<<'PHP'

--- a/specs/new/global-scope-single-part-with-single-level-use-statement-and-alias.php
+++ b/specs/new/global-scope-single-part-with-single-level-use-statement-and-alias.php
@@ -32,8 +32,8 @@ return [
         'exclude-classes' => [],
         'exclude-functions' => [],
 
-        'registered-classes' => [],
-        'registered-functions' => [],
+        'expected-recorded-classes' => [],
+        'expected-recorded-functions' => [],
     ],
 
     'New statement call of a class belonging to the global namespace imported via an aliased use statement' => [

--- a/specs/new/global-scope-single-part-with-single-level-use-statement.php
+++ b/specs/new/global-scope-single-part-with-single-level-use-statement.php
@@ -32,8 +32,8 @@ return [
         'exclude-classes' => [],
         'exclude-functions' => [],
 
-        'registered-classes' => [],
-        'registered-functions' => [],
+        'expected-recorded-classes' => [],
+        'expected-recorded-functions' => [],
     ],
 
     'New statement call of a class belonging to the global namespace imported via a use statement' => [

--- a/specs/new/global-scope-single-part.php
+++ b/specs/new/global-scope-single-part.php
@@ -32,8 +32,8 @@ return [
         'exclude-classes' => [],
         'exclude-functions' => [],
 
-        'registered-classes' => [],
-        'registered-functions' => [],
+        'expected-recorded-classes' => [],
+        'expected-recorded-functions' => [],
     ],
 
     'New statement call of a class belonging to the global namespace' => [

--- a/specs/new/global-scope-two-parts-with-single-level-use-and-alias.php
+++ b/specs/new/global-scope-two-parts-with-single-level-use-and-alias.php
@@ -32,8 +32,8 @@ return [
         'exclude-classes' => [],
         'exclude-functions' => [],
 
-        'registered-classes' => [],
-        'registered-functions' => [],
+        'expected-recorded-classes' => [],
+        'expected-recorded-functions' => [],
     ],
 
     'New statement call of a namespaced class partially imported with an aliased use statement' => [
@@ -190,7 +190,7 @@ PHP
 
     'New statement call of a whitelisted namespaced class partially imported with an aliased use statement' => [
         'whitelist' => ['Foo\Bar'],
-        'registered-classes' => [
+        'expected-recorded-classes' => [
             ['Foo\Bar', 'Humbug\Foo\Bar'],
         ],
         'payload' => <<<'PHP'
@@ -233,7 +233,7 @@ PHP
 
     'New statement call of a whitelisted namespaced class imported with an aliased use statement' => [
         'whitelist' => ['Foo\Bar'],
-        'registered-classes' => [
+        'expected-recorded-classes' => [
             ['Foo\Bar', 'Humbug\Foo\Bar'],
         ],
         'payload' => <<<'PHP'

--- a/specs/new/global-scope-two-parts-with-single-level-use.php
+++ b/specs/new/global-scope-two-parts-with-single-level-use.php
@@ -32,8 +32,8 @@ return [
         'exclude-classes' => [],
         'exclude-functions' => [],
 
-        'registered-classes' => [],
-        'registered-functions' => [],
+        'expected-recorded-classes' => [],
+        'expected-recorded-functions' => [],
     ],
 
     'New statement call of a namespaced class partially imported with a use statement' => [
@@ -76,7 +76,7 @@ PHP
 
     'New statement call of a whitelisted namespaced class partially imported with a use statement' => [
         'whitelist' => ['Foo\Bar'],
-        'registered-classes' => [
+        'expected-recorded-classes' => [
             ['Foo\Bar', 'Humbug\Foo\Bar'],
         ],
         'payload' => <<<'PHP'
@@ -157,7 +157,7 @@ PHP
 
     'FQ new statement call of a whitelisted namespaced class partially imported with a use statement' => [
         'whitelist' => ['Foo\Bar'],
-        'registered-classes' => [
+        'expected-recorded-classes' => [
             ['Foo\Bar', 'Humbug\Foo\Bar'],
         ],
         'payload' => <<<'PHP'
@@ -238,7 +238,7 @@ PHP
 
     'New statement call of a whitelisted namespaced class imported with a use statement' => [
         'whitelist' => ['Foo\Bar'],
-        'registered-classes' => [
+        'expected-recorded-classes' => [
             ['Foo\Bar', 'Humbug\Foo\Bar'],
         ],
         'payload' => <<<'PHP'
@@ -323,7 +323,7 @@ PHP
 
     'FQ new statement call of a whitelisted namespaced class imported with a use statement' => [
         'whitelist' => ['Foo\Bar'],
-        'registered-classes' => [
+        'expected-recorded-classes' => [
             ['Foo\Bar', 'Humbug\Foo\Bar'],
         ],
         'payload' => <<<'PHP'

--- a/specs/new/global-scope-two-parts.php
+++ b/specs/new/global-scope-two-parts.php
@@ -32,8 +32,8 @@ return [
         'exclude-classes' => [],
         'exclude-functions' => [],
 
-        'registered-classes' => [],
-        'registered-functions' => [],
+        'expected-recorded-classes' => [],
+        'expected-recorded-functions' => [],
     ],
 
     'New statement call of a namespaced class' => [
@@ -90,7 +90,7 @@ PHP
 
     'New statement call of a whitelisted namespaced class' => [
         'whitelist' => ['Foo\Bar'],
-        'registered-classes' => [
+        'expected-recorded-classes' => [
             ['Foo\Bar', 'Humbug\Foo\Bar'],
         ],
         'payload' => <<<'PHP'
@@ -121,7 +121,7 @@ PHP
 
     'FQ new statement call of a whitelisted namespaced class' => [
         'whitelist' => ['Foo\Bar'],
-        'registered-classes' => [
+        'expected-recorded-classes' => [
             ['Foo\Bar', 'Humbug\Foo\Bar'],
         ],
         'payload' => <<<'PHP'

--- a/specs/new/namespace-single-part-with-single-level-use-statement.php
+++ b/specs/new/namespace-single-part-with-single-level-use-statement.php
@@ -33,8 +33,8 @@ return [
         'exclude-classes' => [],
         'exclude-functions' => [],
 
-        'registered-classes' => [],
-        'registered-functions' => [],
+        'expected-recorded-classes' => [],
+        'expected-recorded-functions' => [],
     ],
 
     'New statement call of a class' => [

--- a/specs/new/namespace-single-part.php
+++ b/specs/new/namespace-single-part.php
@@ -32,8 +32,8 @@ return [
         'exclude-classes' => [],
         'exclude-functions' => [],
 
-        'registered-classes' => [],
-        'registered-functions' => [],
+        'expected-recorded-classes' => [],
+        'expected-recorded-functions' => [],
     ],
 
     'New statement call of a class' => [

--- a/specs/new/namespace-two-parts-with-single-level-use.php
+++ b/specs/new/namespace-two-parts-with-single-level-use.php
@@ -32,8 +32,8 @@ return [
         'exclude-classes' => [],
         'exclude-functions' => [],
 
-        'registered-classes' => [],
-        'registered-functions' => [],
+        'expected-recorded-classes' => [],
+        'expected-recorded-functions' => [],
     ],
 
     'New statement call of a class belonging to the global namespace imported via a use statement' => [

--- a/specs/new/namespace-two-parts-with-two-level-use.php
+++ b/specs/new/namespace-two-parts-with-two-level-use.php
@@ -32,8 +32,8 @@ return [
         'exclude-classes' => [],
         'exclude-functions' => [],
 
-        'registered-classes' => [],
-        'registered-functions' => [],
+        'expected-recorded-classes' => [],
+        'expected-recorded-functions' => [],
     ],
 
     'New statement call of a class via a use statement' => [
@@ -114,7 +114,7 @@ PHP
 
     'New statement call of a whitelisted class via a use statement' => [
         'whitelist' => ['X\Foo\Bar'],
-        'registered-classes' => [
+        'expected-recorded-classes' => [
             ['X\Foo\Bar', 'Humbug\X\Foo\Bar'],
         ],
         'payload' => <<<'PHP'

--- a/specs/new/namespace-two-parts.php
+++ b/specs/new/namespace-two-parts.php
@@ -32,8 +32,8 @@ return [
         'exclude-classes' => [],
         'exclude-functions' => [],
 
-        'registered-classes' => [],
-        'registered-functions' => [],
+        'expected-recorded-classes' => [],
+        'expected-recorded-functions' => [],
     ],
 
     'New statement call of a class' => [

--- a/specs/special-keywords/self-parent-return-type.php
+++ b/specs/special-keywords/self-parent-return-type.php
@@ -32,8 +32,8 @@ return [
         'exclude-classes' => [],
         'exclude-functions' => [],
 
-        'registered-classes' => [],
-        'registered-functions' => [],
+        'expected-recorded-classes' => [],
+        'expected-recorded-functions' => [],
     ],
 
     'Usage for classes in the global scope' => <<<'PHP'

--- a/specs/special-keywords/self-static-parent-const.php
+++ b/specs/special-keywords/self-static-parent-const.php
@@ -32,8 +32,8 @@ return [
         'exclude-classes' => [],
         'exclude-functions' => [],
 
-        'registered-classes' => [],
-        'registered-functions' => [],
+        'expected-recorded-classes' => [],
+        'expected-recorded-functions' => [],
     ],
 
     'Usage for classes in the global scope' => <<<'PHP'

--- a/specs/special-keywords/self-static-parent-method.php
+++ b/specs/special-keywords/self-static-parent-method.php
@@ -32,8 +32,8 @@ return [
         'exclude-classes' => [],
         'exclude-functions' => [],
 
-        'registered-classes' => [],
-        'registered-functions' => [],
+        'expected-recorded-classes' => [],
+        'expected-recorded-functions' => [],
     ],
 
     'Usage for classes in the global scope' => <<<'PHP'

--- a/specs/special-keywords/self-static-parent-static-var.php
+++ b/specs/special-keywords/self-static-parent-static-var.php
@@ -32,8 +32,8 @@ return [
         'exclude-classes' => [],
         'exclude-functions' => [],
 
-        'registered-classes' => [],
-        'registered-functions' => [],
+        'expected-recorded-classes' => [],
+        'expected-recorded-functions' => [],
     ],
 
     'Usage for classes in the global scope' => <<<'PHP'

--- a/specs/static-method/global-scope-single-part-with-single-level-use-statement-and-alias.php
+++ b/specs/static-method/global-scope-single-part-with-single-level-use-statement-and-alias.php
@@ -32,8 +32,8 @@ return [
         'exclude-classes' => [],
         'exclude-functions' => [],
 
-        'registered-classes' => [],
-        'registered-functions' => [],
+        'expected-recorded-classes' => [],
+        'expected-recorded-functions' => [],
     ],
 
     'Static method call statement of a class belonging to the global namespace imported via an aliased use statement' => <<<'PHP'

--- a/specs/static-method/global-scope-single-part-with-single-level-use-statement.php
+++ b/specs/static-method/global-scope-single-part-with-single-level-use-statement.php
@@ -32,8 +32,8 @@ return [
         'exclude-classes' => [],
         'exclude-functions' => [],
 
-        'registered-classes' => [],
-        'registered-functions' => [],
+        'expected-recorded-classes' => [],
+        'expected-recorded-functions' => [],
     ],
 
     'Static method call statement of a class belonging to the global namespace imported via a use statement' => <<<'PHP'

--- a/specs/static-method/global-scope-single-part.php
+++ b/specs/static-method/global-scope-single-part.php
@@ -32,8 +32,8 @@ return [
         'exclude-classes' => [],
         'exclude-functions' => [],
 
-        'registered-classes' => [],
-        'registered-functions' => [],
+        'expected-recorded-classes' => [],
+        'expected-recorded-functions' => [],
     ],
 
     'Static method call statement of a class belonging to the global namespace' => <<<'PHP'

--- a/specs/static-method/global-scope-two-parts-with-single-level-use-and-alias.php
+++ b/specs/static-method/global-scope-two-parts-with-single-level-use-and-alias.php
@@ -32,8 +32,8 @@ return [
         'exclude-classes' => [],
         'exclude-functions' => [],
 
-        'registered-classes' => [],
-        'registered-functions' => [],
+        'expected-recorded-classes' => [],
+        'expected-recorded-functions' => [],
     ],
 
     'Static method call statement of a namespaced class partially imported with an aliased use statement' => <<<'PHP'
@@ -173,7 +173,7 @@ PHP
 
     'Static method call statement of a whitelisted namespaced class partially imported with an aliased use statement' => [
         'whitelist' => ['Foo\Bar'],
-        'registered-classes' => [
+        'expected-recorded-classes' => [
             ['Foo\Bar', 'Humbug\Foo\Bar'],
         ],
         'payload' => <<<'PHP'
@@ -216,7 +216,7 @@ PHP
 
     'Static method call statement of a whitelisted namespaced class imported with an aliased use statement' => [
         'whitelist' => ['Foo\Bar'],
-        'registered-classes' => [
+        'expected-recorded-classes' => [
             ['Foo\Bar', 'Humbug\Foo\Bar'],
         ],
         'payload' => <<<'PHP'
@@ -289,7 +289,7 @@ PHP
 
     'FQ static method call statement of a whitelisted namespaced class imported with an aliased use statement' => [
         'whitelist' => ['Foo\Bar'],
-        'registered-classes' => [
+        'expected-recorded-classes' => [
             ['Foo\Bar', 'Humbug\Foo\Bar'],
         ],
         'payload' => <<<'PHP'

--- a/specs/static-method/global-scope-two-parts-with-single-level-use.php
+++ b/specs/static-method/global-scope-two-parts-with-single-level-use.php
@@ -32,8 +32,8 @@ return [
         'exclude-classes' => [],
         'exclude-functions' => [],
 
-        'registered-classes' => [],
-        'registered-functions' => [],
+        'expected-recorded-classes' => [],
+        'expected-recorded-functions' => [],
     ],
 
     'Static method call statement of a namespaced class partially imported with a use statement' => <<<'PHP'
@@ -173,7 +173,7 @@ PHP
 
     'Static method call statement of a whitelisted namespaced class partially imported with a use statement' => [
         'whitelist' => ['Foo\Bar'],
-        'registered-classes' => [
+        'expected-recorded-classes' => [
             ['Foo\Bar', 'Humbug\Foo\Bar'],
         ],
         'payload' => <<<'PHP'
@@ -216,7 +216,7 @@ PHP
 
     'SStatic method call statement of a whitelisted namespaced class partially imported with a use statementtatic method call statement of a whitelisted namespaced class imported with a use statement' => [
         'whitelist' => ['Foo\Bar'],
-        'registered-classes' => [
+        'expected-recorded-classes' => [
             ['Foo\Bar', 'Humbug\Foo\Bar'],
         ],
         'payload' => <<<'PHP'
@@ -250,7 +250,7 @@ PHP
 
     'FQ static method call statement of a whitelisted namespaced class partially imported with a use statement' => [
         'whitelist' => ['Foo\Bar'],
-        'registered-classes' => [
+        'expected-recorded-classes' => [
             ['Foo\Bar', 'Humbug\Foo\Bar'],
         ],
         'payload' => <<<'PHP'
@@ -293,7 +293,7 @@ PHP
 
     'FQ static method call statement of a whitelisted namespaced class imported with a use statement' => [
         'whitelist' => ['Foo\Bar'],
-        'registered-classes' => [
+        'expected-recorded-classes' => [
             ['Foo\Bar', 'Humbug\Foo\Bar'],
         ],
         'payload' => <<<'PHP'

--- a/specs/static-method/global-scope-two-parts.php
+++ b/specs/static-method/global-scope-two-parts.php
@@ -32,8 +32,8 @@ return [
         'exclude-classes' => [],
         'exclude-functions' => [],
 
-        'registered-classes' => [],
-        'registered-functions' => [],
+        'expected-recorded-classes' => [],
+        'expected-recorded-functions' => [],
     ],
 
     'Static method call statement of a namespaced class' => <<<'PHP'
@@ -83,7 +83,7 @@ PHP
 
     'Static method call statement of a namespaced class which has been whitelisted' => [
         'whitelist' => ['Foo\Bar'],
-        'registered-classes' => [
+        'expected-recorded-classes' => [
             ['Foo\Bar', 'Humbug\Foo\Bar'],
         ],
         'payload' => <<<'PHP'
@@ -114,7 +114,7 @@ PHP
 
     'FQ static method call statement of a namespaced class which has been whitelisted' => [
         'whitelist' => ['Foo\Bar'],
-        'registered-classes' => [
+        'expected-recorded-classes' => [
             ['Foo\Bar', 'Humbug\Foo\Bar'],
         ],
         'payload' => <<<'PHP'

--- a/specs/static-method/namespace-single-part-with-single-level-use-statement.php
+++ b/specs/static-method/namespace-single-part-with-single-level-use-statement.php
@@ -33,8 +33,8 @@ return [
         'exclude-classes' => [],
         'exclude-functions' => [],
 
-        'registered-classes' => [],
-        'registered-functions' => [],
+        'expected-recorded-classes' => [],
+        'expected-recorded-functions' => [],
     ],
 
     'Static method call statement of a class' => <<<'PHP'

--- a/specs/static-method/namespace-single-part.php
+++ b/specs/static-method/namespace-single-part.php
@@ -32,8 +32,8 @@ return [
         'exclude-classes' => [],
         'exclude-functions' => [],
 
-        'registered-classes' => [],
-        'registered-functions' => [],
+        'expected-recorded-classes' => [],
+        'expected-recorded-functions' => [],
     ],
 
     'Static method call statement of a class' => <<<'PHP'

--- a/specs/static-method/namespace-two-parts-with-single-level-use.php
+++ b/specs/static-method/namespace-two-parts-with-single-level-use.php
@@ -32,8 +32,8 @@ return [
         'exclude-classes' => [],
         'exclude-functions' => [],
 
-        'registered-classes' => [],
-        'registered-functions' => [],
+        'expected-recorded-classes' => [],
+        'expected-recorded-functions' => [],
     ],
 
     'Static method call statement of a class belonging to the global namespace imported via a use statement' => <<<'PHP'

--- a/specs/static-method/namespace-two-parts-with-two-level-use.php
+++ b/specs/static-method/namespace-two-parts-with-two-level-use.php
@@ -32,8 +32,8 @@ return [
         'exclude-classes' => [],
         'exclude-functions' => [],
 
-        'registered-classes' => [],
-        'registered-functions' => [],
+        'expected-recorded-classes' => [],
+        'expected-recorded-functions' => [],
     ],
 
     'Static method call statement of a class via a use statement' => <<<'PHP'
@@ -112,7 +112,7 @@ PHP
 
     'Static method call statement of a whitelisted class via a use statement' => [
         'whitelist' => ['X\Foo\Bar'],
-        'registered-classes' => [
+        'expected-recorded-classes' => [
             ['X\Foo\Bar', 'Humbug\X\Foo\Bar'],
         ],
         'payload' => <<<'PHP'

--- a/specs/static-method/namespace-two-parts.php
+++ b/specs/static-method/namespace-two-parts.php
@@ -32,8 +32,8 @@ return [
         'exclude-classes' => [],
         'exclude-functions' => [],
 
-        'registered-classes' => [],
-        'registered-functions' => [],
+        'expected-recorded-classes' => [],
+        'expected-recorded-functions' => [],
     ],
 
     'Static method call statement of a class' => <<<'PHP'
@@ -88,7 +88,7 @@ PHP
 
     'Static method call statement of a whitelisted class' => [
         'whitelist' => ['X\Foo\Bar'],
-        'registered-classes' => [
+        'expected-recorded-classes' => [
             ['X\Foo\Bar', 'Humbug\X\Foo\Bar'],
         ],
         'payload' => <<<'PHP'

--- a/specs/string-literal/array-var.php
+++ b/specs/string-literal/array-var.php
@@ -32,8 +32,8 @@ return [
         'exclude-classes' => [],
         'exclude-functions' => [],
 
-        'registered-classes' => [],
-        'registered-functions' => [],
+        'expected-recorded-classes' => [],
+        'expected-recorded-functions' => [],
     ],
 
     'String argument' => <<<'PHP'

--- a/specs/string-literal/class-const-array.php
+++ b/specs/string-literal/class-const-array.php
@@ -32,8 +32,8 @@ return [
         'exclude-classes' => [],
         'exclude-functions' => [],
 
-        'registered-classes' => [],
-        'registered-functions' => [],
+        'expected-recorded-classes' => [],
+        'expected-recorded-functions' => [],
     ],
 
     'FQCN string argument' => <<<'PHP'

--- a/specs/string-literal/class-const.php
+++ b/specs/string-literal/class-const.php
@@ -32,8 +32,8 @@ return [
         'exclude-classes' => [],
         'exclude-functions' => [],
 
-        'registered-classes' => [],
-        'registered-functions' => [],
+        'expected-recorded-classes' => [],
+        'expected-recorded-functions' => [],
     ],
 
     'FQCN string argument' => <<<'PHP'

--- a/specs/string-literal/class-prop.php
+++ b/specs/string-literal/class-prop.php
@@ -32,8 +32,8 @@ return [
         'exclude-classes' => [],
         'exclude-functions' => [],
 
-        'registered-classes' => [],
-        'registered-functions' => [],
+        'expected-recorded-classes' => [],
+        'expected-recorded-functions' => [],
     ],
 
     'FQCN string argument' => <<<'PHP'

--- a/specs/string-literal/class-var.php
+++ b/specs/string-literal/class-var.php
@@ -32,8 +32,8 @@ return [
         'exclude-classes' => [],
         'exclude-functions' => [],
 
-        'registered-classes' => [],
-        'registered-functions' => [],
+        'expected-recorded-classes' => [],
+        'expected-recorded-functions' => [],
     ],
 
     'FQCN string argument' => <<<'PHP'

--- a/specs/string-literal/const.php
+++ b/specs/string-literal/const.php
@@ -32,8 +32,8 @@ return [
         'exclude-classes' => [],
         'exclude-functions' => [],
 
-        'registered-classes' => [],
-        'registered-functions' => [],
+        'expected-recorded-classes' => [],
+        'expected-recorded-functions' => [],
     ],
 
     'FQCN string argument' => <<<'PHP'
@@ -165,7 +165,7 @@ PHP
 
     'FQC constant call on whitelisted class' => [
         'whitelist' => ['Symfony\Component\Yaml\Ya_1'],
-        'registered-classes' => [
+        'expected-recorded-classes' => [
             ['Symfony\Component\Yaml\Ya_1', 'Humbug\Symfony\Component\Yaml\Ya_1'],
         ],
         'payload' => <<<'PHP'

--- a/specs/string-literal/define-value.php
+++ b/specs/string-literal/define-value.php
@@ -32,8 +32,8 @@ return [
         'exclude-classes' => [],
         'exclude-functions' => [],
 
-        'registered-classes' => [],
-        'registered-functions' => [],
+        'expected-recorded-classes' => [],
+        'expected-recorded-functions' => [],
     ],
 
     'FQCN string argument' => <<<'PHP'

--- a/specs/string-literal/func-arg.php
+++ b/specs/string-literal/func-arg.php
@@ -32,8 +32,8 @@ return [
         'exclude-classes' => [],
         'exclude-functions' => [],
 
-        'registered-classes' => [],
-        'registered-functions' => [],
+        'expected-recorded-classes' => [],
+        'expected-recorded-functions' => [],
     ],
 
     'FQCN string argument' => <<<'PHP'
@@ -587,7 +587,7 @@ PHP
 
     'FQC constant call on whitelisted class' => [
         'whitelist' => ['Symfony\Component\Yaml\Ya_1'],
-        'registered-classes' => [
+        'expected-recorded-classes' => [
             ['Symfony\Component\Yaml\Ya_1', 'Humbug\Symfony\Component\Yaml\Ya_1'],
         ],
         'payload' => <<<'PHP'

--- a/specs/string-literal/method-arg.php
+++ b/specs/string-literal/method-arg.php
@@ -32,8 +32,8 @@ return [
         'exclude-classes' => [],
         'exclude-functions' => [],
 
-        'registered-classes' => [],
-        'registered-functions' => [],
+        'expected-recorded-classes' => [],
+        'expected-recorded-functions' => [],
     ],
 
     'FQCN string argument' => <<<'PHP'

--- a/specs/string-literal/misc.php
+++ b/specs/string-literal/misc.php
@@ -32,8 +32,8 @@ return [
         'exclude-classes' => [],
         'exclude-functions' => [],
 
-        'registered-classes' => [],
-        'registered-functions' => [],
+        'expected-recorded-classes' => [],
+        'expected-recorded-functions' => [],
     ],
 
     'PHP heredoc as argument' => <<<'PHP'

--- a/specs/string-literal/new.php
+++ b/specs/string-literal/new.php
@@ -32,8 +32,8 @@ return [
         'exclude-classes' => [],
         'exclude-functions' => [],
 
-        'registered-classes' => [],
-        'registered-functions' => [],
+        'expected-recorded-classes' => [],
+        'expected-recorded-functions' => [],
     ],
 
     'FQCN string argument' => <<<'PHP'
@@ -165,7 +165,7 @@ PHP
 
     'FQC constant call on whitelisted class' => [
         'whitelist' => ['Symfony\Component\Yaml\Ya_1'],
-        'registered-classes' => [
+        'expected-recorded-classes' => [
             ['Symfony\Component\Yaml\Ya_1', 'Humbug\Symfony\Component\Yaml\Ya_1'],
         ],
         'payload' => <<<'PHP'

--- a/specs/string-literal/return.php.php
+++ b/specs/string-literal/return.php.php
@@ -32,8 +32,8 @@ return [
         'exclude-classes' => [],
         'exclude-functions' => [],
 
-        'registered-classes' => [],
-        'registered-functions' => [],
+        'expected-recorded-classes' => [],
+        'expected-recorded-functions' => [],
     ],
 
     'String argument' => <<<'PHP'

--- a/specs/string-literal/var.php
+++ b/specs/string-literal/var.php
@@ -32,8 +32,8 @@ return [
         'exclude-classes' => [],
         'exclude-functions' => [],
 
-        'registered-classes' => [],
-        'registered-functions' => [],
+        'expected-recorded-classes' => [],
+        'expected-recorded-functions' => [],
     ],
 
     'FQCN string argument' => <<<'PHP'
@@ -182,7 +182,7 @@ PHP
 
     'FQC constant call on whitelisted class' => [
         'whitelist' => ['Symfony\Component\Yaml\Ya_1'],
-        'registered-classes' => [
+        'expected-recorded-classes' => [
             ['Symfony\Component\Yaml\Ya_1', 'Humbug\Symfony\Component\Yaml\Ya_1'],
         ],
         'payload' => <<<'PHP'

--- a/specs/use/use-class-alias.php
+++ b/specs/use/use-class-alias.php
@@ -32,8 +32,8 @@ return [
         'exclude-classes' => [],
         'exclude-functions' => [],
 
-        'registered-classes' => [],
-        'registered-functions' => [],
+        'expected-recorded-classes' => [],
+        'expected-recorded-functions' => [],
     ],
 
     'Use statement of a class belonging to the global scope' => <<<'PHP'

--- a/specs/use/use-class-group.php
+++ b/specs/use/use-class-group.php
@@ -32,8 +32,8 @@ return [
         'exclude-classes' => [],
         'exclude-functions' => [],
 
-        'registered-classes' => [],
-        'registered-functions' => [],
+        'expected-recorded-classes' => [],
+        'expected-recorded-functions' => [],
     ],
 
     'Multiple group use statement' => <<<'PHP'

--- a/specs/use/use-class.php
+++ b/specs/use/use-class.php
@@ -32,8 +32,8 @@ return [
         'exclude-classes' => [],
         'exclude-functions' => [],
 
-        'registered-classes' => [],
-        'registered-functions' => [],
+        'expected-recorded-classes' => [],
+        'expected-recorded-functions' => [],
     ],
 
     'Use statement of a class belonging to the global scope' => <<<'PHP'
@@ -123,7 +123,7 @@ PHP
 
     'Use statement of a whitelisted class belonging to the global scope' => [
         'whitelist' => ['Foo'],
-        'registered-classes' => [
+        'expected-recorded-classes' => [
             ['Foo', 'Humbug\Foo'],
         ],
         'payload' => <<<'PHP'
@@ -171,7 +171,7 @@ PHP
 
     'Use statement of a whitelisted class belonging to the global scope which has been whitelisted' => [
         'whitelist' => ['Foo', '\*'],
-        'registered-classes' => [
+        'expected-recorded-classes' => [
             ['Foo', 'Humbug\Foo'],
         ],
         'payload' => <<<'PHP'
@@ -248,7 +248,7 @@ PHP
 
     'Use statement of two-level class which has been whitelisted' => [
         'whitelist' => ['Foo\Bar'],
-        'registered-classes' => [
+        'expected-recorded-classes' => [
             ['Foo\Bar', 'Humbug\Foo\Bar'],
         ],
         'payload' => <<<'PHP'

--- a/specs/use/use-const-alias.php
+++ b/specs/use/use-const-alias.php
@@ -32,8 +32,8 @@ return [
         'exclude-classes' => [],
         'exclude-functions' => [],
 
-        'registered-classes' => [],
-        'registered-functions' => [],
+        'expected-recorded-classes' => [],
+        'expected-recorded-functions' => [],
     ],
 
     'Constant use statement for a constant belonging to the global namespace' => <<<'PHP'

--- a/specs/use/use-const-group.php
+++ b/specs/use/use-const-group.php
@@ -32,8 +32,8 @@ return [
         'exclude-classes' => [],
         'exclude-functions' => [],
 
-        'registered-classes' => [],
-        'registered-functions' => [],
+        'expected-recorded-classes' => [],
+        'expected-recorded-functions' => [],
     ],
 
     <<<'PHP'

--- a/specs/use/use-const.php
+++ b/specs/use/use-const.php
@@ -32,8 +32,8 @@ return [
         'exclude-classes' => [],
         'exclude-functions' => [],
 
-        'registered-classes' => [],
-        'registered-functions' => [],
+        'expected-recorded-classes' => [],
+        'expected-recorded-functions' => [],
     ],
 
     'Constant use statement for a constant belonging to the global namespace' => <<<'PHP'

--- a/specs/use/use-func-alias.php
+++ b/specs/use/use-func-alias.php
@@ -32,8 +32,8 @@ return [
         'exclude-classes' => [],
         'exclude-functions' => [],
 
-        'registered-classes' => [],
-        'registered-functions' => [],
+        'expected-recorded-classes' => [],
+        'expected-recorded-functions' => [],
     ],
 
     'Use statement for a function belonging to the global namespace' => <<<'PHP'

--- a/specs/use/use-func-group.php
+++ b/specs/use/use-func-group.php
@@ -32,8 +32,8 @@ return [
         'exclude-classes' => [],
         'exclude-functions' => [],
 
-        'registered-classes' => [],
-        'registered-functions' => [],
+        'expected-recorded-classes' => [],
+        'expected-recorded-functions' => [],
     ],
 
     <<<'PHP'

--- a/specs/use/use-func.php
+++ b/specs/use/use-func.php
@@ -32,8 +32,8 @@ return [
         'exclude-classes' => [],
         'exclude-functions' => [],
 
-        'registered-classes' => [],
-        'registered-functions' => [],
+        'expected-recorded-classes' => [],
+        'expected-recorded-functions' => [],
     ],
 
     'Use statement for a function belonging to the global namespace' => <<<'PHP'

--- a/specs/use/use-mix-group.php
+++ b/specs/use/use-mix-group.php
@@ -32,8 +32,8 @@ return [
         'exclude-classes' => [],
         'exclude-functions' => [],
 
-        'registered-classes' => [],
-        'registered-functions' => [],
+        'expected-recorded-classes' => [],
+        'expected-recorded-functions' => [],
     ],
 
     <<<'PHP'

--- a/tests/Scoper/PhpScoperSpecTest.php
+++ b/tests/Scoper/PhpScoperSpecTest.php
@@ -76,8 +76,8 @@ class PhpScoperSpecTest extends TestCase
         ConfigurationKeys::CONSTANTS_INTERNAL_SYMBOLS_KEYWORD,
         ConfigurationKeys::CLASSES_INTERNAL_SYMBOLS_KEYWORD,
         ConfigurationKeys::FUNCTIONS_INTERNAL_SYMBOLS_KEYWORD,
-        'registered-classes',
-        'registered-functions',
+        'expected-recorded-classes',
+        'expected-recorded-functions',
     ];
 
     private const SPECS_SPEC_KEYS = [
@@ -95,8 +95,8 @@ class PhpScoperSpecTest extends TestCase
         ConfigurationKeys::CONSTANTS_INTERNAL_SYMBOLS_KEYWORD,
         ConfigurationKeys::CLASSES_INTERNAL_SYMBOLS_KEYWORD,
         ConfigurationKeys::FUNCTIONS_INTERNAL_SYMBOLS_KEYWORD,
-        'registered-classes',
-        'registered-functions',
+        'expected-recorded-classes',
+        'expected-recorded-functions',
         'payload',
     ];
 
@@ -139,7 +139,7 @@ class PhpScoperSpecTest extends TestCase
 
         $filePath = 'file.php';
 
-        $scoper = $this->createScoper(
+        $scoper = self::createScoper(
             $internalClasses,
             $internalFunctions,
             $internalConstants,
@@ -202,7 +202,7 @@ class PhpScoperSpecTest extends TestCase
             );
         }
 
-        $specMessage = $this->createSpecMessage(
+        $specMessage = self::createSpecMessage(
             $file,
             $spec,
             $contents,
@@ -217,11 +217,11 @@ class PhpScoperSpecTest extends TestCase
 
         $actualRecordedWhitelistedClasses = $whitelist->getRecordedWhitelistedClasses();
 
-        $this->assertSameRecordedSymbols($expectedRegisteredClasses, $actualRecordedWhitelistedClasses, $specMessage);
+        self::assertSameRecordedSymbols($expectedRegisteredClasses, $actualRecordedWhitelistedClasses, $specMessage);
 
         $actualRecordedWhitelistedFunctions = $whitelist->getRecordedWhitelistedFunctions();
 
-        $this->assertSameRecordedSymbols($expectedRegisteredFunctions, $actualRecordedWhitelistedFunctions, $specMessage);
+        self::assertSameRecordedSymbols($expectedRegisteredFunctions, $actualRecordedWhitelistedFunctions, $specMessage);
     }
 
     public static function provideValidFiles(): iterable
@@ -266,7 +266,7 @@ class PhpScoperSpecTest extends TestCase
         }
     }
 
-    private function createScoper(
+    private static function createScoper(
         array $internalClasses,
         array $internalFunctions,
         array $internalConstants,
@@ -348,8 +348,8 @@ class PhpScoperSpecTest extends TestCase
             $fixtureSet[ConfigurationKeys::FUNCTIONS_INTERNAL_SYMBOLS_KEYWORD] ?? $meta[ConfigurationKeys::FUNCTIONS_INTERNAL_SYMBOLS_KEYWORD],
             $fixtureSet[ConfigurationKeys::CONSTANTS_INTERNAL_SYMBOLS_KEYWORD] ?? $meta[ConfigurationKeys::CONSTANTS_INTERNAL_SYMBOLS_KEYWORD],
             '' === $payloadParts[1] ? null : $payloadParts[1],   // Expected output; null means an exception is expected,
-            $fixtureSet['registered-classes'] ?? $meta['registered-classes'],
-            $fixtureSet['registered-functions'] ?? $meta['registered-functions'],
+            $fixtureSet['expected-recorded-classes'] ?? $meta['expected-recorded-classes'],
+            $fixtureSet['expected-recorded-functions'] ?? $meta['expected-recorded-functions'],
             $meta['minPhpVersion'] ?? null,
             $meta['maxPhpVersion'] ?? null,
         ];
@@ -397,7 +397,7 @@ class PhpScoperSpecTest extends TestCase
      * @param string[][] $expectedRegisteredClasses
      * @param string[][] $expectedRegisteredFunctions
      */
-    private function createSpecMessage(
+    private static function createSpecMessage(
         string $file,
         string $spec,
         string $contents,
@@ -407,19 +407,17 @@ class PhpScoperSpecTest extends TestCase
         array $expectedRegisteredClasses,
         array $expectedRegisteredFunctions
     ): string {
-        $formattedWhitelist = $this->formatSimpleList($whitelist->toArray());
+        $formattedWhitelist = self::formatSimpleList($whitelist->toArray());
 
-        $formattedWhitelistGlobalConstants = $this->convertBoolToString($whitelist->exposeGlobalConstants());
-        $formattedWhitelistGlobalFunctions = $this->convertBoolToString($whitelist->exposeGlobalFunctions());
+        $formattedWhitelistGlobalClasses = self::convertBoolToString($whitelist->exposeGlobalClasses());
+        $formattedWhitelistGlobalConstants = self::convertBoolToString($whitelist->exposeGlobalConstants());
+        $formattedWhitelistGlobalFunctions = self::convertBoolToString($whitelist->exposeGlobalFunctions());
 
-        $whitelist->getRecordedWhitelistedFunctions();
-        $whitelist->getRecordedWhitelistedClasses();
+        $formattedExpectedRegisteredClasses = self::formatTupleList($expectedRegisteredClasses);
+        $formattedExpectedRegisteredFunctions = self::formatTupleList($expectedRegisteredFunctions);
 
-        $formattedExpectedRegisteredClasses = $this->formatTupleList($expectedRegisteredClasses);
-        $formattedExpectedRegisteredFunctions = $this->formatTupleList($expectedRegisteredFunctions);
-
-        $formattedActualRegisteredClasses = $this->formatTupleList($whitelist->getRecordedWhitelistedClasses());
-        $formattedActualRegisteredFunctions = $this->formatTupleList($whitelist->getRecordedWhitelistedFunctions());
+        $formattedActualRegisteredClasses = self::formatTupleList($whitelist->getRecordedWhitelistedClasses());
+        $formattedActualRegisteredFunctions = self::formatTupleList($whitelist->getRecordedWhitelistedFunctions());
 
         $titleSeparator = str_repeat(
             '=',
@@ -430,45 +428,45 @@ class PhpScoperSpecTest extends TestCase
         );
 
         return <<<OUTPUT
-$titleSeparator
-SPECIFICATION
-$titleSeparator
-$spec
-$file
-
-$titleSeparator
-INPUT
-whitelist: $formattedWhitelist
-whitelist global constants: $formattedWhitelistGlobalConstants
-whitelist global functions: $formattedWhitelistGlobalFunctions
-$titleSeparator
-$contents
-
-$titleSeparator
-EXPECTED
-$titleSeparator
-$expected
-----------------
-registered classes: $formattedExpectedRegisteredClasses
-registered functions: $formattedExpectedRegisteredFunctions
-
-$titleSeparator
-ACTUAL
-$titleSeparator
-$actual
-----------------
-registered classes: $formattedActualRegisteredClasses
-registered functions: $formattedActualRegisteredFunctions
-
--------------------------------------------------------------------------------
-OUTPUT
-        ;
+        $titleSeparator
+        SPECIFICATION
+        $titleSeparator
+        $spec
+        $file
+        
+        $titleSeparator
+        INPUT
+        whitelist: $formattedWhitelist
+        whitelist global classes: $formattedWhitelistGlobalClasses
+        whitelist global functions: $formattedWhitelistGlobalFunctions
+        whitelist global constants: $formattedWhitelistGlobalConstants
+        $titleSeparator
+        $contents
+        
+        $titleSeparator
+        EXPECTED
+        $titleSeparator
+        $expected
+        ----------------
+        recorded functions: $formattedExpectedRegisteredFunctions
+        recorded classes: $formattedExpectedRegisteredClasses
+        
+        $titleSeparator
+        ACTUAL
+        $titleSeparator
+        $actual
+        ----------------
+        recorded functions: $formattedActualRegisteredFunctions
+        recorded classes: $formattedActualRegisteredClasses
+        
+        -------------------------------------------------------------------------------
+        OUTPUT;
     }
 
     /**
      * @param string[] $strings
      */
-    private function formatSimpleList(array $strings): string
+    private static function formatSimpleList(array $strings): string
     {
         if (0 === count($strings)) {
             return '[]';
@@ -495,7 +493,7 @@ OUTPUT
     /**
      * @param string[][] $stringTuples
      */
-    private function formatTupleList(array $stringTuples): string
+    private static function formatTupleList(array $stringTuples): string
     {
         if (0 === count($stringTuples)) {
             return '[]';
@@ -522,7 +520,7 @@ OUTPUT
         );
     }
 
-    private function convertBoolToString(bool $bool): string
+    private static function convertBoolToString(bool $bool): string
     {
         return true === $bool ? 'true' : 'false';
     }
@@ -531,7 +529,7 @@ OUTPUT
      * @param string[][] $expected
      * @param string[][] $actual
      */
-    private function assertSameRecordedSymbols(array $expected, array $actual, string $message): void
+    private static function assertSameRecordedSymbols(array $expected, array $actual, string $message): void
     {
         $sort = static fn (array $a, array $b) => $a[0] <=> $b[0];
 


### PR DESCRIPTION
- Rename `registered-classes` and its function counterpart into `expected-recorded-classes` which is more correct
- Add `whitelist global classes` along the functions & constants