### PR TITLE
refactor: Throw more friendly exceptions when loading a configuration

### DIFF
--- a/src/Configuration/Configuration.php
+++ b/src/Configuration/Configuration.php
@@ -14,10 +14,9 @@ declare(strict_types=1);
 
 namespace Humbug\PhpScoper\Configuration;
 
+use Humbug\PhpScoper\Configuration\Throwable\InvalidConfigurationValue;
 use Humbug\PhpScoper\Patcher\Patcher;
-use InvalidArgumentException;
 use function Safe\preg_match;
-use function sprintf;
 
 final class Configuration
 {
@@ -38,6 +37,8 @@ final class Configuration
      * @param array<string, array{string, string}> $excludedFilesWithContents Array of tuple
      *                                                                        with the first argument being the file path and
      *                                                                        the second its contents
+     *
+     * @throws InvalidConfigurationValue
      */
     public function __construct(
         private ?string $path,
@@ -71,6 +72,8 @@ final class Configuration
 
     /**
      * @param non-empty-string $prefix
+     *
+     * @throws InvalidConfigurationValue
      */
     public function withPrefix(string $prefix): self
     {
@@ -151,21 +154,11 @@ final class Configuration
     private static function validatePrefix(string $prefix): void
     {
         if (1 !== preg_match(self::PREFIX_PATTERN, $prefix)) {
-            throw new InvalidArgumentException(
-                sprintf(
-                    'The prefix needs to be composed solely of letters, digits and backslashes (as namespace separators). Got "%s"',
-                    $prefix,
-                ),
-            );
+            throw InvalidConfigurationValue::forInvalidPrefixPattern($prefix);
         }
 
         if (preg_match('/\\\{2,}/', $prefix)) {
-            throw new InvalidArgumentException(
-                sprintf(
-                    'Invalid namespace separator sequence. Got "%s"',
-                    $prefix,
-                ),
-            );
+            throw InvalidConfigurationValue::forInvalidNamespaceSeparator($prefix);
         }
     }
 }

--- a/src/Configuration/ConfigurationFactory.php
+++ b/src/Configuration/ConfigurationFactory.php
@@ -14,13 +14,14 @@ declare(strict_types=1);
 
 namespace Humbug\PhpScoper\Configuration;
 
+use Humbug\PhpScoper\Configuration\Throwable\InvalidConfigurationFile;
+use Humbug\PhpScoper\Configuration\Throwable\InvalidConfigurationValue;
+use Humbug\PhpScoper\Configuration\Throwable\UnknownConfigurationKey;
 use Humbug\PhpScoper\Patcher\ComposerPatcher;
 use Humbug\PhpScoper\Patcher\Patcher;
 use Humbug\PhpScoper\Patcher\PatcherChain;
 use Humbug\PhpScoper\Patcher\SymfonyParentTraitPatcher;
 use Humbug\PhpScoper\Patcher\SymfonyPatcher;
-use InvalidArgumentException;
-use RuntimeException;
 use SplFileInfo;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Finder\Finder;
@@ -33,9 +34,7 @@ use function array_unshift;
 use function bin2hex;
 use function dirname;
 use function file_exists;
-use function gettype;
 use function Humbug\PhpScoper\chain;
-use function in_array;
 use function is_array;
 use function is_callable;
 use function is_dir;
@@ -47,7 +46,6 @@ use function random_bytes;
 use function readlink as native_readlink;
 use function realpath;
 use function Safe\file_get_contents;
-use function sprintf;
 use function trim;
 use const DIRECTORY_SEPARATOR;
 
@@ -64,14 +62,13 @@ final readonly class ConfigurationFactory
     /**
      * @param non-empty-string|null  $path  Absolute canonical path to the configuration file.
      * @param list<non-empty-string> $paths List of absolute canonical paths to append besides the one configured
+     *
+     * @throws InvalidConfigurationValue
+     * @throws UnknownConfigurationKey
      */
     public function create(?string $path = null, array $paths = []): Configuration
     {
-        if (null === $path) {
-            $config = [];
-        } else {
-            $config = $this->loadConfigFile($path);
-        }
+        $config = null === $path ? [] : $this->loadConfigFile($path);
 
         self::validateConfigKeys($config);
 
@@ -134,24 +131,17 @@ final readonly class ConfigurationFactory
         return $config->withPrefix($prefix);
     }
 
+    /**
+     * @throws InvalidConfigurationValue
+     */
     private function loadConfigFile(string $path): array
     {
         if (!$this->fileSystem->isAbsolutePath($path)) {
-            throw new InvalidArgumentException(
-                sprintf(
-                    'Expected the path of the configuration file to load to be an absolute path, got "%s" instead',
-                    $path,
-                ),
-            );
+            throw InvalidConfigurationFile::forNonAbsolutePath($path);
         }
 
         if (!file_exists($path)) {
-            throw new InvalidArgumentException(
-                sprintf(
-                    'Expected the path of the configuration file to exists but the file "%s" could not be found',
-                    $path,
-                ),
-            );
+            throw InvalidConfigurationFile::forFileNotFound($path);
         }
 
         $isADirectoryLink = is_link($path)
@@ -159,23 +149,13 @@ final readonly class ConfigurationFactory
             && is_file(native_readlink($path));
 
         if (!$isADirectoryLink && !is_file($path)) {
-            throw new InvalidArgumentException(
-                sprintf(
-                    'Expected the path of the configuration file to be a file but "%s" appears to be a directory.',
-                    $path,
-                ),
-            );
+            throw InvalidConfigurationFile::forNotAFile($path);
         }
 
         $config = include $path;
 
         if (!is_array($config)) {
-            throw new InvalidArgumentException(
-                sprintf(
-                    'Expected configuration to be an array, found "%s" instead.',
-                    gettype($config),
-                ),
-            );
+            throw InvalidConfigurationFile::forInvalidValue($path);
         }
 
         return $config;
@@ -184,22 +164,8 @@ final readonly class ConfigurationFactory
     private static function validateConfigKeys(array $config): void
     {
         array_map(
-            static fn (string $key) => self::validateConfigKey($key),
+            ConfigurationKeys::assertIsValidKey(...),
             array_keys($config),
-        );
-    }
-
-    private static function validateConfigKey(string $key): void
-    {
-        if (in_array($key, ConfigurationKeys::KEYWORDS, true)) {
-            return;
-        }
-
-        throw new InvalidArgumentException(
-            sprintf(
-                'Invalid configuration key value "%s" found.',
-                $key,
-            ),
         );
     }
 
@@ -224,6 +190,8 @@ final readonly class ConfigurationFactory
     }
 
     /**
+     * @throws InvalidConfigurationValue
+     *
      * @return array<(callable(string,string,string): string)|Patcher>
      */
     private static function retrievePatchers(array $config): array
@@ -235,31 +203,21 @@ final readonly class ConfigurationFactory
         $patchers = $config[ConfigurationKeys::PATCHERS_KEYWORD];
 
         if (!is_array($patchers)) {
-            throw new InvalidArgumentException(
-                sprintf(
-                    'Expected patchers to be an array of callables, found "%s" instead.',
-                    gettype($patchers),
-                ),
-            );
+            throw InvalidConfigurationValue::forInvalidPatchersType($patchers);
         }
 
         foreach ($patchers as $index => $patcher) {
-            if (is_callable($patcher)) {
-                continue;
+            if (!is_callable($patcher)) {
+                throw InvalidConfigurationValue::forInvalidPatcherType($index, $patcher);
             }
-
-            throw new InvalidArgumentException(
-                sprintf(
-                    'Expected patchers to be an array of callables, the "%d" element is not.',
-                    $index,
-                ),
-            );
         }
 
         return $patchers;
     }
 
     /**
+     * @throws InvalidConfigurationValue
+     *
      * @return string[] Absolute paths
      */
     private function retrieveExcludedFiles(string $dirPath, array $config): array
@@ -271,22 +229,12 @@ final readonly class ConfigurationFactory
         $excludedFiles = $config[ConfigurationKeys::EXCLUDED_FILES_KEYWORD];
 
         if (!is_array($excludedFiles)) {
-            throw new InvalidArgumentException(
-                sprintf(
-                    'Expected excluded files to be an array of strings, found "%s" instead.',
-                    gettype($excludedFiles),
-                ),
-            );
+            throw InvalidConfigurationValue::forInvalidExcludedFilesTypes($excludedFiles);
         }
 
         foreach ($excludedFiles as $index => $file) {
             if (!is_string($file)) {
-                throw new InvalidArgumentException(
-                    sprintf(
-                        'Expected excluded files to be an array of string, the "%d" element is not.',
-                        $index,
-                    ),
-                );
+                throw InvalidConfigurationValue::forInvalidExcludedFilePath($index, $excludedFiles);
             }
 
             if (!$this->fileSystem->isAbsolutePath($file)) {
@@ -296,10 +244,14 @@ final readonly class ConfigurationFactory
             $excludedFiles[$index] = realpath($file);
         }
 
+        // We ignore files not found excluded file as we do not want to bail out just because a file we do not want to
+        // include does not exist.
         return array_filter($excludedFiles);
     }
 
     /**
+     * @throws InvalidConfigurationValue
+     *
      * @return Finder[]
      */
     private static function retrieveFinders(array $config): array
@@ -311,13 +263,7 @@ final readonly class ConfigurationFactory
         $finders = $config[ConfigurationKeys::FINDER_KEYWORD];
 
         if (!is_array($finders)) {
-            throw new InvalidArgumentException(
-                sprintf(
-                    'Expected finders to be an array of "%s", found "%s" instead.',
-                    Finder::class,
-                    gettype($finders),
-                ),
-            );
+            throw InvalidConfigurationValue::forInvalidFinderTypes($finders);
         }
 
         foreach ($finders as $index => $finder) {
@@ -325,13 +271,7 @@ final readonly class ConfigurationFactory
                 continue;
             }
 
-            throw new InvalidArgumentException(
-                sprintf(
-                    'Expected finders to be an array of "%s", the "%d" element is not.',
-                    Finder::class,
-                    $index,
-                ),
-            );
+            throw InvalidConfigurationValue::forInvalidFinderType($index, $finder);
         }
 
         return $finders;
@@ -339,6 +279,8 @@ final readonly class ConfigurationFactory
 
     /**
      * @param string[] $paths
+     *
+     * @throws InvalidConfigurationValue
      *
      * @return iterable<SplFileInfo>
      */
@@ -353,12 +295,7 @@ final readonly class ConfigurationFactory
 
         foreach ($paths as $path) {
             if (!file_exists($path)) {
-                throw new RuntimeException(
-                    sprintf(
-                        'Could not find the file "%s".',
-                        $path,
-                    ),
-                );
+                throw InvalidConfigurationValue::forFileNotFound($path);
             }
 
             if (is_dir($path)) {
@@ -384,6 +321,8 @@ final readonly class ConfigurationFactory
     /**
      * @param iterable<SplFileInfo|string> $files
      *
+     * @throws InvalidConfigurationValue
+     *
      * @return array<string, array{string, string}> Array of tuple with the first argument being the file path and the second its contents
      */
     private static function retrieveFilesWithContents(iterable $files): array
@@ -396,21 +335,11 @@ final readonly class ConfigurationFactory
                 : realpath($filePathOrFileInfo);
 
             if (!$filePath) {
-                throw new RuntimeException(
-                    sprintf(
-                        'Could not find the file "%s".',
-                        (string) $filePathOrFileInfo,
-                    ),
-                );
+                throw InvalidConfigurationValue::forFileNotFound((string) $filePathOrFileInfo);
             }
 
             if (!is_readable($filePath)) {
-                throw new RuntimeException(
-                    sprintf(
-                        'Could not read the file "%s".',
-                        $filePath,
-                    ),
-                );
+                throw InvalidConfigurationValue::forUnreadableFile($filePath);
             }
 
             $filesWithContents[$filePath] = [$filePath, file_get_contents($filePath)];

--- a/src/Configuration/ConfigurationFactory.php
+++ b/src/Configuration/ConfigurationFactory.php
@@ -14,9 +14,9 @@ declare(strict_types=1);
 
 namespace Humbug\PhpScoper\Configuration;
 
+use Humbug\PhpScoper\Configuration\Throwable\InvalidConfiguration;
 use Humbug\PhpScoper\Configuration\Throwable\InvalidConfigurationFile;
 use Humbug\PhpScoper\Configuration\Throwable\InvalidConfigurationValue;
-use Humbug\PhpScoper\Configuration\Throwable\UnknownConfigurationKey;
 use Humbug\PhpScoper\Patcher\ComposerPatcher;
 use Humbug\PhpScoper\Patcher\Patcher;
 use Humbug\PhpScoper\Patcher\PatcherChain;
@@ -63,8 +63,7 @@ final readonly class ConfigurationFactory
      * @param non-empty-string|null  $path  Absolute canonical path to the configuration file.
      * @param list<non-empty-string> $paths List of absolute canonical paths to append besides the one configured
      *
-     * @throws InvalidConfigurationValue
-     * @throws UnknownConfigurationKey
+     * @throws InvalidConfiguration
      */
     public function create(?string $path = null, array $paths = []): Configuration
     {

--- a/src/Configuration/ConfigurationKeys.php
+++ b/src/Configuration/ConfigurationKeys.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 
 namespace Humbug\PhpScoper\Configuration;
 
+use Humbug\PhpScoper\Configuration\Throwable\UnknownConfigurationKey;
 use Humbug\PhpScoper\NotInstantiable;
 
 final class ConfigurationKeys
@@ -58,4 +59,19 @@ final class ConfigurationKeys
         self::FUNCTIONS_INTERNAL_SYMBOLS_KEYWORD,
         self::CONSTANTS_INTERNAL_SYMBOLS_KEYWORD,
     ];
+
+    /**
+     * @throws UnknownConfigurationKey
+     */
+    public static function assertIsValidKey(string $key): void
+    {
+        if (!self::isValidateKey($key)) {
+            throw UnknownConfigurationKey::forKey($key);
+        }
+    }
+
+    public static function isValidateKey(string $key): bool
+    {
+        return in_array($key, self::KEYWORDS, true);
+    }
 }

--- a/src/Configuration/Throwable/InvalidConfiguration.php
+++ b/src/Configuration/Throwable/InvalidConfiguration.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the humbug/php-scoper package.
+ *
+ * Copyright (c) 2017 Théo FIDRY <theo.fidry@gmail.com>,
+ *                    Pádraic Brady <padraic.brady@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Humbug\PhpScoper\Configuration\Throwable;
+
+use Throwable;
+
+interface InvalidConfiguration extends Throwable
+{
+}

--- a/src/Configuration/Throwable/InvalidConfigurationFile.php
+++ b/src/Configuration/Throwable/InvalidConfigurationFile.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the humbug/php-scoper package.
+ *
+ * Copyright (c) 2017 Théo FIDRY <theo.fidry@gmail.com>,
+ *                    Pádraic Brady <padraic.brady@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Humbug\PhpScoper\Configuration\Throwable;
+
+use UnexpectedValueException;
+use function get_debug_type;
+
+final class InvalidConfigurationFile extends UnexpectedValueException implements InvalidConfiguration
+{
+    public static function forNonAbsolutePath(string $path): self
+    {
+        return new self(
+            sprintf(
+                'Expected the path of the configuration file to load to be an absolute path, got "%s" instead',
+                $path,
+            ),
+        );
+    }
+
+    public static function forFileNotFound(string $path): self
+    {
+        return new self(
+            sprintf(
+                'Expected the path of the configuration file to exists but the file "%s" could not be found',
+                $path,
+            ),
+        );
+    }
+
+    public static function forNotAFile(string $path): self
+    {
+        return new self(
+            sprintf(
+                'Expected the path of the configuration file to be a file but "%s" appears to be a directory.',
+                $path,
+            ),
+        );
+    }
+
+    public static function forInvalidValue(mixed $config): self
+    {
+        return new self(
+            sprintf(
+                'Expected configuration to be an array, found "%s" instead.',
+                get_debug_type($config),
+            ),
+        );
+    }
+}

--- a/src/Configuration/Throwable/InvalidConfigurationValue.php
+++ b/src/Configuration/Throwable/InvalidConfigurationValue.php
@@ -104,4 +104,24 @@ final class InvalidConfigurationValue extends UnexpectedValueException implement
             ),
         );
     }
