### PR TITLE
Remove configuration keys todo

### DIFF
--- a/src/Configuration/ConfigurationKeys.php
+++ b/src/Configuration/ConfigurationKeys.php
@@ -14,7 +14,6 @@ declare(strict_types=1);
 
 namespace Humbug\PhpScoper\Configuration;
 
-// TODO: make it an enum once in PHP 8.1
 final class ConfigurationKeys
 {
     public const PREFIX_KEYWORD = 'prefix';


### PR DESCRIPTION
The `ConfigurationKeys` class cannot be made into an enum since we are using some entries as an array key which is not supported by enums.