### PR TITLE
test: Remove dead code

### DIFF
--- a/tests/Scoper/PhpScoperSpecTest.php
+++ b/tests/Scoper/PhpScoperSpecTest.php
@@ -313,7 +313,7 @@ class PhpScoperSpecTest extends TestCase
         $spec = sprintf(
             '[%s] %s',
             $meta['title'],
-            $fixtureSet['spec'] ?? $fixtureTitle,
+            $fixtureTitle,
         );
 
         $payload = is_string($fixtureSet) ? $fixtureSet : $fixtureSet['payload'];


### PR DESCRIPTION
This `spec` keyword is not allowed within a specification file hence this condition can never be met.