+
+    public static function forInvalidPrefixPattern(string $prefix): self
+    {
+        return new self(
+            sprintf(
+                'The prefix needs to be composed solely of letters, digits and backslashes (as namespace separators). Got "%s".',
+                $prefix,
+            ),
+        );
+    }
+
+    public static function forInvalidNamespaceSeparator(string $prefix): self
+    {
+        return new self(
+            sprintf(
+                'Invalid namespace separator sequence. Got "%s".',
+                $prefix,
+            ),
+        );
+    }
 }

--- a/src/Configuration/Throwable/InvalidConfigurationValue.php
+++ b/src/Configuration/Throwable/InvalidConfigurationValue.php
@@ -1,0 +1,107 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the humbug/php-scoper package.
+ *
+ * Copyright (c) 2017 Théo FIDRY <theo.fidry@gmail.com>,
+ *                    Pádraic Brady <padraic.brady@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Humbug\PhpScoper\Configuration\Throwable;
+
+use Symfony\Component\Finder\Finder;
+use UnexpectedValueException;
+use function gettype;
+
+final class InvalidConfigurationValue extends UnexpectedValueException implements InvalidConfiguration
+{
+    public static function forInvalidPatchersType(mixed $patchers): self
+    {
+        return new self(
+            sprintf(
+                'Expected patchers to be an array of callables, found "%s" instead.',
+                gettype($patchers),
+            ),
+        );
+    }
+
+    public static function forInvalidPatcherType(int|string $index, mixed $patcher): self
+    {
+        return new self(
+            sprintf(
+                'Expected patchers to be an array of callables, the "%s" element is not (found "%s" instead).',
+                $index,
+                gettype($patcher),
+            ),
+        );
+    }
+
+    public static function forInvalidExcludedFilesTypes(mixed $excludedFiles): self
+    {
+        return new self(
+            sprintf(
+                'Expected excluded files to be an array of strings, found "%s" instead.',
+                gettype($excludedFiles),
+            ),
+        );
+    }
+
+    public static function forInvalidExcludedFilePath(int|string $index, mixed $excludedFile): self
+    {
+        return new self(
+            sprintf(
+                'Expected excluded files to be an array of string, the "%d" element is not (found "%s" instead).',
+                $index,
+                gettype($excludedFile),
+            ),
+        );
+    }
+
+    public static function forInvalidFinderTypes(mixed $finders): self
+    {
+        return new self(
+            sprintf(
+                'Expected finders to be an array of "%s", found "%s" instead.',
+                Finder::class,
+                gettype($finders),
+            ),
+        );
+    }
+
+    public static function forInvalidFinderType(int|string $index, mixed $finder): self
+    {
+        return new self(
+            sprintf(
+                'Expected finders to be an array of "%s", the "%s" element is not (found "%s" instead).',
+                Finder::class,
+                $index,
+                gettype($finder),
+            ),
+        );
+    }
+
+    public static function forFileNotFound(string $path): self
+    {
+        return new self(
+            sprintf(
+                'Could not find the file "%s".',
+                $path,
+            ),
+        );
+    }
+
+    public static function forUnreadableFile(string $path): self
+    {
+        return new self(
+            sprintf(
+                'Could not read the file "%s".',
+                $path,
+            ),
+        );
+    }
+}

