### PR TITLE
refactor: Leverage the PhpParser v5 printer changes

### DIFF
--- a/src/PhpParser/Printer/Printer.php
+++ b/src/PhpParser/Printer/Printer.php
@@ -15,13 +15,14 @@ declare(strict_types=1);
 namespace Humbug\PhpScoper\PhpParser\Printer;
 
 use PhpParser\Node;
+use PhpParser\Token;
 
 interface Printer
 {
     /**
-     * @param Node[]       $newStmts
-     * @param Node[]       $oldStmts
-     * @param array<mixed> $oldTokens
+     * @param Node[]  $newStmts
+     * @param Node[]  $oldStmts
+     * @param Token[] $oldTokens
      */
     public function print(array $newStmts, array $oldStmts, array $oldTokens): string;
 }

--- a/src/PhpParser/Printer/StandardPrinter.php
+++ b/src/PhpParser/Printer/StandardPrinter.php
@@ -14,16 +14,18 @@ declare(strict_types=1);
 
 namespace Humbug\PhpScoper\PhpParser\Printer;
 
-use PhpParser\PrettyPrinterAbstract;
+use PhpParser\PrettyPrinter;
 
 final readonly class StandardPrinter implements Printer
 {
-    public function __construct(private PrettyPrinterAbstract $decoratedPrinter)
+    public function __construct(private PrettyPrinter $decoratedPrinter)
     {
     }
 
     public function print(array $newStmts, array $oldStmts, array $oldTokens): string
     {
-        return $this->decoratedPrinter->prettyPrintFile($newStmts)."\n";
+        $printedStatements = $this->decoratedPrinter->prettyPrintFile($newStmts);
+
+        return $printedStatements."\n";
     }
 }


### PR DESCRIPTION
- Typehint against the interface instead of the abstract method.
- Correct the type for the old tokens.