### PR TITLE
fix: Do not scope class-like strings that cannot be class names

### DIFF
--- a/specs/string-literal/var.php
+++ b/specs/string-literal/var.php
@@ -31,6 +31,7 @@ return [
         $x = '\\Symfony\\Component\\Yaml\\Ya_1';
         $x = 'Humbug\\Symfony\\Component\\Yaml\\Ya_1';
         $x = '\\Humbug\\Symfony\\Component\\Yaml\\Ya_1';
+        $x = '1\2';
 
         ----
         <?php
@@ -45,6 +46,7 @@ return [
         $x = 'Humbug\Symfony\Component\Yaml\Ya_1';
         $x = 'Humbug\Symfony\Component\Yaml\Ya_1';
         $x = 'Humbug\Symfony\Component\Yaml\Ya_1';
+        $x = '1\2';
 
         PHP,
 

--- a/src/PhpParser/NodeVisitor/StringScalarPrefixer.php
+++ b/src/PhpParser/NodeVisitor/StringScalarPrefixer.php
@@ -102,7 +102,8 @@ final class StringScalarPrefixer extends NodeVisitorAbstract
         /^
             (\\)?               # leading backslash
             (
-                [\p{L}_\d]+     # class-like name
+                [\p{L}_]        # class-like name first character
+                [\p{L}_\d]*     # class-like name
                 \\              # separator
             )*
             [\p{L}_\d]+         # class-like name

--- a/src/Scoper/Symfony/XmlScoper.php
+++ b/src/Scoper/Symfony/XmlScoper.php
@@ -35,7 +35,7 @@ final readonly class XmlScoper implements Scoper
 {
     private const XML_EXTENSION_REGEX = '/\.xml$/i';
     private const NAMESPACE_PATTERN = '/<prototype.*\snamespace="(?:(?<namespace>(?:[^\\\\]+(?<separator>\\\\(?:\\\\)?))))"/';
-    private const SINGLE_CLASS_PATTERN = '/(?:(?<singleClass>(?:[\p{L}_\d]+(?<singleSeparator>\\\\(?:\\\\)?))):)|(?<class>(?:[\p{L}_\d]+(?<separator>\\\\(?:\\\\)?)+)+[\p{L}_\d]+)/u';
+    private const SINGLE_CLASS_PATTERN = '/(?:(?<singleClass>(?:[\p{L}_][\p{L}_\d]*(?<singleSeparator>\\\\(?:\\\\)?))):)|(?<class>(?:[\p{L}_][\p{L}_\d]*(?<separator>\\\\(?:\\\\)?)+)+[\p{L}_\d]+)/u';
 
     public function __construct(
         private Scoper $decoratedScoper,

--- a/src/Scoper/Symfony/YamlScoper.php
+++ b/src/Scoper/Symfony/YamlScoper.php
@@ -34,7 +34,7 @@ use function substr;
 final readonly class YamlScoper implements Scoper
 {
     private const YAML_EXTENSION_REGEX = '/\.ya?ml$/i';
-    private const CLASS_PATTERN = '/(?:(?<singleClass>(?:[\p{L}_\d]+(?<singleSeparator>\\\\(?:\\\\)?))):)|(?<class>(?:[\p{L}_\d]+(?<separator>\\\\(?:\\\\)?)+)+[\p{L}_\d]+)/u';
+    private const CLASS_PATTERN = '/(?:(?<singleClass>(?:[\p{L}_][\p{L}_\d]*(?<singleSeparator>\\\\(?:\\\\)?))):)|(?<class>(?:[\p{L}_][\p{L}_\d]*(?<separator>\\\\(?:\\\\)?)+)+[\p{L}_\d]+)/u';
 
     public function __construct(
         private Scoper $decoratedScoper,

--- a/tests/Scoper/Symfony/XmlScoperTest.php
+++ b/tests/Scoper/Symfony/XmlScoperTest.php
@@ -387,6 +387,45 @@ class XmlScoperTest extends TestCase
             [],
         ];
 
+        yield 'class-like pattern' => [
+            <<<'XML'
+                <!-- config/services.xml -->
+                <?xml version="1.0" encoding="UTF-8" ?>
+                <container xmlns="http://symfony.com/schema/dic/services"
+                    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                    xsi:schemaLocation="http://symfony.com/schema/dic/services
+                        http://symfony.com/schema/dic/services/services-1.0.xsd">
+
+                    <services>
+                        <service id="App\Mail\PhpMailer" />
+                        <service id="1\2" />
+
+                        <service id="s1" class="App\Mail\PhpMailer" alias="App\Mail\PhpMailer" />
+                        <service id="s2" class="1\2" alias="1\2" />
+                    </services>
+                </container>
+                XML,
+            SymbolsConfiguration::create(),
+            <<<'XML'
+                <!-- config/services.xml -->
+                <?xml version="1.0" encoding="UTF-8" ?>
+                <container xmlns="http://symfony.com/schema/dic/services"
+                    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                    xsi:schemaLocation="http://symfony.com/schema/dic/services
+                        http://symfony.com/schema/dic/services/services-1.0.xsd">
+
+                    <services>
+                        <service id="Humbug\App\Mail\PhpMailer" />
+                        <service id="1\2" />
+
+                        <service id="s1" class="Humbug\App\Mail\PhpMailer" alias="Humbug\App\Mail\PhpMailer" />
+                        <service id="s2" class="1\2" alias="1\2" />
+                    </services>
+                </container>
+                XML,
+            [],
+        ];
+
         yield 'service with argument' => [
             <<<'XML'
                 <!-- app/config/services.xml -->

--- a/tests/Scoper/Symfony/YamlScoperTest.php
+++ b/tests/Scoper/Symfony/YamlScoperTest.php
@@ -152,6 +152,11 @@ class YamlScoperTest extends TestCase
                     Symfony\Component\Console\Input\InputInterface:
                         alias: 'Symfony\Component\Console\Input\ArgvInput'
                     Symfony\Component\Console\Output\OutputInterface: '@Symfony\Component\Console\Output\ConsoleOutput'
+                    1\2: ~
+                    Service2:
+                        class: 1\2
+                    Service3:
+                        alias: 1\2
                 YAML,
             SymbolsConfiguration::create(),
             <<<'YAML'
@@ -160,6 +165,11 @@ class YamlScoperTest extends TestCase
                     Humbug\Symfony\Component\Console\Input\InputInterface:
                         alias: 'Humbug\Symfony\Component\Console\Input\ArgvInput'
                     Humbug\Symfony\Component\Console\Output\OutputInterface: '@Humbug\Symfony\Component\Console\Output\ConsoleOutput'
+                    1\2: ~
+                    Service2:
+                        class: 1\2
+                    Service3:
+                        alias: 1\2
                 YAML,
             [],
         ];


### PR DESCRIPTION
Closes #951.