### PR TITLE
test: standardize the autoload usage

### DIFF
--- a/fixtures/set016-symfony-finder/main.php
+++ b/fixtures/set016-symfony-finder/main.php
@@ -5,7 +5,9 @@ declare(strict_types=1);
 use Symfony\Component\Finder\Finder;
 use Symfony\Component\Finder\SplFileInfo;
 
-require_once __DIR__ . '/vendor/autoload.php';
+require file_exists(__DIR__.'/vendor/scoper-autoload.php')
+    ? __DIR__.'/vendor/scoper-autoload.php'
+    : __DIR__.'/vendor/autoload.php';
 
 $finder = Finder::create()->files()->in(__DIR__)->depth(0)->sortByName();
 

--- a/fixtures/set017-symfony-di/main.php
+++ b/fixtures/set017-symfony-di/main.php
@@ -5,7 +5,9 @@ declare(strict_types=1);
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Reference;
 
-require_once __DIR__ . '/vendor/autoload.php';
+require file_exists(__DIR__.'/vendor/scoper-autoload.php')
+    ? __DIR__.'/vendor/scoper-autoload.php'
+    : __DIR__.'/vendor/autoload.php';
 
 interface Salute
 {

--- a/fixtures/set018-nikic-parser/main.php
+++ b/fixtures/set018-nikic-parser/main.php
@@ -5,7 +5,9 @@ declare(strict_types=1);
 use PhpParser\NodeDumper;
 use PhpParser\ParserFactory;
 
-require_once __DIR__ . '/vendor/autoload.php';
+require file_exists(__DIR__.'/vendor/scoper-autoload.php')
+    ? __DIR__.'/vendor/scoper-autoload.php'
+    : __DIR__.'/vendor/autoload.php';
 
 $code = <<<'CODE'
 <?php

--- a/fixtures/set024/main.php
+++ b/fixtures/set024/main.php
@@ -6,10 +6,8 @@ namespace Acme;
 
 use function file_exists;
 
-if (file_exists($autoload = __DIR__ . '/vendor/scoper-autoload.php')) {
-    require_once $autoload;
-} else {
-    require_once __DIR__ . '/vendor/autoload.php';
-}
+require file_exists(__DIR__.'/vendor/scoper-autoload.php')
+    ? __DIR__.'/vendor/scoper-autoload.php'
+    : __DIR__.'/vendor/autoload.php';
 
 dump('foo', 'bar');

--- a/fixtures/set025/main.php
+++ b/fixtures/set025/main.php
@@ -8,11 +8,9 @@ use function call_user_func;
 use function file_exists;
 use function iter\toArray;
 
-if (file_exists($autoload = __DIR__ . '/vendor/scoper-autoload.php')) {
-    require_once $autoload;
-} else {
-    require_once __DIR__ . '/vendor/autoload.php';
-}
+require file_exists(__DIR__.'/vendor/scoper-autoload.php')
+    ? __DIR__.'/vendor/scoper-autoload.php'
+    : __DIR__.'/vendor/autoload.php';
 
 // Use concatenation to ensure it does not prefix this call. This allows to
 // double check that exposing this function works correctly.

--- a/fixtures/set029-easy-rdf/main.php
+++ b/fixtures/set029-easy-rdf/main.php
@@ -2,13 +2,9 @@
 
 declare(strict_types=1);
 
-$autoload = __DIR__.'/vendor/scoper-autoload.php';
-
-if (false === file_exists($autoload)) {
-    $autoload = __DIR__.'/vendor/autoload.php';
-}
-
-require_once $autoload;
+require file_exists(__DIR__.'/vendor/scoper-autoload.php')
+    ? __DIR__.'/vendor/scoper-autoload.php'
+    : __DIR__.'/vendor/autoload.php';
 
 $foaf = new EasyRdf\Graph('http://njh.me/foaf.rdf');
 $count = $foaf->load();

--- a/fixtures/set030/main.php
+++ b/fixtures/set030/main.php
@@ -2,13 +2,9 @@
 
 declare(strict_types=1);
 
-$autoload = __DIR__.'/vendor/scoper-autoload.php';
-
-if (false === file_exists($autoload)) {
-    $autoload = __DIR__.'/vendor/autoload.php';
-}
-
-require_once $autoload;
+require file_exists(__DIR__.'/vendor/scoper-autoload.php')
+    ? __DIR__.'/vendor/scoper-autoload.php'
+    : __DIR__.'/vendor/autoload.php';
 
 echo foo() ? 'ok' : 'ko';
 echo PHP_EOL;


### PR DESCRIPTION
Use the same pattern for all cases. In a few of them the exposed symbols was not necessary hence not using the `scoper-autoload.php` was not a problem, but still could be that some problems go unnoticed so addressed that.