### PR TITLE
Changed output subpath logic

### DIFF
--- a/src/Configuration/ConfigurationFactory.php
+++ b/src/Configuration/ConfigurationFactory.php
@@ -390,7 +390,7 @@ final class ConfigurationFactory
     {
         $filesWithContents = [];
 
-        foreach ($files as $filePathOrFileInfo) {
+        foreach ($files as $fileKey => $filePathOrFileInfo) {
             $filePath = $filePathOrFileInfo instanceof SplFileInfo
                 ? $filePathOrFileInfo->getRealPath()
                 : realpath($filePathOrFileInfo);
@@ -413,7 +413,7 @@ final class ConfigurationFactory
                 );
             }
 
-            $filesWithContents[$filePath] = [$filePath, file_get_contents($filePath)];
+            $filesWithContents[$fileKey] = [$filePath, file_get_contents($filePath)];
         }
 
         return $filesWithContents;

--- a/src/Console/ConsoleScoper.php
+++ b/src/Console/ConsoleScoper.php
@@ -179,20 +179,22 @@ final class ConsoleScoper
         );
         Assert::notNull($commonDirectoryPath);
 
-        $mapFiles = static fn (array $inputFileTuple) => [
+        $mapFiles = static fn (array $inputFileTuple, string $fileKey ) => [
             Path::normalize($inputFileTuple[0]),
             $inputFileTuple[1],
-            $outputDir.str_replace($commonDirectoryPath, '', Path::normalize($inputFileTuple[0])),
+            $outputDir.str_replace($commonDirectoryPath, '', Path::normalize($fileKey)),
         ];
 
         return [
             array_map(
                 $mapFiles,
                 $filesWithContent,
+                array_keys( $filesWithContent )
             ),
             array_map(
                 $mapFiles,
                 $excludedFilesWithContents,
+                array_keys( $excludedFilesWithContents )
             ),
         ];
     }


### PR DESCRIPTION
Concerning #683, the proposed changes are aimed at guaranteeing the subpath in the output directory is returning the correct values even when libraries are symlinked from a local location.

Since a Symfony Finder component returns files in an associative array where keys are the path of files always relative to the current project even when symlinks are followed, those keys can be effectively used to determine the subpath of the files in the output directory. The advantage is that there will not be any difference when the local library is replaced with the production one.

Please consider that, unlike what we discussed in #683, this first approach replaces the logic behind the current implementation. If this works, we could consider letting the two different strategies coexist through the appropriate configuration.