--- a/src/Configuration/Throwable/UnknownConfigurationKey.php
+++ b/src/Configuration/Throwable/UnknownConfigurationKey.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the humbug/php-scoper package.
+ *
+ * Copyright (c) 2017 Théo FIDRY <theo.fidry@gmail.com>,
+ *                    Pádraic Brady <padraic.brady@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Humbug\PhpScoper\Configuration\Throwable;
+
+use UnexpectedValueException;
+
+final class UnknownConfigurationKey extends UnexpectedValueException implements InvalidConfiguration
+{
+    public static function forKey(string $key): self
+    {
+        return new self(
+            sprintf(
+                'Invalid configuration key value "%s" found.',
+                $key,
+            ),
+        );
+    }
+}

--- a/src/Console/Command/AddPrefixCommand.php
+++ b/src/Console/Command/AddPrefixCommand.php
@@ -23,6 +23,8 @@ use Fidry\Console\ExitCode;
 use Fidry\Console\IO;
 use Humbug\PhpScoper\Configuration\Configuration;
 use Humbug\PhpScoper\Configuration\ConfigurationFactory;
+use Humbug\PhpScoper\Configuration\Throwable\InvalidConfigurationValue;
+use Humbug\PhpScoper\Configuration\Throwable\UnknownConfigurationKey;
 use Humbug\PhpScoper\Console\ConfigLoader;
 use Humbug\PhpScoper\Console\ConsoleScoper;
 use Humbug\PhpScoper\Scoper\ScoperFactory;
