### PR TITLE
Use the recorded symbols to decide when to add the class_alias statements

### DIFF
--- a/src/PhpParser/TraverserFactory.php
+++ b/src/PhpParser/TraverserFactory.php
@@ -130,9 +130,8 @@ class TraverserFactory
             new NodeVisitor\EvalPrefixer($stringNodePrefixer),
 
             new NodeVisitor\ClassAliasStmtAppender(
-                $prefix,
-                $reflector,
                 $identifierResolver,
+                $symbolsRegistry,
             ),
             new NodeVisitor\MultiConstStmtReplacer(),
             new NodeVisitor\ConstStmtReplacer(

--- a/src/Symbol/SymbolsRegistry.php
+++ b/src/Symbol/SymbolsRegistry.php
@@ -72,6 +72,14 @@ final class SymbolsRegistry implements Countable
     }
 
     /**
+     * @return array{string, string}|null
+     */
+    public function getRecordedClass(string $original): ?array
+    {
+        return $this->recordedClasses[$original] ?? null;
+    }
+
+    /**
      * @return list<array{string, string}>
      */
     public function getRecordedClasses(): array

--- a/tests/Symbol/SymbolsRegistryTest.php
+++ b/tests/Symbol/SymbolsRegistryTest.php
@@ -361,6 +361,22 @@ final class SymbolsRegistryTest extends TestCase
         ];
     }
 
+    public function test_it_exposes_recorded_classes(): void
+    {
+        $registry = self::createRegistry(
+            [[new FullyQualified('foo'), new FullyQualified('Humbug\foo')]],
+            [[new FullyQualified('Bar'), new FullyQualified('Humbug\Bar')]],
+        );
+
+        self::assertNull($registry->getRecordedClass('foo'));
+        self::assertNull($registry->getRecordedClass('bar'));
+        self::assertNull($registry->getRecordedClass('Humbug\Bar'));
+        self::assertEquals(
+            ['Bar', 'Humbug\Bar'],
+            $registry->getRecordedClass('Bar'),
+        );
+    }
+
     private static function assertStateIs(
         SymbolsRegistry $symbolsRegistry,
         array $expectedRecordedFunctions,


### PR DESCRIPTION
This makes the feature more reliable as avoid to have to keep synchronized the logic of when a symbol is aliased.