### PR TITLE
build(deps): Remove `symfony/deprecation-contracts` direct dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,6 @@
         "jetbrains/phpstorm-stubs": "^2022.2",
         "nikic/php-parser": "^4.12",
         "symfony/console": "^6.4 || ^7.0",
-        "symfony/deprecation-contracts": "^3.4",
         "symfony/filesystem": "^6.4 || ^7.0",
         "symfony/finder": "^6.4 || ^7.0",
         "thecodingmachine/safe": "^2.0"

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     ],
     "require": {
         "php": "^8.2",
-        "fidry/console": "^0.6.6",
+        "fidry/console": "^0.6.10",
         "fidry/filesystem": "^1.1",
         "jetbrains/phpstorm-stubs": "^2022.2",
         "nikic/php-parser": "^4.12",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c15283979a3692e5e68971b53ffd0d18",
+    "content-hash": "9974693309d51104e97e4e69f9b4256f",
     "packages": [
         {
             "name": "fidry/console",

--- a/composer.lock
+++ b/composer.lock
@@ -4,26 +4,27 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "a78bb28b915ca2cbf024c3e2c8914a31",
+    "content-hash": "9546714a4041905861777b2fb41e1560",
     "packages": [
         {
             "name": "fidry/console",
-            "version": "0.6.9",
+            "version": "0.6.10",
             "source": {
                 "type": "git",
                 "url": "https://github.com/theofidry/console.git",
-                "reference": "01be0be1b8dd7be3f475f0b9755dcc89881ec36a"
+                "reference": "a681ea3aa7f5c0c78cd437250f64b13d2818c95d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/theofidry/console/zipball/01be0be1b8dd7be3f475f0b9755dcc89881ec36a",
-                "reference": "01be0be1b8dd7be3f475f0b9755dcc89881ec36a",
+                "url": "https://api.github.com/repos/theofidry/console/zipball/a681ea3aa7f5c0c78cd437250f64b13d2818c95d",
+                "reference": "a681ea3aa7f5c0c78cd437250f64b13d2818c95d",
                 "shasum": ""
             },
             "require": {
                 "php": "^8.2",
                 "psr/log": "^3.0",
                 "symfony/console": "^6.4 || ^7.0",
+                "symfony/deprecation-contracts": "^3.4",
                 "symfony/event-dispatcher-contracts": "^2.5 || ^3.0",
                 "symfony/service-contracts": "^2.5 || ^3.0",
                 "thecodingmachine/safe": "^2.0",
@@ -39,7 +40,7 @@
                 "composer/semver": "^3.3.2",
                 "ergebnis/composer-normalize": "^2.33",
                 "fidry/makefile": "^0.2.1 || ^1.0.0",
-                "infection/infection": "^0.27",
+                "infection/infection": "^0.28",
                 "phpunit/phpunit": "^10.2",
                 "symfony/dependency-injection": "^6.4",
                 "symfony/flex": "^2.4.0",
@@ -80,7 +81,7 @@
             ],
             "support": {
                 "issues": "https://github.com/theofidry/console/issues",
-                "source": "https://github.com/theofidry/console/tree/0.6.9"
+                "source": "https://github.com/theofidry/console/tree/0.6.10"
             },
             "funding": [
                 {
@@ -88,7 +89,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-12-05T22:30:20+00:00"
+            "time": "2024-04-23T08:36:33+00:00"
         },
         {
             "name": "fidry/filesystem",


### PR DESCRIPTION
This is achieved by upgrading to `fidry/console` 0.6.10 which fixes https://github.com/theofidry/console/issues/221.

Indeed, PHP-Scoper does not use `symfony/deprecation-contracts` directly so it should be left as a transitive dependency.

Closes #939.