@@ -252,6 +254,9 @@ final class AddPrefixCommand implements Command, CommandAware
 
     /**
      * @param list<non-empty-string> $paths
+     *
+     * @throws InvalidConfigurationValue
+     * @throws UnknownConfigurationKey
      */
     private function retrieveConfig(IO $io, array $paths, string $cwd): Configuration
     {

--- a/src/Console/ConfigLoader.php
+++ b/src/Console/ConfigLoader.php
@@ -18,6 +18,8 @@ use Fidry\Console\Command\CommandRegistry;
 use Fidry\Console\IO;
 use Humbug\PhpScoper\Configuration\Configuration;
 use Humbug\PhpScoper\Configuration\ConfigurationFactory;
+use Humbug\PhpScoper\Configuration\Throwable\InvalidConfigurationValue;
+use Humbug\PhpScoper\Configuration\Throwable\UnknownConfigurationKey;
 use Symfony\Component\Console\Exception\RuntimeException;
 use Symfony\Component\Console\Input\StringInput;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -46,6 +48,9 @@ final readonly class ConfigLoader
      * @param non-empty-string|null  $configFilePath        Canonical absolute path
      * @param non-empty-string       $defaultConfigFilePath
      * @param list<non-empty-string> $paths                 List of canonical absolute paths
+     *
+     * @throws InvalidConfigurationValue
+     * @throws UnknownConfigurationKey
      */
     public function loadConfig(
         IO $io,
@@ -96,6 +101,9 @@ final readonly class ConfigLoader
 
     /**
      * @param list<non-empty-string> $paths
+     *
+     * @throws InvalidConfigurationValue
+     * @throws UnknownConfigurationKey
      */
     private function loadConfigWithoutConfigFile(
         IO $io,
@@ -179,6 +187,9 @@ final readonly class ConfigLoader
     /**
      * @param non-empty-string|null  $configFilePath
      * @param list<non-empty-string> $paths
+     *
+     * @throws InvalidConfigurationValue
+     * @throws UnknownConfigurationKey
      */
     private function loadConfiguration(
         ?string $configFilePath,

--- a/tests/Configuration/ConfigurationFactoryTest.php
+++ b/tests/Configuration/ConfigurationFactoryTest.php
@@ -15,6 +15,7 @@ declare(strict_types=1);
 namespace Humbug\PhpScoper\Configuration;
 
 use Fidry\FileSystem\FS;
+use Humbug\PhpScoper\Configuration\Throwable\UnknownConfigurationKey;
 use Humbug\PhpScoper\Container;
 use Humbug\PhpScoper\FileSystemTestCase;
 use Humbug\PhpScoper\Patcher\ComposerPatcher;
@@ -23,7 +24,6 @@ use Humbug\PhpScoper\Patcher\SymfonyParentTraitPatcher;
 use Humbug\PhpScoper\Patcher\SymfonyPatcher;
 use Humbug\PhpScoper\Symbol\NamespaceRegistry;
 use Humbug\PhpScoper\Symbol\SymbolRegistry;
-use InvalidArgumentException;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Group;
 use function array_keys;
@@ -80,7 +80,7 @@ class ConfigurationFactoryTest extends FileSystemTestCase
                 PHP,
         );
 
-        $this->expectException(InvalidArgumentException::class);
+        $this->expectException(UnknownConfigurationKey::class);
         $this->expectExceptionMessage('Invalid configuration key value "unknown key" found.');
 
         $this->createConfigFromStandardFile();

--- a/tests/Configuration/ConfigurationTest.php
+++ b/tests/Configuration/ConfigurationTest.php
@@ -107,12 +107,12 @@ final class ConfigurationTest extends TestCase
     {
         yield [
             ';',
-            'The prefix needs to be composed solely of letters, digits and backslashes (as namespace separators). Got ";"',
+            'The prefix needs to be composed solely of letters, digits and backslashes (as namespace separators). Got ";".',
         ];
 
         yield [
             'App\\\\Foo',
-            'Invalid namespace separator sequence. Got "App\\\\Foo"',
+            'Invalid namespace separator sequence. Got "App\\\\Foo".',
         ];
     }
 

--- a/tests/Configuration/ConfigurationTest.php
+++ b/tests/Configuration/ConfigurationTest.php
@@ -14,10 +14,10 @@ declare(strict_types=1);
 
 namespace Humbug\PhpScoper\Configuration;
 
+use Humbug\PhpScoper\Configuration\Throwable\InvalidConfigurationValue;
 use Humbug\PhpScoper\Patcher\FakePatcher;
 use Humbug\PhpScoper\Patcher\Patcher;
 use Humbug\PhpScoper\Patcher\PatcherChain;
-use InvalidArgumentException;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
@@ -36,7 +36,7 @@ final class ConfigurationTest extends TestCase
         string $prefix,
         string $expectedExceptionMessage
     ): void {
-        $this->expectException(InvalidArgumentException::class);
+        $this->expectException(InvalidConfigurationValue::class);
         $this->expectExceptionMessage($expectedExceptionMessage);
 
         new Configuration(

--- a/tests/Console/Command/AddPrefixCommandTest.php
+++ b/tests/Console/Command/AddPrefixCommandTest.php
@@ -20,6 +20,7 @@ use Fidry\FileSystem\FS;
 use Humbug\PhpScoper\Configuration\ConfigurationFactory;
 use Humbug\PhpScoper\Configuration\RegexChecker;
 use Humbug\PhpScoper\Configuration\SymbolsConfigurationFactory;
+use Humbug\PhpScoper\Configuration\Throwable\InvalidConfigurationValue;
 use Humbug\PhpScoper\Console\Application;
 use Humbug\PhpScoper\Console\AppTesterAbilities;
 use Humbug\PhpScoper\Console\AppTesterTestCase;
@@ -32,7 +33,6 @@ use Humbug\PhpScoper\PhpParser\FakePrinter;
 use Humbug\PhpScoper\Scoper\Scoper;
 use Humbug\PhpScoper\Symbol\EnrichedReflectorFactory;
 use Humbug\PhpScoper\Symbol\Reflector;
-use InvalidArgumentException;
 use PhpParser\Error as PhpParserError;
 use PHPUnit\Framework\Attributes\CoversClass;
 use Prophecy\Argument;
@@ -540,9 +540,9 @@ class AddPrefixCommandTest extends FileSystemTestCase implements AppTesterTestCa
             $this->appTester->run($input);
 
             self::fail('Expected exception to be thrown.');
-        } catch (InvalidArgumentException $exception) {
+        } catch (InvalidConfigurationValue $exception) {
             self::assertSame(
-                'Expected patchers to be an array of callables, the "0" element is not.',
+                'Expected patchers to be an array of callables, the "0" element is not (found "string" instead).',
                 $exception->getMessage(),
             );
         }


### PR DESCRIPTION
Make the configuration and its factory throw more comprehensible exceptions. This also makes the switch from `InvalidArgumentException` to `UnexpectedValueException` which is more correct IMO as it is values provided by the user.