### PR TITLE
Make function alias delcarations one-liners

### DIFF
--- a/src/Autoload/ScoperAutoloadGenerator.php
+++ b/src/Autoload/ScoperAutoloadGenerator.php
@@ -222,7 +222,7 @@ final class ScoperAutoloadGenerator
         if (!$hasNamespacedFunctions) {
             return sprintf(
                 <<<'PHP'
-                    if (!function_exists('%1$s')) function %1$s(%2$s) { return \%3$s(...func_get_args()); }
+                    if (!function_exists('%1$s')) { function %1$s(%2$s) { return \%3$s(...func_get_args()); } }
                     PHP,
                 $original,
                 '__autoload' === $original ? '$className' : '',
@@ -243,7 +243,7 @@ final class ScoperAutoloadGenerator
         return sprintf(
             <<<'PHP'
                 namespace %s{
-                    if (!function_exists('%s')) function %s(%s) { return \%s(...func_get_args()); }
+                    if (!function_exists('%s')) { function %s(%s) { return \%s(...func_get_args()); } }
                 }
                 PHP,
             null === $namespace ? '' : $namespace->toString().' ',

--- a/src/Autoload/ScoperAutoloadGenerator.php
+++ b/src/Autoload/ScoperAutoloadGenerator.php
@@ -222,11 +222,7 @@ final class ScoperAutoloadGenerator
         if (!$hasNamespacedFunctions) {
             return sprintf(
                 <<<'PHP'
-                    if (!function_exists('%1$s')) {
-                        function %1$s(%2$s) {
-                            return \%3$s(...func_get_args());
-                        }
-                    }
+                    if (!function_exists('%1$s')) function %1$s(%2$s) { return \%3$s(...func_get_args()); }
                     PHP,
                 $original,
                 '__autoload' === $original ? '$className' : '',
@@ -247,11 +243,7 @@ final class ScoperAutoloadGenerator
         return sprintf(
             <<<'PHP'
                 namespace %s{
-                    if (!function_exists('%s')) {
-                        function %s(%s) {
-                            return \%s(...func_get_args());
-                        }
-                    }
+                    if (!function_exists('%s')) function %s(%s) { return \%s(...func_get_args()); }
                 }
                 PHP,
             null === $namespace ? '' : $namespace->toString().' ',

--- a/tests/Autoload/ScoperAutoloadGeneratorTest.php
+++ b/tests/Autoload/ScoperAutoloadGeneratorTest.php
@@ -70,16 +70,8 @@ class ScoperAutoloadGeneratorTest extends TestCase
 
                 // Function aliases. For more information see:
                 // https://github.com/humbug/php-scoper/blob/master/docs/further-reading.md#function-aliases
-                if (!function_exists('foo')) {
-                    function foo() {
-                        return \Humbug\foo(...func_get_args());
-                    }
-                }
-                if (!function_exists('bar')) {
-                    function bar() {
-                        return \Humbug\bar(...func_get_args());
-                    }
-                }
+                if (!function_exists('foo')) function foo() { return \Humbug\foo(...func_get_args()); }
+                if (!function_exists('bar')) function bar() { return \Humbug\bar(...func_get_args()); }
 
                 return $loader;
 
@@ -108,25 +100,13 @@ class ScoperAutoloadGeneratorTest extends TestCase
                 // Function aliases. For more information see:
                 // https://github.com/humbug/php-scoper/blob/master/docs/further-reading.md#function-aliases
                 namespace Acme {
-                    if (!function_exists('Acme\foo')) {
-                        function foo() {
-                            return \Humbug\Acme\foo(...func_get_args());
-                        }
-                    }
+                    if (!function_exists('Acme\foo')) function foo() { return \Humbug\Acme\foo(...func_get_args()); }
                 }
                 namespace Acme {
-                    if (!function_exists('Acme\bar')) {
-                        function bar() {
-                            return \Humbug\Acme\bar(...func_get_args());
-                        }
-                    }
+                    if (!function_exists('Acme\bar')) function bar() { return \Humbug\Acme\bar(...func_get_args()); }
                 }
                 namespace Emca {
-                    if (!function_exists('Emca\baz')) {
-                        function baz() {
-                            return \Humbug\Emca\baz(...func_get_args());
-                        }
-                    }
+                    if (!function_exists('Emca\baz')) function baz() { return \Humbug\Emca\baz(...func_get_args()); }
                 }
 
                 namespace {
@@ -226,39 +206,19 @@ class ScoperAutoloadGeneratorTest extends TestCase
                 // Function aliases. For more information see:
                 // https://github.com/humbug/php-scoper/blob/master/docs/further-reading.md#function-aliases
                 namespace {
-                    if (!function_exists('foo')) {
-                        function foo() {
-                            return \Humbug\foo(...func_get_args());
-                        }
-                    }
+                    if (!function_exists('foo')) function foo() { return \Humbug\foo(...func_get_args()); }
                 }
                 namespace {
-                    if (!function_exists('bar')) {
-                        function bar() {
-                            return \Humbug\bar(...func_get_args());
-                        }
-                    }
+                    if (!function_exists('bar')) function bar() { return \Humbug\bar(...func_get_args()); }
                 }
                 namespace Acme {
-                    if (!function_exists('Acme\foo')) {
-                        function foo() {
-                            return \Humbug\Acme\foo(...func_get_args());
-                        }
-                    }
+                    if (!function_exists('Acme\foo')) function foo() { return \Humbug\Acme\foo(...func_get_args()); }
                 }
                 namespace Acme {
-                    if (!function_exists('Acme\bar')) {
-                        function bar() {
-                            return \Humbug\Acme\bar(...func_get_args());
-                        }
-                    }
+                    if (!function_exists('Acme\bar')) function bar() { return \Humbug\Acme\bar(...func_get_args()); }
                 }
                 namespace Emca {
-                    if (!function_exists('Emca\baz')) {
-                        function baz() {
-                            return \Humbug\Emca\baz(...func_get_args());
-                        }
-                    }
+                    if (!function_exists('Emca\baz')) function baz() { return \Humbug\Emca\baz(...func_get_args()); }
                 }
 
                 namespace {
@@ -286,11 +246,7 @@ class ScoperAutoloadGeneratorTest extends TestCase
 
                 // Function aliases. For more information see:
                 // https://github.com/humbug/php-scoper/blob/master/docs/further-reading.md#function-aliases
-                if (!function_exists('__autoload')) {
-                    function __autoload($className) {
-                        return \Humbug\__autoload(...func_get_args());
-                    }
-                }
+                if (!function_exists('__autoload')) function __autoload($className) { return \Humbug\__autoload(...func_get_args()); }
 
                 return $loader;
 
@@ -319,18 +275,10 @@ class ScoperAutoloadGeneratorTest extends TestCase
                 // Function aliases. For more information see:
                 // https://github.com/humbug/php-scoper/blob/master/docs/further-reading.md#function-aliases
                 namespace {
-                    if (!function_exists('__autoload')) {
-                        function __autoload($className) {
-                            return \Humbug\__autoload(...func_get_args());
-                        }
-                    }
+                    if (!function_exists('__autoload')) function __autoload($className) { return \Humbug\__autoload(...func_get_args()); }
                 }
                 namespace Acme {
-                    if (!function_exists('Acme\foo')) {
-                        function foo() {
-                            return \Humbug\Acme\foo(...func_get_args());
-                        }
-                    }
+                    if (!function_exists('Acme\foo')) function foo() { return \Humbug\Acme\foo(...func_get_args()); }
                 }
 
                 namespace {

--- a/tests/Autoload/ScoperAutoloadGeneratorTest.php
+++ b/tests/Autoload/ScoperAutoloadGeneratorTest.php
@@ -70,8 +70,8 @@ class ScoperAutoloadGeneratorTest extends TestCase
 
                 // Function aliases. For more information see:
                 // https://github.com/humbug/php-scoper/blob/master/docs/further-reading.md#function-aliases
-                if (!function_exists('foo')) function foo() { return \Humbug\foo(...func_get_args()); }
-                if (!function_exists('bar')) function bar() { return \Humbug\bar(...func_get_args()); }
+                if (!function_exists('foo')) { function foo() { return \Humbug\foo(...func_get_args()); } }
+                if (!function_exists('bar')) { function bar() { return \Humbug\bar(...func_get_args()); } }
 
                 return $loader;
 
@@ -100,13 +100,13 @@ class ScoperAutoloadGeneratorTest extends TestCase
                 // Function aliases. For more information see:
                 // https://github.com/humbug/php-scoper/blob/master/docs/further-reading.md#function-aliases
                 namespace Acme {
-                    if (!function_exists('Acme\foo')) function foo() { return \Humbug\Acme\foo(...func_get_args()); }
+                    if (!function_exists('Acme\foo')) { function foo() { return \Humbug\Acme\foo(...func_get_args()); } }
                 }
                 namespace Acme {
-                    if (!function_exists('Acme\bar')) function bar() { return \Humbug\Acme\bar(...func_get_args()); }
+                    if (!function_exists('Acme\bar')) { function bar() { return \Humbug\Acme\bar(...func_get_args()); } }
                 }
                 namespace Emca {
-                    if (!function_exists('Emca\baz')) function baz() { return \Humbug\Emca\baz(...func_get_args()); }
+                    if (!function_exists('Emca\baz')) { function baz() { return \Humbug\Emca\baz(...func_get_args()); } }
                 }
 
                 namespace {
@@ -206,19 +206,19 @@ class ScoperAutoloadGeneratorTest extends TestCase
                 // Function aliases. For more information see:
                 // https://github.com/humbug/php-scoper/blob/master/docs/further-reading.md#function-aliases
                 namespace {
-                    if (!function_exists('foo')) function foo() { return \Humbug\foo(...func_get_args()); }
+                    if (!function_exists('foo')) { function foo() { return \Humbug\foo(...func_get_args()); } }
                 }
                 namespace {
-                    if (!function_exists('bar')) function bar() { return \Humbug\bar(...func_get_args()); }
+                    if (!function_exists('bar')) { function bar() { return \Humbug\bar(...func_get_args()); } }
                 }
                 namespace Acme {
-                    if (!function_exists('Acme\foo')) function foo() { return \Humbug\Acme\foo(...func_get_args()); }
+                    if (!function_exists('Acme\foo')) { function foo() { return \Humbug\Acme\foo(...func_get_args()); } }
                 }
                 namespace Acme {
-                    if (!function_exists('Acme\bar')) function bar() { return \Humbug\Acme\bar(...func_get_args()); }
+                    if (!function_exists('Acme\bar')) { function bar() { return \Humbug\Acme\bar(...func_get_args()); } }
                 }
                 namespace Emca {
-                    if (!function_exists('Emca\baz')) function baz() { return \Humbug\Emca\baz(...func_get_args()); }
+                    if (!function_exists('Emca\baz')) { function baz() { return \Humbug\Emca\baz(...func_get_args()); } }
                 }
 
                 namespace {
@@ -246,7 +246,7 @@ class ScoperAutoloadGeneratorTest extends TestCase
 
                 // Function aliases. For more information see:
                 // https://github.com/humbug/php-scoper/blob/master/docs/further-reading.md#function-aliases
-                if (!function_exists('__autoload')) function __autoload($className) { return \Humbug\__autoload(...func_get_args()); }
+                if (!function_exists('__autoload')) { function __autoload($className) { return \Humbug\__autoload(...func_get_args()); } }
 
                 return $loader;
 
@@ -275,10 +275,10 @@ class ScoperAutoloadGeneratorTest extends TestCase
                 // Function aliases. For more information see:
                 // https://github.com/humbug/php-scoper/blob/master/docs/further-reading.md#function-aliases
                 namespace {
-                    if (!function_exists('__autoload')) function __autoload($className) { return \Humbug\__autoload(...func_get_args()); }
+                    if (!function_exists('__autoload')) { function __autoload($className) { return \Humbug\__autoload(...func_get_args()); } }
                 }
                 namespace Acme {
-                    if (!function_exists('Acme\foo')) function foo() { return \Humbug\Acme\foo(...func_get_args()); }
+                    if (!function_exists('Acme\foo')) { function foo() { return \Humbug\Acme\foo(...func_get_args()); } }
                 }
 
                 namespace {


### PR DESCRIPTION
When there is several functions, having the 5 lines form is too verbose.