### PR TITLE
doc: Fix the broken link even more

### DIFF
--- a/docs/further-reading.md
+++ b/docs/further-reading.md
@@ -62,7 +62,7 @@ When [exposing a class], an alias will be registered.
 
 #### Function aliases
 
-When [exposing a function] or when a globally declared [excluded function]
+When [exposing a function] or when a globally declared [excluded-function]
 declaration is found (see [#706]), an alias will be registered.
 
 


### PR DESCRIPTION
There was a missing dash.

![image](https://github.com/humbug/php-scoper/assets/952007/d0677c13-ccb9-4660-9aaf-efcbf15ae25e)

From #896
