### PR TITLE
Rejects _ as a valid regex delimiter, fixes issue #666.

### DIFF
--- a/src/Configuration/RegexChecker.php
+++ b/src/Configuration/RegexChecker.php
@@ -78,7 +78,7 @@ final class RegexChecker
     {
         // This is not ideal as not true but is good enough for our case.
         // See https://github.com/humbug/php-scoper/issues/597
-        return '\\' !== $delimiter && native_preg_match('/^\p{L}$/u', $delimiter) === 0;
+        return '\\' !== $delimiter && '_' !== $delimiter && native_preg_match('/^\p{L}$/u', $delimiter) === 0;
     }
 
     private static function isValidRegexFlags(string $value): bool

--- a/tests/Configuration/RegexCheckerTest.php
+++ b/tests/Configuration/RegexCheckerTest.php
@@ -81,6 +81,12 @@ final class RegexCheckerTest extends TestCase
             false,
         ];
 
+        // See https://github.com/humbug/php-scoper/issues/666
+        yield 'fake regex (3)' => [
+            '__',
+            false,
+        ];
+
         yield 'minimal fake regex' => [
             '////',
             false,


### PR DESCRIPTION
This is one way to fix issue #666 which is related to #597.

Alternatively it could be implemented by rejecting empty regex. However, there appears to be a test to explicitly accept empty regex so it made sense to simply reject `_` as a delimiter altogether.