### PR TITLE
Docs: Fix constant/function assignment in WP example

### DIFF
--- a/docs/further-reading.md
+++ b/docs/further-reading.md
@@ -180,14 +180,15 @@ function getWpExcludedSymbols(string $fileName): array
     );
 }
 
-$wp_classes   = getWpExcludedSymbols('exclude-wordpress-classes.json');
-$wp_functions = getWpExcludedSymbols('exclude-wordpress-functions.json');
-$wp_constants = getWpExcludedSymbols('exclude-wordpress-constants.json');
+$wpConstants = getWpExcludedSymbols('exclude-wordpress-constants.json');
+$wpClasses = getWpExcludedSymbols('exclude-wordpress-classes.json');
+$wpFunctions = getWpExcludedSymbols('exclude-wordpress-functions.json');
+
 
 return [
-  'exclude-classes' => $wp_classes,
-  'exclude-constants' => $wp_functions,
-  'exclude-functions' => $wp_constants,
+  'exclude-constants' => $wpConstants,
+  'exclude-classes' => $wpClasses,
+  'exclude-functions' => $wpFunctions,
   // ...
 ];
 ```

--- a/docs/further-reading.md
+++ b/docs/further-reading.md
@@ -6,7 +6,7 @@
   - [Function aliases](#function-aliases)
 - [Laravel support](#laravel-support)
 - [Symfony support](#symfony-support)
-- [Wordpress support](#wordpress-support)
+- [WordPress support](#wordpress-support)
 
 
 ### How to deal with unknown third-party symbols
@@ -155,9 +155,9 @@ return [
 Note that the path is the "regular path(s)" that can be passed to patchers.
 
 
-### Wordpress Support
+### WordPress Support
 
-When writing a Wordpress plugin, you need to [exclude Wordpress' symbols](#excluded-symbols). To facilitate
+When writing a WordPress plugin, you need to [exclude WordPress' symbols](#excluded-symbols). To facilitate
 this task, [Snicco] created a third-party CLI tool [php-scoper-excludes] that can be used to generate
 PHP-Scoper compatible symbol lists for any PHP codebase you point it.
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [x] Docs have been added/updated (for bug fixes/features)


**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Docs update


**What is the current behavior?** (You can also link to an open issue here)
In the WordPress code example, lists of constants are assigned to `exclude-functions`, and lists of functions are assigned to `exclude-constants`. Also, there are typos: "Wordpress".


**What is the new behavior (if this is a feature change)?**
Correctly assign constants to `exclude-constants` and functions to `exclude-functions`. Change variable naming to camelCase as part of the Boy Scout rule.
Also, fix typos to "WordPress".


**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No


**Other information**:
The scope of the PR changed from fixing the typos to fixing the constants/functions list assignment.