### PR TITLE
feat: Do not swallow exceptions when scoping

### DIFF
--- a/fixtures/set002/original/composer/installed.json
+++ b/fixtures/set002/original/composer/installed.json
@@ -1,1 +1,3 @@
-{"just here": "for the detection"}
+{
+    "packages": []
+}

--- a/fixtures/set002/scoped/composer/installed.json
+++ b/fixtures/set002/scoped/composer/installed.json
@@ -1,1 +1,3 @@
-{"just here": "for the detection"}
+{
+    "packages": []
+}

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -24,8 +24,6 @@ parameters:
         - message: '#NamespaceManipulator::getOriginalName\(\) should return#'
           path: 'src/PhpParser/NodeVisitor/NamespaceStmt/NamespaceManipulator.php'
         - message: '#Dead catch#'
-          path: 'tests/Scoper/PhpScoperTest.php'
-        - message: '#Dead catch#'
           path: 'tests/Scoper/PhpScoperSpecTest.php'
         - message: '#DummyScoperFactory extends @final#'
           path: 'tests/Console/Command/DummyScoperFactory.php'

--- a/src/Console/Command/AddPrefixCommand.php
+++ b/src/Console/Command/AddPrefixCommand.php
@@ -51,6 +51,7 @@ final class AddPrefixCommand implements Command, CommandAware
     private const OUTPUT_DIR_OPT = 'output-dir';
     private const FORCE_OPT = 'force';
     private const STOP_ON_FAILURE_OPT = 'stop-on-failure';
+    private const CONTINUE_ON_FAILURE_OPT = 'continue-on-failure';
     private const CONFIG_FILE_OPT = 'config';
     private const NO_CONFIG_OPT = 'no-config';
 
@@ -108,6 +109,12 @@ final class AddPrefixCommand implements Command, CommandAware
                     'Stops on failure.',
                 ),
                 new InputOption(
+                    self::CONTINUE_ON_FAILURE_OPT,
+                    null,
+                    InputOption::VALUE_NONE,
+                    'Continue on non PHP-Parser parsing failures.',
+                ),
+                new InputOption(
                     self::CONFIG_FILE_OPT,
                     'c',
                     InputOption::VALUE_REQUIRED,
@@ -150,10 +157,38 @@ final class AddPrefixCommand implements Command, CommandAware
             $config,
             $paths,
             $outputDir,
-            $io->getOption(self::STOP_ON_FAILURE_OPT)->asBoolean(),
+            self::getStopOnFailure($io),
         );
 
         return ExitCode::SUCCESS;
+    }
+
+    private static function getStopOnFailure(IO $io): bool
+    {
+        $stopOnFailure = $io->getOption(self::STOP_ON_FAILURE_OPT)->asBoolean();
+        $continueOnFailure = $io->getOption(self::CONTINUE_ON_FAILURE_OPT)->asBoolean();
+
+        if ($stopOnFailure) {
+            $io->info(
+                sprintf(
+                    'Using the option "%s" is now deprecated. Any non PHP-Parser parsing error will now halt the process. To continue upon non-PHP-Parser parsing errors, use the option "%s".',
+                    self::STOP_ON_FAILURE_OPT,
+                    self::CONTINUE_ON_FAILURE_OPT,
+                ),
+            );
+        }
+
+        if (true === $stopOnFailure && true === $continueOnFailure) {
+            $io->info(
+                sprintf(
+                    'Only one of the two options "%s" and "%s" can be used at the same time.',
+                    self::STOP_ON_FAILURE_OPT,
+                    self::CONTINUE_ON_FAILURE_OPT,
+                ),
+            );
+        }
+
+        return $stopOnFailure;
     }
 
     /**

--- a/src/Console/ConsoleScoper.php
+++ b/src/Console/ConsoleScoper.php
@@ -22,6 +22,7 @@ use Humbug\PhpScoper\Scoper\Scoper;
 use Humbug\PhpScoper\Scoper\ScoperFactory;
 use Humbug\PhpScoper\Symbol\SymbolsRegistry;
 use Humbug\PhpScoper\Throwable\Exception\ParsingException;
+use PhpParser\Error as PhpParserError;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Filesystem\Path;
 use Throwable;
@@ -33,7 +34,6 @@ use function count;
 use function preg_match as native_preg_match;
 use function Safe\file_get_contents;
 use function Safe\fileperms;
-use function sprintf;
 use function str_replace;
 use function strlen;
 use function usort;
@@ -230,13 +230,9 @@ final class ConsoleScoper
                 $inputFilePath,
                 $inputContents,
             );
-        } catch (Throwable $throwable) {
-            $exception = new ParsingException(
-                sprintf(
-                    'Could not parse the file "%s".',
-                    $inputFilePath,
-                ),
-                0,
+        } catch (PhpParserError $throwable) {
+            $exception = ParsingException::forFile(
+                $inputFilePath,
                 $throwable,
             );
 

--- a/src/Scoper/PhpScoper.php
+++ b/src/Scoper/PhpScoper.php
@@ -16,6 +16,7 @@ namespace Humbug\PhpScoper\Scoper;
 
 use Humbug\PhpScoper\PhpParser\Printer\Printer;
 use Humbug\PhpScoper\PhpParser\TraverserFactory;
+use Humbug\PhpScoper\Throwable\Exception\ParsingException;
 use PhpParser\Error as PhpParserError;
 use PhpParser\Lexer;
 use PhpParser\Parser;
@@ -42,8 +43,6 @@ final class PhpScoper implements Scoper
 
     /**
      * Scopes PHP files.
-     *
-     * @throws PhpParserError
      */
     public function scope(string $filePath, string $contents): string
     {
@@ -51,7 +50,11 @@ final class PhpScoper implements Scoper
             return $this->decoratedScoper->scope(...func_get_args());
         }
 
