### PR TITLE
fix: Configure the printer PHP version to 7.2 by default

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -63,8 +63,11 @@ then a random prefix will be automatically generated.
 The PHP version provided is used to configure the underlying [PHP-Parser] Parser and Printer. This will not affect
 the PHP internal symbols used by PHP-Scoper but may affect what code can be parsed and how the code will be printed.
 
-If `null` or `''` (empty string) is given, then the host version will be used, i.e. executing it with PHP 8.4 will
-result in PHP 8.4 being used as the PHP version. 
+If `null` or `''` (empty string) is given, then the host version will be used for the parser and 5.3 will be used for
+the printer. This allows PHP-Scoper to parse code with the current host version without breaking older code. As a
+result, one can parse a PHP 7.2 compatible code in PHP 8.3 without breaking the PHP 7.2 compatibility. Indeed, if the
+printer version is forced to a higher version, e.g. the host version 8.3, then the code may be reformated in a way that
+it will no longer be compatible with PHP 7.2 (e.g. nowdocs and heredocs).
 
 
 ### Output directory

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -60,14 +60,19 @@ then a random prefix will be automatically generated.
 
 ### PHP Version
 
-The PHP version provided is used to configure the underlying [PHP-Parser] Parser and Printer. This will not affect
-the PHP internal symbols used by PHP-Scoper but may affect what code can be parsed and how the code will be printed.
+The PHP version provided is used to configure the underlying [PHP-Parser] Parser and Printer. 
+
+The version used by the Parser will affect what code it can understand, e.g. if it is configured in PHP 8.2 it will not
+understand a PHP 8.3 construct (e.g. typed class constants). However, what symbols are interpreted as internal will
+remain unchanged. The function `json_validate()` will be considered as internal even if the parser is configured with
+PHP 8.2.
+
+The printer version affects the code style. For example nowdocs and heredocs will be indented if the printer's PHP
+version is higher than 7.4 but will be formated without indent otherwise.
 
 If `null` or `''` (empty string) is given, then the host version will be used for the parser and 5.3 will be used for
-the printer. This allows PHP-Scoper to parse code with the current host version without breaking older code. As a
-result, one can parse a PHP 7.2 compatible code in PHP 8.3 without breaking the PHP 7.2 compatibility. Indeed, if the
-printer version is forced to a higher version, e.g. the host version 8.3, then the code may be reformated in a way that
-it will no longer be compatible with PHP 7.2 (e.g. nowdocs and heredocs).
+the printer. This allows PHP-Scoper to a PHP 7.2 compatible codebase without breaking its compatibility although the
+host version is a newer version.
 
 
 ### Output directory

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -70,7 +70,7 @@ PHP 8.2.
 The printer version affects the code style. For example nowdocs and heredocs will be indented if the printer's PHP
 version is higher than 7.4 but will be formated without indent otherwise.
 
-If `null` or `''` (empty string) is given, then the host version will be used for the parser and 5.3 will be used for
+If `null` or `''` (empty string) is given, then the host version will be used for the parser and 7.2 will be used for
 the printer. This allows PHP-Scoper to a PHP 7.2 compatible codebase without breaking its compatibility although the
 host version is a newer version.
 

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -61,5 +61,3 @@ parameters:
         # Fixed in https://github.com/nikic/PHP-Parser/pull/1003
         - message: '#Standard constructor expects array#'
           path: 'src/Container.php'
-        - message: '#Standard constructor expects array#'
-          path: 'src/PhpParser/Printer/StandardPrinterFactory.php'

--- a/src/PhpParser/Printer/StandardPrinterFactory.php
+++ b/src/PhpParser/Printer/StandardPrinterFactory.php
@@ -23,7 +23,7 @@ final class StandardPrinterFactory implements PrinterFactory
     {
         return new StandardPrinter(
             new Standard([
-                'phpVersion' => $phpVersion ?? PhpVersion::fromComponents(5, 3),
+                'phpVersion' => $phpVersion ?? PhpVersion::fromComponents(7, 2),
             ]),
         );
     }

--- a/src/PhpParser/Printer/StandardPrinterFactory.php
+++ b/src/PhpParser/Printer/StandardPrinterFactory.php
@@ -23,7 +23,7 @@ final class StandardPrinterFactory implements PrinterFactory
     {
         return new StandardPrinter(
             new Standard([
-                'phpVersion' => $phpVersion,
+                'phpVersion' => $phpVersion ?? PhpVersion::fromComponents(5, 3),
             ]),
         );
     }


### PR DESCRIPTION
See the discussion in https://github.com/nikic/PHP-Parser/issues/1007.

This should fix https://github.com/sebastianbergmann/phpunit/issues/5855 although this may result in more ugly code formatting than desired. For this reason the default printer version is 7.2 rather than 5.3 as it would make the code too otherwise.