### PR TITLE
Fix regex detection

### DIFF
--- a/src/RegexChecker.php
+++ b/src/RegexChecker.php
@@ -43,6 +43,11 @@ final class RegexChecker
 
         $firstCharacter = $value[0];
 
+        if ('\\' === $firstCharacter) {
+            // This is not ideal as not true.
+            return false;
+        }
+
         $parts = explode($firstCharacter, $value);
 
         if (false === $parts || count($parts) !== 3) {

--- a/tests/RegexCheckerTest.php
+++ b/tests/RegexCheckerTest.php
@@ -64,8 +64,13 @@ final class RegexCheckerTest extends TestCase
             true,
         ];
 
-        yield 'fake regex' => [
+        yield 'fake regex (0)' => [
             '/Foo/Bar/',
+            false,
+        ];
+
+        yield 'fake regex (1)' => [
+            '\Foo\A',
             false,
         ];
 


### PR DESCRIPTION
`\Foo\A` is detected as a regex and whilst this is true (`\` used as a delimiter here with the flag `A`), it makes a lot of things complicated for an edge case which IMO has no reasons to be: if you wish such a regex simply use another delimiter.