### PR TITLE
Fix function with multiple namespaces

### DIFF
--- a/src/Autoload/ScoperAutoloadGenerator.php
+++ b/src/Autoload/ScoperAutoloadGenerator.php
@@ -306,7 +306,7 @@ final class ScoperAutoloadGenerator
             $originalFQ = new FullyQualified($exposed);
 
             $namespace = $originalFQ->slice(0, -1);
-            $functionName = null === $namespace ? $exposed : (string) $originalFQ->slice(1);
+            $functionName = null === $namespace ? $exposed : (string) $originalFQ->slice(-1, 1);
 
             $groupedFunctions[(string) $namespace][] = [$exposed, $functionName, $prefix];
         }

--- a/tests/AutoReview/GAE2ETest.php
+++ b/tests/AutoReview/GAE2ETest.php
@@ -31,7 +31,7 @@ class GAE2ETest extends TestCase
 
     public function test_github_actions_executes_all_the_e2e_tests(): void
     {
-        $expected = array_diff(E2ECollector::getE2ENames(), self::IGNORED_E2E_TESTS);
+        $expected = array_values(array_diff(E2ECollector::getE2ENames(), self::IGNORED_E2E_TESTS));
         $actual = GAE2ECollector::getExecutedE2ETests();
 
         self::assertEqualsCanonicalizing($expected, $actual);

--- a/tests/Autoload/ScoperAutoloadGeneratorTest.php
+++ b/tests/Autoload/ScoperAutoloadGeneratorTest.php
@@ -188,6 +188,7 @@ class ScoperAutoloadGeneratorTest extends TestCase
                     ['Acme\bar', 'Humbug\Acme\bar'],
                     ['Acme\foo', 'Humbug\Acme\foo'],
                     ['Emca\baz', 'Humbug\Emca\baz'],
+                    ['Acme\Emca\foo', 'Humbug\Acme\Emca\foo'],
                 ],
             ),
             [],
@@ -218,6 +219,10 @@ class ScoperAutoloadGeneratorTest extends TestCase
 
                 // Function aliases. For more information see:
                 // https://github.com/humbug/php-scoper/blob/master/docs/further-reading.md#function-aliases
+                namespace Acme\Emca {
+                    if (!function_exists('Acme\Emca\foo')) { function foo() { return \Humbug\Acme\Emca\foo(...func_get_args()); } }
+                }
+                
                 namespace Acme {
                     if (!function_exists('Acme\bar')) { function bar() { return \Humbug\Acme\bar(...func_get_args()); } }
                     if (!function_exists('Acme\foo')) { function foo() { return \Humbug\Acme\foo(...func_get_args()); } }

--- a/tests/Autoload/ScoperAutoloadGeneratorTest.php
+++ b/tests/Autoload/ScoperAutoloadGeneratorTest.php
@@ -222,7 +222,7 @@ class ScoperAutoloadGeneratorTest extends TestCase
                 namespace Acme\Emca {
                     if (!function_exists('Acme\Emca\foo')) { function foo() { return \Humbug\Acme\Emca\foo(...func_get_args()); } }
                 }
-                
+
                 namespace Acme {
                     if (!function_exists('Acme\bar')) { function bar() { return \Humbug\Acme\bar(...func_get_args()); } }
                     if (!function_exists('Acme\foo')) { function foo() { return \Humbug\Acme\foo(...func_get_args()); } }


### PR DESCRIPTION
Hi @theofidry, I discovered a bug with the php-scoper.

Before the fix, I get
```
namespace Acme\Emca {
    if (!function_exists('Acme\Emca\foo')) { function Emca\foo() { return \Humbug\Acme\Emca\foo(...func_get_args()); } }
}
```
which is crashing.