### PR TITLE
test: Fix e2e AutoReview test

### DIFF
--- a/tests/AutoReview/GAE2ETest.php
+++ b/tests/AutoReview/GAE2ETest.php
@@ -17,6 +17,7 @@ namespace Humbug\PhpScoper\AutoReview;
 use PHPUnit\Framework\Attributes\CoversNothing;
 use PHPUnit\Framework\TestCase;
 use function array_diff;
+use function sort;
 
 /**
  * @internal
@@ -32,6 +33,8 @@ class GAE2ETest extends TestCase
     public function test_github_actions_executes_all_the_e2e_tests(): void
     {
         $expected = array_diff(E2ECollector::getE2ENames(), self::IGNORED_E2E_TESTS);
+        sort($expected);
+
         $actual = GAE2ECollector::getExecutedE2ETests();
 
         self::assertEqualsCanonicalizing($expected, $actual);

--- a/tests/AutoReview/MakefileE2ETest.php
+++ b/tests/AutoReview/MakefileE2ETest.php
@@ -93,7 +93,7 @@ class MakefileE2ETest extends BaseMakefileTestCase
         $e2eRule = current($e2eRules);
         self::assertNotFalse($e2eRule, 'Expected to find the e2e rule in the Makefile.');
 
-        return $e2eRule->getPrerequisites();
+        return array_values($e2eRule->getPrerequisites());
     }
 
     /**

--- a/tests/AutoReview/MakefileE2ETest.php
+++ b/tests/AutoReview/MakefileE2ETest.php
@@ -23,6 +23,7 @@ use function array_map;
 use function array_values;
 use function current;
 use function Safe\file_get_contents;
+use function sort;
 use function str_starts_with;
 
 /**
@@ -93,7 +94,10 @@ class MakefileE2ETest extends BaseMakefileTestCase
         $e2eRule = current($e2eRules);
         self::assertNotFalse($e2eRule, 'Expected to find the e2e rule in the Makefile.');
 
-        return array_values($e2eRule->getPrerequisites());
+        $finalE2eRules = $e2eRule->getPrerequisites();
+        sort($finalE2eRules);
+
+        return $finalE2eRules;
     }
 
     /**


### PR DESCRIPTION
It looks like in some versions of PHPUnit the assert equal canonicalizing is not really taking care of the keys. I can't find the changelog about it though.