### PR TITLE
ci: Review the Lint workflow

### DIFF
--- a/.github/workflows/composer-root-version.yaml
+++ b/.github/workflows/composer-root-version.yaml
@@ -8,12 +8,7 @@ on:
 jobs:
     cs-lint:
         runs-on: ubuntu-latest
-        name: CS lint
-        strategy:
-            fail-fast: false
-            matrix:
-                php: [ '8.1' ]  # Should be the latest PHP version supported
-
+        name: Lint CS
         steps:
             -   name: Checkout
                 uses: actions/checkout@v3
@@ -21,8 +16,9 @@ jobs:
             -   name: Setup PHP
                 uses: shivammathur/setup-php@v2
                 with:
-                    php-version: "${{ matrix.php }}"
+                    php-version: '8.1'
                     tools: composer
+                    coverage: none
 
             # https://docs.github.com/en/actions/learn-github-actions/workflow-commands-for-github-actions#setting-an-environment-variable
             -   name: Configure composer root version
@@ -49,7 +45,7 @@ jobs:
                 with:
                     working-directory: 'composer-root-version-checker'
 
-            -   name: Lints CS
+            -   name: Lint CS
                 run: cd composer-root-version-checker; make cs_lint
 
     tests:

--- a/.github/workflows/composer-root-version.yaml
+++ b/.github/workflows/composer-root-version.yaml
@@ -42,7 +42,7 @@ jobs:
                     working-directory: 'vendor-bin/php-cs-fixer'
 
             -   name: Ensure that PHP-CS-Fixer dependencies are updated correctly
-                run: make install_php_cs_fixer
+                run: make php_cs_fixer_install
 
             -   name: Install the Composer dependencies
                 uses: ramsey/composer-install@v2

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -6,19 +6,9 @@ on:
     pull_request:
 
 jobs:
-    tests:
+    cs:
         runs-on: ubuntu-latest
-        name: Lint ${{ matrix.check.name }}
-        strategy:
-            fail-fast: false
-            matrix:
-                php: [ '8.1' ]
-                check:
-                    -   name: CS
-                        command: make cs_lint
-                    -   name: PHPStan
-                        command: make phpstan
-
+        name: CS
         steps:
             -   name: Checkout
                 uses: actions/checkout@v3
@@ -26,7 +16,7 @@ jobs:
             -   name: Setup PHP
                 uses: shivammathur/setup-php@v2
                 with:
-                    php-version: "${{ matrix.php }}"
+                    php-version: '8.1'
                     tools: composer
                     coverage: none
 
@@ -39,10 +29,44 @@ jobs:
             -   name: Install Composer dependencies
                 uses: ramsey/composer-install@v2
 
-            -   name: Install Composer PHPStan dependencies
+            -   name: Install PHP-CS-Fixer
+                uses: ramsey/composer-install@v2
+                with:
+                    working-directory: 'vendor-bin/php-cs-fixer'
+
+            -   name: Ensure PHP-CS-Fixer Makefile target is up to date
+                run: make php_cs_fixer_install
+
+            -   run: make cs_lint
+    phpstan:
+        runs-on: ubuntu-latest
+        name: PHPStan
+        steps:
+            -   name: Checkout
+                uses: actions/checkout@v3
+
+            -   name: Setup PHP
+                uses: shivammathur/setup-php@v2
+                with:
+                    php-version: '8.1'
+                    tools: composer
+                    coverage: none
+
+            # https://docs.github.com/en/actions/learn-github-actions/workflow-commands-for-github-actions#setting-an-environment-variable
+            -   name: Configure composer root version
+                run: |
+                    source .composer-root-version
+                    echo "COMPOSER_ROOT_VERSION=${COMPOSER_ROOT_VERSION}" >> $GITHUB_ENV
+
+            -   name: Install Composer dependencies
+                uses: ramsey/composer-install@v2
+
+            -   name: Install PHPStan
                 uses: ramsey/composer-install@v2
                 with:
                     working-directory: 'vendor-bin/phpstan'
 
-            -   name: Run ${{ matrix.check.name }}
-                run: ${{ matrix.check.command }}
+            -   name: Ensure PHPStan Makefile target is up to date
+                run: make phpstan_install
+
+            -   run: make phpstan

--- a/Makefile
+++ b/Makefile
@@ -539,8 +539,8 @@ vendor-bin/covers-validator/composer.lock: vendor-bin/covers-validator/composer.
 	@echo "$(@) is not up to date. You may want to run the following command:"
 	@echo "$$ composer bin covers-validator update --lock && touch -c $(@)"
 
-.PHONY: install_php_cs_fixer
-install_php_cs_fixer: $(PHP_CS_FIXER_BIN)
+.PHONY: php_cs_fixer_install
+php_cs_fixer_install: $(PHP_CS_FIXER_BIN)
 
 $(PHP_CS_FIXER_BIN): vendor-bin/php-cs-fixer/vendor
 	touch -c $@
@@ -550,6 +550,9 @@ vendor-bin/php-cs-fixer/vendor: vendor-bin/php-cs-fixer/composer.lock $(COMPOSER
 vendor-bin/php-cs-fixer/composer.lock: vendor-bin/php-cs-fixer/composer.json
 	@echo "$(@) is not up to date. You may want to run the following command:"
 	@echo "$$ composer bin php-cs-fixer update --lock && touch -c $(@)"
+
+.PHONY: phpstan_install
+phpstan_install: $(PHPSTAN_BIN)
 
 $(PHPSTAN_BIN): vendor-bin/phpstan/vendor
 	touch -c $@


### PR DESCRIPTION
- Rename "Lint CS (8.1)" and "Lint PHPStan (8.1)" to respectively "CS" and "PHPStan".
- Fix PHP-CS-Fixer not being installed by ramsey/install
- Ensure the makefile targets are up to date in the CI before running the command.
- Rename "CS lint (8.1)" to "Lint CS"