### PR TITLE
test: Do not hide the original throwable stack trace when failing to parse a file

### DIFF
--- a/tests/Scoper/PhpScoperSpecTest.php
+++ b/tests/Scoper/PhpScoperSpecTest.php
@@ -22,6 +22,7 @@ use Humbug\PhpScoper\Configuration\SymbolsConfigurationFactory;
 use Humbug\PhpScoper\Container;
 use Humbug\PhpScoper\PhpParser\TraverserFactory;
 use Humbug\PhpScoper\Scoper\Spec\SpecFinder;
+use Humbug\PhpScoper\Scoper\Spec\UnparsableFile;
 use Humbug\PhpScoper\Symbol\EnrichedReflector;
 use Humbug\PhpScoper\Symbol\NamespaceRegistry;
 use Humbug\PhpScoper\Symbol\Reflector;
@@ -244,13 +245,7 @@ class PhpScoperSpecTest extends TestCase
                     );
                 }
             } catch (Throwable $throwable) {
-                self::fail(
-                    sprintf(
-                        'An error occurred while parsing the file "%s": %s',
-                        $file,
-                        $throwable->getMessage(),
-                    ),
-                );
+                throw UnparsableFile::create($file, $throwable);
             }
         }
     }
@@ -306,6 +301,7 @@ class PhpScoperSpecTest extends TestCase
             ];
         }
 
+        throw new Error('hello');
         $spec = sprintf(
             '[%s] %s',
             $meta['title'],

--- a/tests/Scoper/PhpScoperSpecTest.php
+++ b/tests/Scoper/PhpScoperSpecTest.php
@@ -305,7 +305,6 @@ class PhpScoperSpecTest extends TestCase
             ];
         }
 
-        throw new Error('hello');
         $spec = sprintf(
             '[%s] %s',
             $meta['title'],

--- a/tests/Scoper/Spec/UnparsableFile.php
+++ b/tests/Scoper/Spec/UnparsableFile.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the humbug/php-scoper package.
+ *
+ * Copyright (c) 2017 Théo FIDRY <theo.fidry@gmail.com>,
+ *                    Pádraic Brady <padraic.brady@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Humbug\PhpScoper\Scoper\Spec;
+
+use DomainException;
+use SplFileInfo;
+use Throwable;
+use function sprintf;
+
+final class UnparsableFile extends DomainException
+{
+    public static function create(
+        SplFileInfo $file,
+        Throwable $throwable,
+    ): self {
+        return new self(
+            sprintf(
+                'An error occurred while parsing the file "%s": %s',
+                $file,
+                $throwable->getMessage(),
+            ),
+            previous: $throwable,
+        );
+    }
+}


### PR DESCRIPTION
When a spec file could not be parsed, a `self::fail()` was used instead of letting the throwable bubble up. This was done to know which fail failed to parsed.

The implementation however, is faulty as if an exception is thrown, there is no stack trace. This is especially annoying when the throwable may not be thrown due to an invalid spec file but due to the way this file is parsed (i.e. code within the `PhpScoperSpecTest`).

This PR introduces a new exception which will contain the previously thrown exception but will also include a more friendly message to easily know for which file this was caused.