### PR TITLE
Fix InspectSymbol command slowness

### DIFF
--- a/src/Console/Command/InspectSymbolCommand.php
+++ b/src/Console/Command/InspectSymbolCommand.php
@@ -158,7 +158,7 @@ final class InspectSymbolCommand implements Command
             // We do not want the init command to be triggered if there is no
             // config file.
             true,
-            [],
+            [__FILE__],
             getcwd(),
         );
     }


### PR DESCRIPTION
Because we are not passing any path, the config loader tries to add all the paths of the current working directory and does so eagerly. To avoid that, we now pass a single file since the included/excluded file should not matter for the command result.

Closes #751