-        return $this->scopePhp($contents);
+        try {
+            return $this->scopePhp($contents);
+        } catch (PhpParserError $parsingException) {
+            throw ParsingException::forFile($filePath, $parsingException);
+        }
     }
 
     public function scopePhp(string $php): string

--- a/src/Throwable/Exception/ParsingException.php
+++ b/src/Throwable/Exception/ParsingException.php
@@ -14,6 +14,18 @@ declare(strict_types=1);
 
 namespace Humbug\PhpScoper\Throwable\Exception;
 
+use Throwable;
+
 final class ParsingException extends RuntimeException
 {
+    public static function forFile(string $filePath, Throwable $previous): self
+    {
+        return new self(
+            sprintf(
+                'Could not parse the file "%s".',
+                $filePath,
+            ),
+            previous: $previous,
+        );
+    }
 }

--- a/tests/Console/Command/AddPrefixCommandIntegrationTest.php
+++ b/tests/Console/Command/AddPrefixCommandIntegrationTest.php
@@ -195,7 +195,7 @@ class AddPrefixCommandIntegrationTest extends FileSystemTestCase implements AppT
 
             PhpScoper version TestVersion 28/01/2020
 
-             * [NO] /path/to/composer/installed.json
+             * [OK] /path/to/composer/installed.json
              * [OK] /path/to/executable-file.php
              * [OK] /path/to/file.php
              * [NO] /path/to/invalid-file.php
@@ -245,19 +245,7 @@ class AddPrefixCommandIntegrationTest extends FileSystemTestCase implements AppT
 
             PhpScoper version TestVersion 28/01/2020
 
-             * [NO] /path/to/composer/installed.json
-            	Could not parse the file "/path/to/composer/installed.json".: InvalidArgumentException
-            Stack trace:
-            #0
-            #1
-            #2
-            #3
-            #4
-            #5
-            #6
-            #7
-            #8
-            #9
+             * [OK] /path/to/composer/installed.json
              * [OK] /path/to/executable-file.php
              * [OK] /path/to/file.php
              * [NO] /path/to/invalid-file.php

--- a/tests/Scoper/PhpScoperTest.php
+++ b/tests/Scoper/PhpScoperTest.php
@@ -23,6 +23,7 @@ use Humbug\PhpScoper\PhpParser\TraverserFactory;
 use Humbug\PhpScoper\Symbol\EnrichedReflector;
 use Humbug\PhpScoper\Symbol\Reflector;
 use Humbug\PhpScoper\Symbol\SymbolsRegistry;
+use Humbug\PhpScoper\Throwable\Exception\ParsingException;
 use LogicException;
 use PhpParser\Error as PhpParserError;
 use PhpParser\Lexer;
@@ -267,18 +268,14 @@ class PhpScoperTest extends TestCase
 
             PHP;
 
-        try {
-            $this->scoper->scope($filePath, $contents);
+        $this->expectExceptionObject(
+            new ParsingException(
+                'Could not parse the file "invalid-file.php".',
+                previous: new PhpParserError('Syntax error, unexpected \';\' on line 3'),
+            ),
+        );
 
-            self::fail('Expected exception to have been thrown.');
-        } catch (PhpParserError $error) {
-            self::assertEquals(
-                'Syntax error, unexpected \';\' on line 3',
-                $error->getMessage(),
-            );
-            self::assertSame(0, $error->getCode());
-            self::assertNull($error->getPrevious());
-        }
+        $this->scoper->scope($filePath, $contents);
     }
 
     public function test_creates_a_new_traverser_for_each_file(): void


### PR DESCRIPTION
Closes #847.

As reported in #847, the current strategy is not ideal: if a failure occurs, the file is preserved. You can only see that there was a failure by paying attention to the output or having a more verbose output, unless you pass the `--stop-on-failure` option.

I think historically it has been that way because in the early days of PHP-Scoper, a failure was non infrequent and it was very frustrating to not be able to examine the result despite the failure.

The tool is now more robust and the only exception that I can see regularly coming still is invalid PHP code (e.g. when it is a template). As such, this PR proposes to:

- Leave the file unchanged if a PHP-Parser parsing error occurred (it is still marked as failed and appears in the logs as before).
- Fail on any other failure (i.e. proceed as if `--stop-on-failure` was always provided).
- Introduce a new counterpart option `--continue-on-failure`.

The option `--stop-on-failure` has now been deprecated and will be removed a future version as it is now useless.