### PR TITLE
fix: Do not assume non-resolved symbols matches exposed or excluded symbols

### DIFF
--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -12,6 +12,7 @@
 - [Files autoloading](#files-autoloading)
 - [Exposing/Excluding traits](#exposingexcluding-traits)
 - [Exposing/Excluding enums](#exposingexcluding-enums)
+- [Declaring a custom namespaced function `function_exists()`](#declaring-a-custom-namespaced-function-function_exists)
 
 
 ### Dynamic symbols
@@ -261,6 +262,27 @@ that extends the scoped trait, but this is currently not implemented.
 
 There is currently no way to expose or exclude an enum. The problem being there
 is no way to alias one.
+
+
+### Declaring a custom namespaced function `function_exists()`
+
+When PHP-Scoper encounters a call such as this one:
+
+```php
+namespace App;
+
+function_exists('NewApp\main');
+```
+
+That the string contained by `function_exists` is a fully-qualified class name.
+This is true however if `function_exists()` is the native PHP one. However,
+technically, if the function `App\function_exists()` does exist, then the call
+above would call `App\function_exists()` and not `function_exists()`.
+
+This is a very unlikely scenario which is why PHP-Scoper will assume it is the
+PHP native one.
+
+If, by any chance, this is a problem, you will have to fix it with [patchers].
 
 
 <br />

--- a/fixtures/set027-laravel/scoper.inc.php
+++ b/fixtures/set027-laravel/scoper.inc.php
@@ -25,8 +25,8 @@ return [
             }
 
             return str_replace(
-                '$component = \'\\\\Illuminate\\\\Console\\\\View\\\\Components\\\\\' . \ucfirst($method);',
-                '$component = \'\\\\'.$prefix.'\\\\Illuminate\\\\Console\\\\View\\\\Components\\\\\' . \ucfirst($method);',
+                '$component = \'\\\\Illuminate\\\\Console\\\\View\\\\Components\\\\\' . ucfirst($method);',
+                '$component = \'\\\\'.$prefix.'\\\\Illuminate\\\\Console\\\\View\\\\Components\\\\\' . ucfirst($method);',
                 $contents,
             );
         },

--- a/specs/const/const-declaration-with-global-exposed.php
+++ b/specs/const/const-declaration-with-global-exposed.php
@@ -147,11 +147,11 @@ return [
         namespace Humbug\Acme;
 
         const FOO_CONST = foo();
-        \define('BAR_CONST', foo());
-        \define('Humbug\\Acme\\BAR_CONST', foo());
-        \define(FOO_CONST, foo());
-        \define(\FOO_CONST, foo());
-        \define(\Humbug\Acme\FOO_CONST, foo());
+        define('BAR_CONST', foo());
+        define('Humbug\\Acme\\BAR_CONST', foo());
+        define(FOO_CONST, foo());
+        define(\FOO_CONST, foo());
+        define(\Humbug\Acme\FOO_CONST, foo());
 
         PHP,
 
@@ -174,11 +174,11 @@ return [
             namespace Acme;
 
             const FOO_CONST = foo();
-            \define('BAR_CONST', foo());
-            \define('Acme\\BAR_CONST', foo());
-            \define(FOO_CONST, foo());
-            \define(\FOO_CONST, foo());
-            \define(\Acme\BAR_CONST, foo());
+            define('BAR_CONST', foo());
+            define('Acme\\BAR_CONST', foo());
+            define(FOO_CONST, foo());
+            define(\FOO_CONST, foo());
+            define(\Acme\BAR_CONST, foo());
 
             PHP,
     ),
@@ -202,11 +202,11 @@ return [
             namespace Humbug\Acme;
 
             const FOO_CONST = foo();
-            \define('BAR_CONST', foo());
-            \define('Acme\\BAR_CONST', foo());
-            \define(FOO_CONST, foo());
-            \define(\FOO_CONST, foo());
-            \define(\Acme\BAR_CONST, foo());
+            define('BAR_CONST', foo());
+            define('Acme\\BAR_CONST', foo());
+            define(FOO_CONST, foo());
+            define(\FOO_CONST, foo());
+            define(\Acme\BAR_CONST, foo());
 
             PHP,
     ),
@@ -230,11 +230,11 @@ return [
             namespace Humbug\Acme;
 
             \define('Acme\\FOO_CONST', foo());
-            \define('BAR_CONST', foo());
-            \define('Acme\\BAR_CONST', foo());
-            \define(FOO_CONST, foo());
-            \define(\FOO_CONST, foo());
-            \define(\Acme\BAR_CONST, foo());
+            define('BAR_CONST', foo());
+            define('Acme\\BAR_CONST', foo());
+            define(FOO_CONST, foo());
+            define(\FOO_CONST, foo());
+            define(\Acme\BAR_CONST, foo());
 
             PHP,
     ),

--- a/specs/const/const-declaration.php
+++ b/specs/const/const-declaration.php
@@ -243,20 +243,20 @@ return [
             const X = 'x';
             const Y = '';
         }
-        if (!\defined('Humbug\\BAR_CONST')) {
-            \define('Humbug\\BAR_CONST', foo());
+        if (!defined('Humbug\\BAR_CONST')) {
+            define('Humbug\\BAR_CONST', foo());
         }
-        if (!\defined('Humbug\\Acme\\BAR_CONST')) {
-            \define('Humbug\\Acme\\BAR_CONST', foo());
+        if (!defined('Humbug\\Acme\\BAR_CONST')) {
+            define('Humbug\\Acme\\BAR_CONST', foo());
         }
-        if (!\defined('Humbug\\Acme\\FOO_CONST')) {
-            \define(FOO_CONST, foo());
+        if (!defined('Humbug\\Acme\\FOO_CONST')) {
+            define(FOO_CONST, foo());
         }
-        if (!\defined('Humbug\\FOO_CONST')) {
-            \define(\Humbug\FOO_CONST, foo());
+        if (!defined('Humbug\\FOO_CONST')) {
+            define(\Humbug\FOO_CONST, foo());
         }
-        if (!\defined('Humbug\\Acme\\BAR_CONST')) {
-            \define(\Humbug\Acme\BAR_CONST, foo());
+        if (!defined('Humbug\\Acme\\BAR_CONST')) {
+            define(\Humbug\Acme\BAR_CONST, foo());
         }
 
         PHP,
@@ -296,20 +296,20 @@ return [
                 const X = 'x';
                 const Y = '';
             }
-            if (!\defined('Humbug\\BAR_CONST')) {
-                \define('Humbug\\BAR_CONST', foo());
+            if (!defined('Humbug\\BAR_CONST')) {
+                define('Humbug\\BAR_CONST', foo());
             }
-            if (!\defined('Acme\\BAR_CONST')) {
-                \define('Acme\\BAR_CONST', foo());
+            if (!defined('Acme\\BAR_CONST')) {
+                define('Acme\\BAR_CONST', foo());
             }
-            if (!\defined('Acme\\FOO_CONST')) {
-                \define(FOO_CONST, foo());
+            if (!defined('Acme\\FOO_CONST')) {
+                define(FOO_CONST, foo());
             }
-            if (!\defined('Humbug\\FOO_CONST')) {
-                \define(\Humbug\FOO_CONST, foo());
+            if (!defined('Humbug\\FOO_CONST')) {
+                define(\Humbug\FOO_CONST, foo());
             }
-            if (!\defined('Acme\\BAR_CONST')) {
-                \define(\Acme\BAR_CONST, foo());
+            if (!defined('Acme\\BAR_CONST')) {
+                define(\Acme\BAR_CONST, foo());
             }
 
             PHP,
@@ -350,20 +350,20 @@ return [
                 const X = 'x';
                 const Y = '';
             }
-            if (!\defined('Humbug\\BAR_CONST')) {
-                \define('Humbug\\BAR_CONST', foo());
+            if (!defined('Humbug\\BAR_CONST')) {
+                define('Humbug\\BAR_CONST', foo());
             }
-            if (!\defined('Acme\\BAR_CONST')) {
-                \define('Acme\\BAR_CONST', foo());
+            if (!defined('Acme\\BAR_CONST')) {
+                define('Acme\\BAR_CONST', foo());
             }
-            if (!\defined('Humbug\\Acme\\FOO_CONST')) {
-                \define(FOO_CONST, foo());
+            if (!defined('Humbug\\Acme\\FOO_CONST')) {
+                define(FOO_CONST, foo());
             }
-            if (!\defined('Humbug\\FOO_CONST')) {
-                \define(\Humbug\FOO_CONST, foo());
+            if (!defined('Humbug\\FOO_CONST')) {
+                define(\Humbug\FOO_CONST, foo());
             }
-            if (!\defined('Acme\\BAR_CONST')) {
-                \define(\Acme\BAR_CONST, foo());
+            if (!defined('Acme\\BAR_CONST')) {
+                define(\Acme\BAR_CONST, foo());
             }
 
             PHP,
@@ -388,8 +388,8 @@ return [
                     }
 
                     function isAnotherNewToken(int $token): bool {
-                        if (!\defined('ANOTHER_NEW_TOKEN')) {
-                            \define('ANOTHER_NEW_TOKEN', 502);
+                        if (!defined('ANOTHER_NEW_TOKEN')) {
+                            define('ANOTHER_NEW_TOKEN', 502);
                         }
 
                         return ANOTHER_NEW_TOKEN === $token;
@@ -404,8 +404,8 @@ return [
                     }
 
                     function isAnotherNewToken(int $token): bool {
-                        if (!\defined('ANOTHER_NEW_TOKEN')) {
-                            \define('ANOTHER_NEW_TOKEN', 502);
+                        if (!defined('ANOTHER_NEW_TOKEN')) {
+                            define('ANOTHER_NEW_TOKEN', 502);
                         }
 
                         return \ANOTHER_NEW_TOKEN === $token;
@@ -429,8 +429,8 @@ return [
                 }
                 function isAnotherNewToken(int $token) : bool
                 {
-                    if (!\defined('ANOTHER_NEW_TOKEN')) {
-                        \define('ANOTHER_NEW_TOKEN', 502);
+                    if (!defined('ANOTHER_NEW_TOKEN')) {
+                        define('ANOTHER_NEW_TOKEN', 502);
                     }
                     return \ANOTHER_NEW_TOKEN === $token;
                 }
@@ -445,8 +445,8 @@ return [
                 }
                 function isAnotherNewToken(int $token) : bool
                 {
-                    if (!\defined('ANOTHER_NEW_TOKEN')) {
-                        \define('ANOTHER_NEW_TOKEN', 502);
+                    if (!defined('ANOTHER_NEW_TOKEN')) {
+                        define('ANOTHER_NEW_TOKEN', 502);
                     }
                     return \ANOTHER_NEW_TOKEN === $token;
                 }

--- a/specs/const/native-const.php
+++ b/specs/const/native-const.php
@@ -37,8 +37,8 @@ return [
         namespace Humbug\Acme;
 
         $x = \DIRECTORY_SEPARATOR;
-        if (!\defined('PATH_SEPARATOR')) {
-            \define('PATH_SEPARATOR', "\n");
+        if (!defined('PATH_SEPARATOR')) {
+            define('PATH_SEPARATOR', "\n");
         }
 
         PHP,
@@ -63,8 +63,8 @@ return [
 
         use const Humbug\Acme\DIRECTORY_SEPARATOR;
         $x = DIRECTORY_SEPARATOR;
-        if (!\defined('PATH_SEPARATOR')) {
-            \define('PATH_SEPARATOR', "\n");
+        if (!defined('PATH_SEPARATOR')) {
+            define('PATH_SEPARATOR', "\n");
         }
 
         PHP,

--- a/specs/func-declaration/global.php
+++ b/specs/func-declaration/global.php
@@ -605,7 +605,7 @@ return [
             }
             namespace Humbug\A;
 
-            \trigger_deprecation();
+            trigger_deprecation();
             namespace Humbug\B;
 
             use function trigger_deprecation;

--- a/specs/function/exposed-func-existence-checked.php
+++ b/specs/function/exposed-func-existence-checked.php
@@ -100,7 +100,7 @@ return [
 
             namespace Humbug\Acme;
 
-            \function_exists('Humbug\\Acme\\main');
+            function_exists('Humbug\\Acme\\main');
 
             PHP,
     ),
@@ -118,7 +118,7 @@ return [
 
             namespace Acme;
 
-            \function_exists('Acme\\main');
+            function_exists('Acme\\main');
 
             PHP,
     ),

--- a/specs/function/namespace-global-scope-func.php
+++ b/specs/function/namespace-global-scope-func.php
@@ -53,9 +53,6 @@ return [
 
         PHP,
 
-    // In theory this case CAN be wrong. There is however a very high chance it
-    // is not as it implies having both A\foo() and foo() in the
-    // codebase with only foo() exposed.
     'Exposed constant call in a namespace' => SpecWithConfig::create(
         exposeFunctions: ['foo'],
         spec: <<<'PHP'
@@ -69,7 +66,7 @@ return [
 
             namespace Humbug\A;
 
-            \Humbug\foo();
+            foo();
 
             PHP,
     ),

--- a/specs/function/native-func.php
+++ b/specs/function/native-func.php
@@ -33,7 +33,7 @@ return [
 
         namespace Humbug\Acme;
 
-        $x = \is_array([]);
+        $x = is_array([]);
 
         PHP,
 

--- a/specs/misc/date.php
+++ b/specs/misc/date.php
@@ -93,14 +93,14 @@ return [
         new Foo('Humbug\\d\\H\\Z');
         new DateTime('d\\H\\Z');
         new DateTimeImmutable('d\\H\\Z');
-        \date_create('d\\H\\Z');
-        \date('d\\H\\Z');
-        \gmdate('d\\H\\Z');
+        date_create('d\\H\\Z');
+        date('d\\H\\Z');
+        gmdate('d\\H\\Z');
         DateTime::createFromFormat('d\\H\\Z', '15\\Feb\\2009');
         DateTimeImmutable::createFromFormat('d\\H\\Z', '15\\Feb\\2009');
-        \date_create_from_format('d\\H\\Z', '15\\Feb\\2009');
+        date_create_from_format('d\\H\\Z', '15\\Feb\\2009');
         (new DateTime('now'))->format('Humbug\\d\\H\\Z');
-        \date_format(new DateTime('now'), 'Humbug\\d\\H\\Z');
+        date_format(new DateTime('now'), 'Humbug\\d\\H\\Z');
 
         PHP,
 ];

--- a/specs/misc/expose-symbols-case-sensitiveness.php
+++ b/specs/misc/expose-symbols-case-sensitiveness.php
@@ -65,7 +65,7 @@ return [
             namespace Humbug\Acme;
 
             const FOO = 'foo';
-            \define('Humbug\\Acme\\BAR', 'bar');
+            define('Humbug\\Acme\\BAR', 'bar');
             echo \Humbug\Acme\BAR;
 
             PHP,
@@ -86,7 +86,7 @@ return [
             namespace Humbug\Acme;
 
             \define('Acme\\FOO', 'foo');
-            \define('Acme\\BAR', 'bar');
+            define('Acme\\BAR', 'bar');
 
             PHP,
     ),
@@ -131,7 +131,7 @@ return [
                 }
             }
             const FOO = 'foo';
-            \define('Acme\\BAR', 'bar');
+            define('Acme\\BAR', 'bar');
             namespace Humbug\Bar;
 
             use Acme\Foo;

--- a/specs/special-keywords/self-parent-return-type.php
+++ b/specs/special-keywords/self-parent-return-type.php
@@ -154,7 +154,7 @@ return [
             public function normalize() : parent
             {
                 $instance = clone $this;
-                $instance->name = \strtoupper($this->name);
+                $instance->name = strtoupper($this->name);
                 return $instance;
             }
         }

--- a/specs/string-literal/misc.php
+++ b/specs/string-literal/misc.php
@@ -44,7 +44,7 @@ return [
         declare (strict_types=1);
         namespace Humbug\Acme;
 
-        \sprintf(<<<'_PHP'
+        sprintf(<<<'_PHP'
         if (!function_exists('%1$s')) {
             function %1$s() {
                 return \%2$s(func_get_args());

--- a/src/PhpParser/NodeVisitor/FunctionIdentifierRecorder.php
+++ b/src/PhpParser/NodeVisitor/FunctionIdentifierRecorder.php
@@ -154,7 +154,8 @@ final class FunctionIdentifierRecorder extends NodeVisitorAbstract
         $name = $node->name;
 
         return $name instanceof Name
-            && $name->isFullyQualified()
+            // PHP-Scoper assumes that it is the PHP native function.
+            // See limitations.md#declaring-a-custom-namespaced-function-function_exists
             && $name->toString() === 'function_exists';
     }
 

--- a/src/PhpParser/NodeVisitor/NameStmtPrefixer.php
+++ b/src/PhpParser/NodeVisitor/NameStmtPrefixer.php
@@ -384,7 +384,7 @@ final class NameStmtPrefixer extends NodeVisitorAbstract
         // explicitly register a constant to be exposed or that the constant
         // is internal that it is the constant in question and not the one
         // relative to the namespace.
-        // Indeed it would otherwise mean that the user has for example Acme\FOO
+        // Indeed, it would otherwise mean that the user has for example Acme\FOO
         // and \FOO in the codebase AND decide to expose \FOO.
         // It is not only unlikely but sketchy, hence should not be an issue
         // in practice.
@@ -432,19 +432,19 @@ final class NameStmtPrefixer extends NodeVisitorAbstract
                 : null;
         }
 
-        if ($this->enrichedReflector->isFunctionInternal($resolvedNameString)) {
-            return new FullyQualified(
-                $originalName->toString(),
-                $originalName->getAttributes(),
-            );
-        }
+//        if ($this->enrichedReflector->isFunctionInternal($resolvedNameString)) {
+//            return new FullyQualified(
+//                $originalName->toString(),
+//                $originalName->getAttributes(),
+//            );
+//        }
+//
+//        if ($this->enrichedReflector->isExposedFunction($resolvedNameString)) {
+//            return $this->enrichedReflector->isExposedFunctionFromGlobalNamespace($resolvedNameString)
+//                ? $resolvedName
+//                : null;
+//        }
 
-        if ($this->enrichedReflector->isExposedFunction($resolvedNameString)) {
-            return $this->enrichedReflector->isExposedFunctionFromGlobalNamespace($resolvedNameString)
-                ? $resolvedName
-                : null;
-        }
-
-        return $resolvedName;
+        return $originalName;
     }
 }

--- a/src/PhpParser/NodeVisitor/NameStmtPrefixer.php
+++ b/src/PhpParser/NodeVisitor/NameStmtPrefixer.php
@@ -432,19 +432,6 @@ final class NameStmtPrefixer extends NodeVisitorAbstract
                 : null;
         }
 
-//        if ($this->enrichedReflector->isFunctionInternal($resolvedNameString)) {
-//            return new FullyQualified(
-//                $originalName->toString(),
-//                $originalName->getAttributes(),
-//            );
-//        }
-//
-//        if ($this->enrichedReflector->isExposedFunction($resolvedNameString)) {
-//            return $this->enrichedReflector->isExposedFunctionFromGlobalNamespace($resolvedNameString)
-//                ? $resolvedName
-//                : null;
-//        }
-
         return $originalName;
     }
 }


### PR DESCRIPTION
Previously if a non-fully qualified symbol was matching an exposed or excluded one, PHP-Scoper assumed it matched. Technically this is wrong, but the assumption was still good for 99% of the cases.

However with #981, we no longer need this.