### PR TITLE
test: Ensure the laravel e2e test cannot fail due to a color detection issue

### DIFF
--- a/.makefile/e2e.file
+++ b/.makefile/e2e.file
@@ -195,7 +195,7 @@ e2e_027: $(PHP_SCOPER_PHAR_BIN) fixtures/set027-laravel/vendor
 		--stop-on-failure
 	composer --working-dir=build/set027-laravel dump-autoload --no-dev
 
-	php build/set027-laravel/artisan -V > build/set027-laravel/output
+	NO_COLOR=1 php build/set027-laravel/artisan -V > build/set027-laravel/output
 	diff fixtures/set027-laravel/expected-output build/set027-laravel/output
 
 .PHONY: e2e_028


### PR DESCRIPTION
This is an annoying class of issues as it is more likely to appear locally than in the CI.