### PR TITLE
Fix tests

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -207,16 +207,16 @@
         },
         {
             "name": "nikic/php-parser",
-            "version": "v5.0.2",
+            "version": "v5.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nikic/PHP-Parser.git",
-                "reference": "139676794dc1e9231bf7bcd123cfc0c99182cb13"
+                "reference": "683130c2ff8c2739f4822ff7ac5c873ec529abd1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/139676794dc1e9231bf7bcd123cfc0c99182cb13",
-                "reference": "139676794dc1e9231bf7bcd123cfc0c99182cb13",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/683130c2ff8c2739f4822ff7ac5c873ec529abd1",
+                "reference": "683130c2ff8c2739f4822ff7ac5c873ec529abd1",
                 "shasum": ""
             },
             "require": {
@@ -227,7 +227,7 @@
             },
             "require-dev": {
                 "ircmaxell/php-yacc": "^0.0.7",
-                "phpunit/phpunit": "^7.0 || ^8.0 || ^9.0"
+                "phpunit/phpunit": "^9.0"
             },
             "bin": [
                 "bin/php-parse"
@@ -259,9 +259,9 @@
             ],
             "support": {
                 "issues": "https://github.com/nikic/PHP-Parser/issues",
-                "source": "https://github.com/nikic/PHP-Parser/tree/v5.0.2"
+                "source": "https://github.com/nikic/PHP-Parser/tree/v5.1.0"
             },
-            "time": "2024-03-05T20:51:40+00:00"
+            "time": "2024-07-01T20:03:41+00:00"
         },
         {
             "name": "psr/container",

--- a/specs/exp/instanceof.php
+++ b/specs/exp/instanceof.php
@@ -96,7 +96,7 @@ return [
 
         $file = new \stdClass();
 
-        ($file instanceof \SplFileInfo) ? $file : new \SplFileInfo($file);
+        $file instanceof \SplFileInfo ? $file : new \SplFileInfo($file);
 
         ----
         <?php
@@ -104,7 +104,7 @@ return [
         namespace Humbug\Acme;
 
         $file = new \stdClass();
-        ($file instanceof \SplFileInfo) ? $file : new \SplFileInfo($file);
+        $file instanceof \SplFileInfo ? $file : new \SplFileInfo($file);
 
         PHP,
 

--- a/src/Symbol/Reflector.php
+++ b/src/Symbol/Reflector.php
@@ -182,6 +182,12 @@ final readonly class Reflector
         'ldap_connect_wallet',
         'posix_pathconf',
         'posix_fpathconf',
+
+        // Removed in https://github.com/JetBrains/phpstorm-stubs/pull/1627
+        'ares_gethostbyname',
+        'uv_ares_init_options',
+        'uv_handle_type',
+        'uv_read2_start',
     ];
 
     /**

--- a/tests/AutoReview/GAE2ETest.php
+++ b/tests/AutoReview/GAE2ETest.php
@@ -31,7 +31,7 @@ class GAE2ETest extends TestCase
 
     public function test_github_actions_executes_all_the_e2e_tests(): void
     {
-        $expected = array_values(array_diff(E2ECollector::getE2ENames(), self::IGNORED_E2E_TESTS));
+        $expected = array_diff(E2ECollector::getE2ENames(), self::IGNORED_E2E_TESTS);
         $actual = GAE2ECollector::getExecutedE2ETests();
 
         self::assertEqualsCanonicalizing($expected, $actual);

--- a/tests/AutoReview/GAE2ETest.php
+++ b/tests/AutoReview/GAE2ETest.php
@@ -31,7 +31,7 @@ class GAE2ETest extends TestCase
 
     public function test_github_actions_executes_all_the_e2e_tests(): void
     {
-        $expected = array_diff(E2ECollector::getE2ENames(), self::IGNORED_E2E_TESTS);
+        $expected = array_values(array_diff(E2ECollector::getE2ENames(), self::IGNORED_E2E_TESTS));
         $actual = GAE2ECollector::getExecutedE2ETests();
 
         self::assertEqualsCanonicalizing($expected, $actual);


### PR DESCRIPTION
I think there is a change in the behavior of some dependency which remove this useless parenthesis when parsing the file.

```
($file instanceof \SplFileInfo) ? $file : new \SplFileInfo($file);
```
is transformed to
```
$file instanceof \SplFileInfo ? $file : new \SplFileInfo($file);
```

Since the parenthesis is useless, it seems better to remove it from the both input and output IMHO.