### PR TITLE
Fix a problem where output-dir argument is not provided through command, but is present on configuration file

### DIFF
--- a/src/Console/Command/AddPrefixCommand.php
+++ b/src/Console/Command/AddPrefixCommand.php
@@ -93,6 +93,7 @@ final class AddPrefixCommand implements Command, CommandAware
                     'o',
                     InputOption::VALUE_REQUIRED,
                     'The output directory in which the prefixed code will be dumped.',
+                    ''
                 ),
                 new InputOption(
                     self::FORCE_OPT,


### PR DESCRIPTION
With the implementation of https://github.com/humbug/php-scoper/pull/632, `output-dir` is still not being utilized because of the input argument being marked as required, with no default value. Currently, if you run just `php-scoper add-prefix` without any extra arguments, it will err with a 

```
$ php-scoper add-prefix

  Expected a string. Got "NULL" for the option "output-dir".  
                                                              
In Assert.php line 2074:
                                 
  Expected a string. Got "NULL" 
```

**How to fully reproduce the issue**:

```bash
$ mkdir bug-reproducer
$ cd bug-reproducer
$ php-scoper init
$ php-scoper add-prefix
```

This PR makes the input "optional" by providing a default value for it, which will then use the value from the configuration file if it exists, or fallback to the default value (this check is done [here](https://github.com/humbug/php-scoper/blob/f7bd92f2459f1d9a643313f6d324476b0e23e087/src/Console/Command/AddPrefixCommand.php#L161-L170)).



I apologize for not creating a test for it, but I haven't found any example of where you are reading a configuration from the actual config file.