### PR TITLE
Documentation : `Exposing functions` -> change to Heading level 3

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -346,7 +346,7 @@ return $loader;
 ```
 
 
-##### Exposing functions
+### Exposing functions
 
 The mechanism is very similar to the one used for classes. However since a
 function similar to `class_alias` does not exists for functions, we declare


### PR DESCRIPTION
Adapt markdown for configuration.md file, where `Exposing functions` should be a  heading of the same level as `Exposing classed` and `Exposing constants` to improve the readability of the docs