### PR TITLE
chore: Add undesired lock files to the gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,7 +14,9 @@
 /dist/
 /fixtures/*/.box_dump/
 /fixtures/*/vendor/
+/fixtures/set004/composer.lock
 /fixtures/set004/scoper.inc.php
+/fixtures/set014/composer.lock
 /fixtures/set028-symfony/expected-output
 /fixtures/set030/composer.lock
 /fixtures/set030/expected-output


### PR DESCRIPTION
Those fixtures did not use to generate a lock file but it looks like under certain circumstances it now do (maybe just the new Composer version).