### PR TITLE
Normalize paths to avoid issue on Windows filesystems

### DIFF
--- a/src/Console/ConsoleScoper.php
+++ b/src/Console/ConsoleScoper.php
@@ -180,9 +180,9 @@ final class ConsoleScoper
         Assert::notNull($commonDirectoryPath);
 
         $mapFiles = static fn (array $inputFileTuple) => [
-            $inputFileTuple[0],
+            Path::normalize($inputFileTuple[0]),
             $inputFileTuple[1],
-            $outputDir.str_replace($commonDirectoryPath, '', $inputFileTuple[0]),
+            $outputDir.str_replace($commonDirectoryPath, '', Path::normalize($inputFileTuple[0])),
         ];
 
         return [


### PR DESCRIPTION
Related to https://github.com/humbug/php-scoper/issues/810

Hi,

I was facing the same issue after updating one of my package and doing local testings on a Windows mahcine. I've checked this fix locally and it's doing fine. I've used normalize instead of canonicalize as it's a bit faster and I don't think that weird paths like `to/../to/` are expected.

Tests workflow is green on my fork but I'm facing unexpected failure on E2E tests. I can't see why this commit could brain out PHAR generation. Let's see how this this PR performs 😸 

Feel free to close it if it's not welcome.
